### PR TITLE
chore(package): expose kb-server tool handlers via exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     },
     "./mcp": {
       "default": "./dist/kb-server/server.js"
+    },
+    "./kb-server/db": {
+      "types": "./dist/kb-server/db.d.ts",
+      "default": "./dist/kb-server/db.js"
+    },
+    "./kb-server/tools/*": {
+      "types": "./dist/kb-server/tools/*.d.ts",
+      "default": "./dist/kb-server/tools/*.js"
     }
   },
   "bin": {


### PR DESCRIPTION
Expose `kb-server/tools/*` and `kb-server/db` via the package exports map so consumers using `Node16` module resolution can import individual tool handlers (e.g., `@jafreck/lore/kb-server/tools/search`).