### PR TITLE
feat(kb-server): add SearchObserver callback for search observability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ export type { PollerOptions } from './indexer/poller.js';
 
 // ── MCP server ────────────────────────────────────────────────────────────────
 export { createKbMcpServer } from './kb-server/server.js';
+export type { KbServerOptions } from './kb-server/server.js';
+export type { SearchObservation, SearchObserver } from './kb-server/tools/search.js';
 export {
   openReadOnly,
   getSymbolById,

--- a/src/kb-server/server.ts
+++ b/src/kb-server/server.ts
@@ -42,6 +42,7 @@ import { SentenceTransformersProvider, type EmbeddingProvider } from '../indexer
 import * as lookup from './tools/lookup.js';
 import * as graph from './tools/graph.js';
 import * as search from './tools/search.js';
+import type { SearchObserver } from './tools/search.js';
 import * as testMap from './tools/test-map.js';
 import * as snippet from './tools/snippet.js';
 import * as blame from './tools/blame.js';
@@ -97,19 +98,29 @@ function handleCommitStats(db: Database.Database, args: CommitStatsArgs): unknow
   }
 }
 
+// ─── Server options ───────────────────────────────────────────────────────────
+
+/** Optional configuration for `createKbMcpServer`. */
+export interface KbServerOptions {
+  /** Callback invoked after every `kb_search` call with query/mode/latency/result metadata. */
+  searchObserver?: SearchObserver;
+}
+
 // ─── Server factory ───────────────────────────────────────────────────────────
 
 /**
  * Create and return a fully-configured `McpServer` with all KB tools registered.
  *
- * @param db      Read-only SQLite connection to the knowledge-base.
- * @param dbPath  Path to the DB file, needed by `kb_writeback` for write access.
+ * @param db       Read-only SQLite connection to the knowledge-base.
+ * @param dbPath   Path to the DB file, needed by `kb_writeback` for write access.
  * @param embedder Optional live embedding provider for semantic/fused search.
+ * @param options  Optional server configuration (e.g. search observer).
  */
 export function createKbMcpServer(
   db: Database.Database,
   dbPath: string,
   embedder?: EmbeddingProvider,
+  options?: KbServerOptions,
 ): McpServer {
   const server = new McpServer(
     { name: 'lore-kb-server', version: '0.1.0' },
@@ -161,7 +172,7 @@ export function createKbMcpServer(
       branch: z.string().optional().describe('Optional branch to filter results.'),
     },
     async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(await search.handler(db, args, embedder)) }],
+      content: [{ type: 'text', text: JSON.stringify(await search.handler(db, args, embedder, options?.searchObserver)) }],
     }),
   );
 

--- a/src/kb-server/tools/search.ts
+++ b/src/kb-server/tools/search.ts
@@ -15,6 +15,34 @@
 import type { Database } from '../db.js';
 import type { EmbeddingProvider } from '../../indexer/embedder.js';
 
