### PR TITLE
Remove orphan FTS rows on deleted files (#21)

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -182,6 +182,7 @@ export class IndexBuilder {
           if (row) {
             // Null out any resolved_id references pointing to this file
             db.prepare('UPDATE file_imports SET resolved_id = NULL WHERE resolved_id = ?').run(row.id);
+            db.prepare('DELETE FROM symbols_fts WHERE rowid IN (SELECT id FROM symbols WHERE file_id = ?)').run(row.id);
             db.prepare('DELETE FROM files WHERE id = ?').run(row.id);
           }
           continue;

--- a/tests/indexer/index.test.ts
+++ b/tests/indexer/index.test.ts
@@ -140,4 +140,47 @@ describe('IndexBuilder — branch support in update()', () => {
     const headFiles = queryFilesWithBranch(dbPath, 'HEAD');
     expect(headFiles.length).toBeGreaterThan(0);
   });
+
+  it('should remove branch-scoped file rows and related symbols_fts entries when a tracked file is deleted', async () => {
+    const builderDev = new IndexBuilder(dbPath, { rootDir: srcDir, branch: 'dev' });
+    await builderDev.build();
+
+    const beforeDb = new Database(dbPath, { readonly: true });
+    const mainFileRow = beforeDb
+      .prepare('SELECT id FROM files WHERE path = ? AND branch = ?')
+      .get(srcFile, 'main') as { id: number } | undefined;
+    expect(mainFileRow).toBeDefined();
+
+    const mainSymbolIds = beforeDb
+      .prepare(
+        'SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.path = ? AND f.branch = ?',
+      )
+      .all(srcFile, 'main') as Array<{ id: number }>;
+    beforeDb.close();
+    expect(mainSymbolIds.length).toBeGreaterThan(0);
+
+    rmSync(srcFile, { force: true });
+    const builderMain = new IndexBuilder(dbPath, { rootDir: srcDir, branch: 'main' });
+    await builderMain.update([srcFile]);
+
+    const afterDb = new Database(dbPath, { readonly: true });
+    const deletedMainFile = afterDb
+      .prepare('SELECT id FROM files WHERE path = ? AND branch = ?')
+      .get(srcFile, 'main') as { id: number } | undefined;
+    const devFile = afterDb
+      .prepare('SELECT id FROM files WHERE path = ? AND branch = ?')
+      .get(srcFile, 'dev') as { id: number } | undefined;
+    const staleFtsCountRow = afterDb
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM symbols_fts
+         WHERE rowid IN (${mainSymbolIds.map(() => '?').join(',')})`,
+      )
+      .get(...mainSymbolIds.map(row => row.id)) as { count: number };
+    afterDb.close();
+
+    expect(deletedMainFile).toBeUndefined();
+    expect(devFile).toBeDefined();
+    expect(staleFtsCountRow.count).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fix `IndexBuilder.update()` so deleting a tracked file also removes its related `symbols_fts` rows, preventing ghost full-text matches while preserving branch-scoped behavior. Added regression coverage for deleting a file in one branch while another branch copy remains.

Closes #21

## Changes

- `src/indexer/index.ts`
  - In the deleted-file branch of `update()`, delete `symbols_fts` rows for symbol IDs belonging to the resolved file before deleting the file row.
  - Keep existing `file_imports.resolved_id` cleanup and path+branch-scoped file targeting intact.
- `tests/indexer/index.test.ts`
  - Added a regression test that deletes a tracked file on `main`, runs incremental `update()`, and verifies: the `main` file row is removed, the `dev` branch row remains, and no orphan `symbols_fts` rows remain for the deleted file's symbols.

## Testing

- `npm run build`
- `npx vitest run`

Closes #21