### PR TITLE
chore(build): add prepare script for git URL installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "vitest run",
     "coverage": "vitest run --coverage"


### PR DESCRIPTION
Add `prepare` script so that `npm install github:jafreck/Lore#tag` works correctly by auto-building from source. Without this, git URL installations get source without `dist/`.