+// ─── Observability ────────────────────────────────────────────────────────────
+
+/**
+ * Observation emitted after every `kb_search` invocation.
+ * Consumers can use this to log, collect metrics, or detect search-quality issues.
+ */
+export interface SearchObservation {
+  /** ISO-8601 timestamp when the search completed. */
+  timestamp: string;
+  /** The raw query string sent by the caller. */
+  query: string;
+  /** The mode the caller requested (defaults to 'structural'). */
+  requestedMode: 'structural' | 'semantic' | 'fused';
+  /** The mode that was actually used (may differ due to fallback). */
+  modeUsed: string;
+  /** Number of results returned. */
+  resultCount: number;
+  /** Best (lowest distance / highest BM25) score among results, or `null` if empty. */
+  topScore: number | null;
+  /** Wall-clock milliseconds for the entire handler call. */
+  latencyMs: number;
+  /** Branch filter applied, if any. */
+  branch?: string;
+}
+
+/** Callback invoked after each search completes. Fire-and-forget — errors are swallowed. */
+export type SearchObserver = (observation: SearchObservation) => void;
+
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
@@ -197,32 +225,53 @@ export async function handler(
   db: Database.Database,
   args: SearchArgs,
   embedder?: EmbeddingProvider,
+  observer?: SearchObserver,
 ): Promise<SearchResult> {
+  const start = Date.now();
   const limit = args.limit ?? 20;
   const mode = args.mode ?? 'structural';
 
   const structural = structuralSearch(db, args.query, limit, args.branch);
 
+  let result: SearchResult;
+
   if (mode === 'structural') {
-    return { results: structural, mode_used: 'structural' };
-  }
-
-  if (!embedder) {
+    result = { results: structural, mode_used: 'structural' };
+  } else if (!embedder) {
     // No query-time embedder available — callers can detect this degradation.
-    return { results: structural, mode_used: 'structural (no query-time embedder)' };
-  }
+    result = { results: structural, mode_used: 'structural (no query-time embedder)' };
+  } else {
+    const semantic = await semanticSearch(db, args.query, limit, embedder, args.branch);
 
-  const semantic = await semanticSearch(db, args.query, limit, embedder, args.branch);
-
-  if (mode === 'semantic') {
-    if (semantic) {
-      return { results: semantic, mode_used: 'semantic' };
+    if (mode === 'semantic') {
+      result = semantic
+        ? { results: semantic, mode_used: 'semantic' }
+        : { results: structural, mode_used: 'structural (fallback: no embeddings)' };
+    } else {
+      // mode === 'fused'
+      const fused = rrfFuse(structural, semantic, limit);
+      const modeUsed = semantic ? 'fused' : 'structural (fallback: no embeddings)';
+      result = { results: fused, mode_used: modeUsed };
     }
-    return { results: structural, mode_used: 'structural (fallback: no embeddings)' };
   }
 
-  // mode === 'fused'
-  const fused = rrfFuse(structural, semantic, limit);
-  const modeUsed = semantic ? 'fused' : 'structural (fallback: no embeddings)';
-  return { results: fused, mode_used: modeUsed };
+  // ── Emit observation ─────────────────────────────────────────────────────
+  if (observer) {
+    try {
+      observer({
+        timestamp: new Date().toISOString(),
+        query: args.query,
+        requestedMode: mode,
+        modeUsed: result.mode_used,
+        resultCount: result.results.length,
+        topScore: result.results.length > 0 ? result.results[0]!.score : null,
+        latencyMs: Date.now() - start,
+        branch: args.branch,
+      });
+    } catch {
+      // Observer errors must never break search.
+    }
+  }
+
+  return result;
 }

--- a/tests/kb-server/server.test.ts
+++ b/tests/kb-server/server.test.ts
@@ -11,11 +11,25 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   },
 }));
 
