### PR TITLE
fix: remove authToken from .npmrc to unblock OIDC trusted publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 legacy-peer-deps=true
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Problem\nThe project-level `.npmrc` contained `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, which overrides the OIDC token set by `actions/setup-node` during the publish workflow. Since `NODE_AUTH_TOKEN` is not set (trusted publishing uses OIDC instead), npm falls back to an empty token and fails with 404.\n\n## Fix\nRemove the `_authToken` line from `.npmrc`. The `actions/setup-node` action with `registry-url` handles auth via `~/.npmrc` automatically when using OIDC provenance.\n\nThis unblocks the v0.2.0 publish that failed in workflow run #22689136298.