### PR TITLE
ci: update publish workflow for npm trusted publishing (OIDC provenance)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types:
       - published
@@ -12,8 +9,10 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
+      id-token: write        # Required for npm trusted publishing (OIDC provenance)
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +31,6 @@ jobs:
 
       - name: Dry-run publish
         run: npm publish --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Closes #72

## Changes
- Update `.github/workflows/publish.yml` to use npm trusted publishing via OIDC provenance instead of `NODE_AUTH_TOKEN` secret
  - Added `id-token: write` permission for OIDC
  - Added `environment: npm` for optional deployment protection rules
  - Use `--provenance --access public` flags
  - Removed `NODE_AUTH_TOKEN` env vars (no longer needed)
  - Simplified trigger to `release: published` only (removed tag push)

## Setup required after merge
1. **Create a GitHub environment** called `npm` (optional but recommended for approval gates): Settings → Environments → New environment
2. **Configure trusted publishing on npmjs.com**: Package settings → Configure trusted publishing → Repository: `jafreck/Lore`, Workflow: `publish.yml`, Environment: `npm`
3. **Future releases**: Create a GitHub Release → workflow auto-publishes to npm with provenance