### PR TITLE
docs: fix MCP architecture diagram to show agents not models

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,12 @@ flowchart LR
         WRITEBACK[kb_writeback]
     end
 
-    subgraph LLM_AGENTS[Agents]
-        CLAUDE[Claude]
-        COPILOT[GitHub Copilot]
-        CUSTOM_AGENT[Custom Agents]
-        CLAUDE ~~~ COPILOT ~~~ CUSTOM_AGENT
-    end
-
-    subgraph ENTRY[User Entrypoints]
-        VSCODE[VS Code]
+    subgraph MCP_CLIENTS[MCP Clients — Agents]
+        CLAUDE_CODE[Claude Code / Desktop]
+        COPILOT[VS Code + Copilot]
         CURSOR[Cursor]
-        CHAT[Chat UI]
-        ORCH[Agent Frameworks]
-        VSCODE ~~~ CURSOR ~~~ CHAT ~~~ ORCH
+        CUSTOM[Custom Agent Frameworks]
+        CLAUDE_CODE ~~~ COPILOT ~~~ CURSOR ~~~ CUSTOM
     end
 
     SRC --> WALK --> PARSE --> EXTRACT
@@ -77,9 +70,7 @@ flowchart LR
 
     DB --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK
 
-    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK <--> LLM_AGENTS
-
-    LLM_AGENTS <--- ENTRY
+    LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & WRITEBACK <--> MCP_CLIENTS
 ```
 
 Lore sits between your codebase and any LLM-powered tool. The **indexer**


### PR DESCRIPTION
## Summary

The Mermaid architecture diagram in the README incorrectly listed **models** (e.g. "Claude") as MCP consumers and had a misleading two-layer split between "Agents" and "User Entrypoints." Models are stateless text-in/text-out — it's the **agents** (MCP clients) that connect to MCP servers and invoke tools.

## Changes

- Collapse the redundant **Agents** + **User Entrypoints** subgraphs into a single **MCP Clients — Agents** subgraph
- Rename `Claude` → `Claude Code / Desktop` (Claude is a model; Claude Code/Desktop are the agent wrappers that make MCP calls)
- Merge `VS Code` + `GitHub Copilot` into `VS Code + Copilot` (Copilot is the agent layer inside VS Code)
- Move `Cursor` into the MCP Clients group (it is itself an MCP client/agent)
- Remove the intermediate arrow layer between MCP server and clients