### PR TITLE
docs(readme): clarify Lore memory model and add RAG retrieval bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lore
 
-**The teammate who's read every commit.** Lore is your codebase's institutional memory — it knows what was built, why it changed, and how it all connects.
+**The teammate who knows every commit.** Lore is your codebase's institutional memory — it knows what was built, why it changed, and how it all connects.
 
 Language-aware codebase indexer — it maps symbols, imports, call relationships,
 code summaries, and git history, with optional embeddings for semantic search.


### PR DESCRIPTION
## Summary
- refresh README intro copy to focus on what Lore stores and how people/agents use it
- add a `What Lore does` bullet for RAG-style retrieval via semantic/fused `kb_search`

## Notes
- docs-only change
- no runtime behavior changes