### PR TITLE
Add status badges and coverage to architecture diagrams (#71)

### DIFF
--- a/.cadre/progress.md
+++ b/.cadre/progress.md
@@ -1,0 +1,36 @@
+# CADRE Progress
+
+## Fleet Status
+- **Issues**: 19 total | 13 completed | 0 in-progress | 5 failed | 0 blocked | 0 not-started | 0 budget-exceeded
+- **PRs Created**: 10
+- **Token Usage**: 0 / 500,000
+- **Last Updated**: 2026-02-28T07:40:55.119Z
+
+## Issues
+
+| Issue | Title | Status | Phase | PR |
+|-------|-------|--------|-------|----|
+| #36 | Add LLM notes store (kb_notes_write / kb_notes_read) for cached insights | ❌ failed | 0/5 | — |
+| #35 | Add kb_architecture tool for codebase structure overview | ❌ failed | 1/5 | — |
+| #34 | Add kb_commit_stats tool for commit pattern analytics | ❌ failed | 0/5 | — |
+| #33 | Auto-ingest code coverage data (LCOV / Cobertura) | ❌ failed | 0/5 | — |
+| #32 | Add SHA watermark for incremental git ingestion (#26) | ❌ failed | 1/5 | — |
+| #31 | Prevent overlapping poller and watcher runs (#23) | ✅ completed | 5/5 | #41 |
+| #30 | Remove orphan FTS rows on deleted files (#21) | ✅ completed | 5/5 | #43 |
+| #29 | Populate module graph and implement richer cross-language relationship extraction | ✅ completed | 5/5 | #45 |
+| #28 | Branch-aware checkout semantics and reindex checkpoints | ✅ completed | 5/5 | #46 |
+| #27 | Wrap build() and update() file loops in SQLite transactions | ✅ completed | 5/5 | #42 |
+| #26 | Add watermark-based incremental history ingestion | ✅ completed | 5/5 | — |
+| #25 | Add tests for deletion refresh, call-edge resolution, and FTS cleanup | 🚫 dep-blocked | 0/5 | — |
+| #24 | Fix ESM-incompatible require in kb-server/db.ts and emit degraded-mode warning | ✅ completed | 5/5 | #39 |
+| #23 | Add single-flight guard to FilePoller and FileWatcher | ✅ completed | 5/5 | — |
+| #22 | Fix manual refresh deletion detection in CLI | ✅ completed | 5/5 | #40 |
+| #21 | Fix FTS5 orphans on file deletion in update() | ✅ completed | 5/5 | — |
+| #20 | Call ingestGitHistory() in update() when history is enabled | ✅ completed | 5/5 | #38 |
+| #19 | Call embedStructural() in update() when embedder is configured | ✅ completed | 5/5 | #37 |
+| #18 | Invoke buildCallGraph() in build() and update() (branch-scoped) | ✅ completed | 5/5 | #44 |
+
+## Event Log
+
+- `07:22:30` Fleet started: 19 issues
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Lore
 
+[![CI](https://github.com/jafreck/Lore/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jafreck/Lore/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9+-blue)](https://www.typescriptlang.org)
+
 **The teammate that has seen it all** Lore is your agent's institutional knowledge over the codebase — it knows what was built, why it changed, and how it all connects. Lore indexes your code and git history into a structured knowledge base that agents query through MCP. It maps symbols, imports, call relationships, and git history — with optional embeddings for semantic search — so agents can reason about your codebase
 without re-reading it from scratch.
 
@@ -20,6 +25,7 @@ flowchart LR
     subgraph Codebase
         SRC[Source Files]
         GIT[Git Repo]
+        COV[Coverage Reports]
     end
 
     subgraph Lore Indexer
@@ -30,6 +36,7 @@ flowchart LR
         CALLGRAPH[Call-Graph Builder]
         EMBED[Embedder]
         GITHIST[Git History Ingest<br/>commits · diffs · refs]
+        COVINGEST[Coverage Ingest<br/>lcov · cobertura]
     end
 
     DB[(SQL DB)]
@@ -65,6 +72,7 @@ flowchart LR
     EXTRACT & RESOLVE & CALLGRAPH --> DB
     EMBED -.->|optional| DB
     GIT --> GITHIST --> DB
+    COV --> COVINGEST --> DB
 
     DB --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ flowchart LR
     subgraph Codebase
         SRC[Source Files]
         GIT[Git Repo]
+        COVREP[Coverage Reports]
     end
 
     subgraph Lore Indexer
@@ -45,8 +46,19 @@ flowchart LR
         WRITEBACK[kb_writeback]
     end
 
-    subgraph Consumers
-        AGENT[Agent]
+    subgraph LLM_AGENTS[Agents]
+        CLAUDE[Claude]
+        COPILOT[GitHub Copilot]
+        CUSTOM_AGENT[Custom Agents]
+        CLAUDE ~~~ COPILOT ~~~ CUSTOM_AGENT
+    end
+
+    subgraph ENTRY[User Entrypoints]
+        VSCODE[VS Code]
+        CURSOR[Cursor]
+        CHAT[Chat UI]
+        ORCH[Agent Frameworks]
+        VSCODE ~~~ CURSOR ~~~ CHAT ~~~ ORCH
     end
 
     SRC --> WALK --> PARSE --> EXTRACT
@@ -54,12 +66,15 @@ flowchart LR
     EXTRACT --> CALLGRAPH --> REFS
     EXTRACT --> FILES & SYM
     COVER --> COV
+    COVREP --> COVER
     EMBED -.->|optional| VEC
     GIT --> GITHIST --> HIST
 
     FILES & SYM & IMP & REFS & COV & VEC & HIST & META --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK
 
-    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK <-->|stdio / HTTP| AGENT
+    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK <--> LLM_AGENTS
+
+    LLM_AGENTS <--- ENTRY
 ```
 
 ## Indexer stages


### PR DESCRIPTION
## Summary

- Add CI, license, Node.js, and TypeScript status badges to top of README
- Add Coverage Reports input and Coverage Ingest stage to README architecture Mermaid diagram
- Sync `docs/architecture.md` to match: add Coverage Reports to Codebase subgraph, update Consumers to Agents + User Entrypoints