-import { createKbMcpServer } from '../../src/kb-server/server.js';
+import { createKbMcpServer, type KbServerOptions } from '../../src/kb-server/server.js';
 
 describe('createKbMcpServer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('should accept an options parameter with searchObserver', () => {
+    const db = new Database(':memory:');
+    const observer = vi.fn();
+    const options: KbServerOptions = { searchObserver: observer };
+
+    // Should not throw when options are provided.
+    createKbMcpServer(db, '/tmp/test.db', undefined, options);
+
+    // All standard tools should still be registered.
+    const toolNames = mockTool.mock.calls.map((call) => call[0]);
+    expect(toolNames).toContain('kb_search');
+    expect(toolNames).toContain('kb_lookup');
   });
 
   it('should register kb_graph kind schema with module and inheritance values', () => {

--- a/tests/kb-server/tools/search.test.ts
+++ b/tests/kb-server/tools/search.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import { handler, type SearchArgs, type SearchResult } from '../../../src/kb-server/tools/search.js';
+import { handler, type SearchArgs, type SearchResult, type SearchObservation, type SearchObserver } from '../../../src/kb-server/tools/search.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -133,5 +133,94 @@ describe('search handler – semantic/fused fallback without embedder', () => {
   it('should fall back to structural when mode=fused and no embedder provided', async () => {
     const result = await handler(db, { query: 'myFunc', mode: 'fused' });
     expect(result.mode_used).toBe('structural (no query-time embedder)');
+  });
+});
+
+// ─── SearchObserver callback ──────────────────────────────────────────────────
+
+describe('search handler – observer callback', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const mainId = insertFile(db, 'src/main.ts', 'main');
+    insertSymbol(db, mainId, 'parseConfig');
+    insertSymbol(db, mainId, 'renderPage');
+  });
+
+  it('should invoke observer with correct fields on structural search', async () => {
+    const observations: SearchObservation[] = [];
+    const observer: SearchObserver = (obs) => observations.push(obs);
+
+    await handler(db, { query: 'parseConfig', mode: 'structural' }, undefined, observer);
+
+    expect(observations).toHaveLength(1);
+    const obs = observations[0]!;
+    expect(obs.query).toBe('parseConfig');
+    expect(obs.requestedMode).toBe('structural');
+    expect(obs.modeUsed).toBe('structural');
+    expect(obs.resultCount).toBe(1);
+    expect(obs.topScore).toBeTypeOf('number');
+    expect(obs.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(obs.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('should report zero results and null topScore when query has no matches', async () => {
+    const observations: SearchObservation[] = [];
+    const observer: SearchObserver = (obs) => observations.push(obs);
+
+    await handler(db, { query: 'zzz_no_match_zzz', mode: 'structural' }, undefined, observer);
+
+    expect(observations).toHaveLength(1);
+    expect(observations[0]!.resultCount).toBe(0);
+    expect(observations[0]!.topScore).toBeNull();
+  });
+
+  it('should report fallback mode when semantic requested without embedder', async () => {
+    const observations: SearchObservation[] = [];
+    const observer: SearchObserver = (obs) => observations.push(obs);
+
+    await handler(db, { query: 'parseConfig', mode: 'semantic' }, undefined, observer);
+
+    expect(observations).toHaveLength(1);
+    expect(observations[0]!.requestedMode).toBe('semantic');
+    expect(observations[0]!.modeUsed).toBe('structural (no query-time embedder)');
+  });
+
+  it('should include branch in observation when branch filter is used', async () => {
+    const observations: SearchObservation[] = [];
+    const observer: SearchObserver = (obs) => observations.push(obs);
+
+    await handler(db, { query: 'parseConfig', mode: 'structural', branch: 'main' }, undefined, observer);
+
+    expect(observations).toHaveLength(1);
+    expect(observations[0]!.branch).toBe('main');
+  });
+
+  it('should not include branch in observation when no branch filter is used', async () => {
+    const observations: SearchObservation[] = [];
+    const observer: SearchObserver = (obs) => observations.push(obs);
+
+    await handler(db, { query: 'parseConfig', mode: 'structural' }, undefined, observer);
+
+    expect(observations).toHaveLength(1);
+    expect(observations[0]!.branch).toBeUndefined();
+  });
+
+  it('should not break search if observer throws', async () => {
+    const throwingObserver: SearchObserver = () => {
+      throw new Error('observer boom');
+    };
+
+    const result = await handler(db, { query: 'parseConfig', mode: 'structural' }, undefined, throwingObserver);
+
+    expect(result.mode_used).toBe('structural');
+    expect(result.results.length).toBeGreaterThan(0);
+  });
+
+  it('should not invoke observer when none is provided', async () => {
+    // Ensure no errors when observer is undefined (default path).
+    const result = await handler(db, { query: 'parseConfig', mode: 'structural' });
+    expect(result.results.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Add a `SearchObserver` callback to the `kb_search` tool handler that emits structured observations after every search call, enabling consumers to log, collect metrics, or detect search-quality issues.

## Changes

### `src/kb-server/tools/search.ts`
- Add `SearchObservation` interface: `timestamp`, `query`, `requestedMode`, `modeUsed`, `resultCount`, `topScore`, `latencyMs`, `branch`
- Add `SearchObserver` callback type
- `handler()` accepts optional 4th `observer` parameter; emits observation after each search (errors swallowed)

### `src/kb-server/server.ts`
- Add `KbServerOptions` interface with optional `searchObserver`
- `createKbMcpServer()` accepts optional 4th `options` parameter, wires observer to search handler

### `src/index.ts`
- Export `KbServerOptions`, `SearchObservation`, `SearchObserver`

### Tests
- 7 new tests in `tests/kb-server/tools/search.test.ts` covering observer invocation, fields, empty results, branch propagation, fallback mode reporting, error resilience
- 1 new test in `tests/kb-server/server.test.ts` for options parameter acceptance

## Testing

All 207 tests pass. `tsc --noEmit` clean.