### PR TITLE
fix: install latest npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 


### PR DESCRIPTION
## Problem\nThe publish workflow fails because the npm version bundled with Node.js 22 doesn't fully support OIDC trusted publishing for auth. It signs provenance but can't authenticate the publish PUT request via OIDC.\n\n## Fix\nAdd `npm install -g npm@latest` step before installing dependencies, ensuring the latest npm with full OIDC trusted publishing support is used.\n\nNo `NPM_TOKEN` secret needed — auth is handled entirely via OIDC.\n\nSupersedes #84.