### PR TITLE
Revamp README architecture diagram and add architecture doc (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,98 @@
 # Lore
 
-**The teammate who knows every commit.** Lore is your codebase's institutional memory — it knows what was built, why it changed, and how it all connects.
-
-Language-aware codebase indexer — it maps symbols, imports, call relationships,
-code summaries, and git history, with optional embeddings for semantic search.
-
-Lore builds a rich, queryable memory of your codebase and its evolution. You
-can explore it directly through the CLI and MCP tools, or connect IDEs and
-agents so they can reason over the same shared context.
+**The teammate that has seen it all** Lore is your agent's institutional knowledge over the codebase — it knows what was built, why it changed, and how it all connects. Lore indexes your code and git history into a structured knowledge base that agents query through MCP. It maps symbols, imports, call relationships, and git history — with optional embeddings for semantic search — so agents can reason about your codebase
+without re-reading it from scratch.
 
 ## What Lore does
 
-- Parses source files with tree-sitter and extracts symbols/imports/call refs
+- Parses source files and extracts symbols, imports, and call refs
 - Resolves internal vs external imports and builds call/import graph edges
-- Stores everything in a normalized SQLite schema with optional vector search
-- Enables RAG-style retrieval with semantic/fused `kb_search` for people and agents
+- Stores everything in a normalized SQL schema with optional vector search
+- Enables RAG-style retrieval with semantic/fused search
 - Indexes git history (commits, touched files, refs/branches/tags)
-- Supports line-level git blame through MCP (`kb_blame`)
+- Supports line-level git blame through MCP
 - Supports automatic refresh via watch mode, poll mode, and git hooks
+
+## How Lore integrates with LLMs
+
+```mermaid
+flowchart LR
+    subgraph Codebase
+        SRC[Source Files]
+        GIT[Git Repo]
+    end
+
+    subgraph Lore Indexer
+        WALK[Walker]
+        PARSE[Parser]
+        EXTRACT[Extractors<br/>symbols · imports · call refs]
+        RESOLVE[Import Resolver<br/>internal ↔ external]
+        CALLGRAPH[Call-Graph Builder]
+        EMBED[Embedder]
+        GITHIST[Git History Ingest<br/>commits · diffs · refs]
+    end
+
+    DB[(SQL DB)]
+
+    subgraph MCP Server
+        LOOKUP[kb_lookup]
+        SEARCH[kb_search]
+        GRAPH[kb_graph]
+        SNIPPET[kb_snippet]
+        BLAME[kb_blame]
+        HISTORY[kb_history]
+        METRICS[kb_metrics]
+        WRITEBACK[kb_writeback]
+    end
+
+    subgraph LLM_AGENTS[Agents]
+        CLAUDE[Claude]
+        COPILOT[GitHub Copilot]
+        CUSTOM_AGENT[Custom Agents]
+        CLAUDE ~~~ COPILOT ~~~ CUSTOM_AGENT
+    end
+
+    subgraph ENTRY[User Entrypoints]
+        VSCODE[VS Code]
+        CURSOR[Cursor]
+        CHAT[Chat UI]
+        ORCH[Agent Frameworks]
+        VSCODE ~~~ CURSOR ~~~ CHAT ~~~ ORCH
+    end
+
+    SRC --> WALK --> PARSE --> EXTRACT
+    EXTRACT --> RESOLVE & CALLGRAPH
+    EXTRACT & RESOLVE & CALLGRAPH --> DB
+    EMBED -.->|optional| DB
+    GIT --> GITHIST --> DB
+
+    DB --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK
+
+    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK <--> LLM_AGENTS
+
+    LLM_AGENTS <--- ENTRY
+```
+
+Lore sits between your codebase and any LLM-powered tool. The **indexer**
+pipeline walks source files, parses them into ASTs, and extracts
+symbols/imports/call-refs via language-specific extractors, then resolves
+imports (internal vs external) and builds the call graph. An optional
+**embedder** generates dense vectors for semantic search, and a parallel
+**git history** ingest captures commits, diffs, and refs. Everything is
+persisted to a normalized SQL database. The **MCP server** then exposes that
+database as a set of tools that any MCP-compatible client can call to look up
+symbols, search code, traverse call graphs, read snippets, query
+blame/history, and write summaries back.
+
+The index stays fresh automatically. You can install **git hooks**
+(`post-commit`, `post-merge`, etc.) that trigger an incremental refresh on
+every commit, run a **watch** mode that reacts to filesystem events in
+real time, or use **poll** mode for environments where watch events are
+unreliable. Each refresh only re-processes files whose content hash has
+changed, so updates are fast even on large repositories.
+
+See [docs/architecture.md](docs/architecture.md) for the full schema and
+pipeline breakdown.
 
 ## Supported languages
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# Lore Architecture
+
+Detailed view of Lore's indexing pipeline, storage schema, and MCP tool surface.
+
+## Full pipeline
+
+```mermaid
+flowchart LR
+    subgraph Codebase
+        SRC[Source Files]
+        GIT[Git Repo]
+    end
+
+    subgraph Lore Indexer
+        WALK[Walker<br/>fast-glob · extension map]
+        PARSE[ParserPool<br/>tree-sitter grammars]
+        EXTRACT[Extractors<br/>symbols · imports · call refs]
+        RESOLVE[ImportResolver<br/>internal ↔ external]
+        CALLGRAPH[Call-Graph Builder<br/>callee resolution · topo sort]
+        EMBED[Embedder<br/>sentence-transformers<br/>Python subprocess]
+        GITHIST[Git History Ingest<br/>commits · diffs · refs]
+    end
+
+    subgraph SQLite KB
+        FILES[(files)]
+        SYM[(symbols · symbols_fts)]
+        IMP[(file_imports · external_deps)]
+        REFS[(symbol_refs)]
+        VEC[(vec0 embeddings)]
+        HIST[(commits · commit_files<br/>commit_refs)]
+        META[(kb_meta · symbol_summaries)]
+    end
+
+    subgraph MCP Server
+        LOOKUP[kb_lookup]
+        SEARCH[kb_search<br/>BM25 · vector · fused]
+        GRAPH[kb_graph]
+        SNIPPET[kb_snippet]
+        BLAME[kb_blame]
+        HISTORY[kb_history]
+        METRICS[kb_metrics]
+        WRITEBACK[kb_writeback]
+    end
+
+    subgraph Consumers
+        AGENT[Agent]
+    end
+
+    SRC --> WALK --> PARSE --> EXTRACT
+    EXTRACT --> RESOLVE --> IMP
+    EXTRACT --> CALLGRAPH --> REFS
+    EXTRACT --> FILES & SYM
+    EMBED -.->|optional| VEC
+    GIT --> GITHIST --> HIST
+
+    FILES & SYM & IMP & REFS & VEC & HIST & META --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK
+
+    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK <-->|stdio / HTTP| AGENT
+```
+
+## Indexer stages
+
+| Stage | Module | What it does |
+|-------|--------|--------------|
+| Walk | `walker.ts` | Discovers source files via `fast-glob`, maps extensions to languages |
+| Parse | `parser.ts` | Lazily creates one tree-sitter `Parser` per language, caches for reuse |
+| Extract | `extractors/*` | Language-specific visitors that pull symbols, imports, and call refs from the AST |
+| Resolve | `resolver.ts` | Classifies each raw import as internal (resolved to a file ID) or external (third-party / stdlib) |
+| Call-Graph | `call-graph.ts` | Matches raw callee names in `symbol_refs` to concrete symbol IDs; supports topo sort and cycle detection |
+| Embed | `embedder.ts` | Optional — spawns a Python subprocess running sentence-transformers to produce dense vectors |
+| Git History | `git-history.ts` | Ingests commits, per-file diffs, and branch/tag refs via `simple-git` |
+
+## SQLite schema groups
+
+| Table group | Tables | Purpose |
+|-------------|--------|---------|
+| Files | `files` | Indexed source files with path, branch, language, hash |
+| Symbols | `symbols`, `symbols_fts` | Named code symbols + FTS5 full-text index |
+| Imports | `file_imports`, `external_deps` | Import declarations resolved to file IDs or external packages |
+| Call refs | `symbol_refs` | Call-site edges from caller symbol to callee symbol |
+| Embeddings | `symbol_embeddings`, `symbol_semantic_embeddings` | vec0 virtual tables for dense vector search |
+| History | `commits`, `commit_files`, `commit_refs` | Git commit metadata, touched files, and named refs |
+| Metadata | `kb_meta`, `symbol_summaries`, `modules`, `file_modules` | Key-value config, LLM summaries, logical module groupings |
+
+## MCP tools
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Find symbols by name or files by path (optional branch filter) |
+| `kb_search` | Structural BM25, semantic vector, or fused RRF search |
+| `kb_graph` | Query call, import, module, or inheritance edges |
+| `kb_snippet` | Return source snippets by file path and line range |
+| `kb_blame` | Return git blame metadata for a line or line range |
+| `kb_history` | Query history by file, commit, author, ref, or recency |
+| `kb_metrics` | Return aggregate index metrics and per-branch breakdown |
+| `kb_writeback` | Persist symbol summaries into `symbol_summaries` |


### PR DESCRIPTION
## Summary

Revamps the README's "How Lore integrates with LLMs" Mermaid diagram and adds a separate detailed architecture reference doc.

### README changes
- **Diagram**: Replaces the original 3-box diagram with a detailed pipeline view showing all indexer stages (Walker → Parser → Extractors → Import Resolver → Call-Graph Builder), optional Embedder, Git History Ingest, SQL DB, all 8 MCP tools, Agents (Claude, GitHub Copilot, Custom), and User Entrypoints (VS Code, Cursor, Chat UI, Agent Frameworks)
- **Intro**: Repositioned Lore as agent infrastructure rather than a general-purpose tool
- **Freshness**: Added paragraph explaining how the index stays current (git hooks, watch mode, poll mode, content-hash diffing)
- **Technology references**: Removed specific tech names (tree-sitter, fast-glob, sentence-transformers) from the diagram to keep it architecture-focused
- **Link**: Added link to new `docs/architecture.md` for deeper detail

### New file: `docs/architecture.md`
- Full pipeline Mermaid with per-table SQLite schema breakdown
- Indexer stages table with module names and descriptions
- SQLite schema groups table
- MCP tools reference table