### PR TITLE
Add direct dependency API indexing (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ flowchart LR
     DB[(SQL DB)]
 
     subgraph MCP Server
-        LOOKUP[lore_lookup]
-        SEARCH[lore_search]
-        GRAPH[lore_graph]
-        SNIPPET[lore_snippet]
-        BLAME[lore_blame]
-        HISTORY[lore_history]
-        METRICS[lore_metrics]
-        WRITEBACK[lore_writeback]
+        LOOKUP[kb_lookup]
+        SEARCH[kb_search]
+        GRAPH[kb_graph]
+        SNIPPET[kb_snippet]
+        BLAME[kb_blame]
+        HISTORY[kb_history]
+        METRICS[kb_metrics]
+        WRITEBACK[kb_writeback]
     end
 
     subgraph MCP_CLIENTS[MCP Clients — Agents]
@@ -204,7 +204,7 @@ await new IndexBuilder(
 Build or update a knowledge base.
 
 ```bash
-npx @jafreck/lore index --root <dir> --db <path> [--embedding-model <id>] [--history] [--history-depth <n>] [--history-all] [--include <glob>] [--exclude <glob>] [--language <lang>]
+npx @jafreck/lore index --root <dir> --db <path> [--embedding-model <id>] [--index-deps] [--history] [--history-depth <n>] [--history-all] [--include <glob>] [--exclude <glob>] [--language <lang>]
 ```
 
 Key flags:
@@ -212,6 +212,7 @@ Key flags:
 - `--root <dir>` required source root
 - `--db <path>` required SQLite output path
 - `--embedding-model <id>` embedding model identifier
+- `--index-deps` opt-in dependency API indexing from direct dependency declaration files
 - `--history` enable git history ingestion
 - `--history-depth <n>` cap number of ingested commits
 - `--history-all` traverse all refs (branches/tags)
@@ -219,14 +220,32 @@ Key flags:
 - `--exclude` repeatable glob exclude filter
 - `--language` repeatable language filter (mapped to extensions)
 
+Dependency API indexing is disabled by default and only runs when `--index-deps`
+is provided (or `indexDependencies: true` in programmatic options). When
+enabled, Lore indexes declaration-level public API surface from direct
+dependencies across supported ecosystems:
+
+- TypeScript/JavaScript: exported declarations from `.d.ts` files in direct npm
+  dependencies declared in root `package.json` (`dependencies`,
+  `devDependencies`, `peerDependencies`)
+- Python: stubbed/public declarations from direct dependencies via `.pyi` and
+  `py.typed` package metadata
+- Go: exported declarations from direct module requirements declared in root
+  `go.mod`
+- Rust: `pub` declaration surface from crates declared directly in root
+  `Cargo.toml`
+
+For all ecosystems, Lore excludes implementation bodies and does not crawl
+transitive dependency trees.
+
 ### lore refresh
 
 Incremental refresh flow for an existing index.
 
 ```bash
-npx @jafreck/lore refresh --db <path> --root <dir> [--history] [--history-depth <n>] [--history-all]
-npx @jafreck/lore refresh --db <path> --root <dir> --watch [--history]
-npx @jafreck/lore refresh --db <path> --root <dir> --poll [--history]
+npx @jafreck/lore refresh --db <path> --root <dir> [--index-deps] [--history] [--history-depth <n>] [--history-all]
+npx @jafreck/lore refresh --db <path> --root <dir> --watch [--index-deps] [--history]
+npx @jafreck/lore refresh --db <path> --root <dir> --poll [--index-deps] [--history]
 ```
 
 Modes:
@@ -285,15 +304,15 @@ gracefully degrades to structural search.
 
 | Tool | Purpose |
 |------|---------|
-| `lore_lookup` | Find symbols by name or files by path (optional branch filter) |
-| `lore_search` | Structural BM25, semantic vector, or fused RRF search |
-| `lore_graph` | Query call/import/module/inheritance edges; call edges include `callee_coverage_percent` |
-| `lore_snippet` | Return source snippets by file path and line range |
-| `lore_blame` | Return git blame metadata for a line or line range |
-| `lore_history` | Query history by file, commit, author, ref, or recency |
-| `lore_metrics` | Return aggregate index metrics plus coverage/staleness fields (`coverage_available`, `coverage_commit`, `current_commit`, `commits_behind`, `stale`, global coverage totals) |
-| `lore_coverage` | Return symbol-level coverage, uncovered lines, and staleness metadata for the latest coverage run |
-| `lore_writeback` | Persist symbol summaries into `symbol_summaries` |
+| `kb_lookup` | Find symbols by name or files by path (optional branch filter), including external dependency API symbols from `external_symbols` in symbol lookups |
+| `kb_search` | Structural BM25, semantic vector, or fused RRF search; structural symbol queries also include external dependency API name matches from `external_symbols` |
+| `kb_graph` | Query call/import/module/inheritance edges; call edges include `callee_coverage_percent` |
+| `kb_snippet` | Return source snippets by file path and line range |
+| `kb_blame` | Return git blame metadata for a line or line range |
+| `kb_history` | Query history by file, commit, author, ref, or recency |
+| `kb_metrics` | Return aggregate index metrics plus coverage/staleness fields (`coverage_available`, `coverage_commit`, `current_commit`, `commits_behind`, `stale`, global coverage totals) |
+| `kb_coverage` | Return symbol-level coverage, uncovered lines, and staleness metadata for the latest coverage run |
+| `kb_writeback` | Persist symbol summaries into `symbol_summaries` |
 
 ### MCP config example
 
@@ -310,7 +329,7 @@ gracefully degrades to structural search.
 
 ## Git history indexing
 
-Lore can ingest full git history and expose it through `lore_history`.
+Lore can ingest full git history and expose it through `kb_history`.
 
 ### Indexed history tables
 
@@ -318,7 +337,7 @@ Lore can ingest full git history and expose it through `lore_history`.
 - `commit_files`: per-commit touched paths with change type and diff stats
 - `commit_refs`: refs currently pointing at commits (`branch`/`tag`/`other`)
 
-### lore_history modes
+### kb_history modes
 
 - `recent`: newest commits
 - `file`: commits that touched a path
@@ -328,7 +347,7 @@ Lore can ingest full git history and expose it through `lore_history`.
 
 ## Blame queries
 
-Use `lore_blame` for line-level attribution.
+Use `kb_blame` for line-level attribution.
 
 Examples:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ flowchart LR
         PARSE[ParserPool<br/>tree-sitter grammars]
         EXTRACT[Extractors<br/>symbols · imports · call refs]
         RESOLVE[ImportResolver<br/>internal ↔ external]
+        DEPAPI[Dependency API Indexer<br/>direct deps · TS/Py/Go/Rust declarations]
         CALLGRAPH[Call-Graph Builder<br/>callee resolution · topo sort]
         COVER[Coverage Ingest<br/>LCOV · Cobertura]
         EMBED[Embedder<br/>sentence-transformers<br/>Python subprocess]
@@ -27,6 +28,7 @@ flowchart LR
         FILES[(files)]
         SYM[(symbols · symbols_fts)]
         IMP[(file_imports · external_deps)]
+        EXT[(external_symbols)]
         REFS[(symbol_refs)]
         COV[(coverage_runs · coverage_files<br/>coverage_lines)]
         VEC[(vec0 embeddings)]
@@ -35,15 +37,15 @@ flowchart LR
     end
 
     subgraph MCP Server
-        LOOKUP[lore_lookup]
-        SEARCH[lore_search<br/>BM25 · vector · fused]
-        GRAPH[lore_graph]
-        SNIPPET[lore_snippet]
-        BLAME[lore_blame]
-        HISTORY[lore_history]
-        METRICS[lore_metrics]
-        KB_COVERAGE[lore_coverage]
-        WRITEBACK[lore_writeback]
+        LOOKUP[kb_lookup]
+        SEARCH[kb_search<br/>BM25 · vector · fused]
+        GRAPH[kb_graph]
+        SNIPPET[kb_snippet]
+        BLAME[kb_blame]
+        HISTORY[kb_history]
+        METRICS[kb_metrics]
+        KB_COVERAGE[kb_coverage]
+        WRITEBACK[kb_writeback]
     end
 
     subgraph LLM_AGENTS[Agents]
@@ -63,6 +65,7 @@ flowchart LR
 
     SRC --> WALK --> PARSE --> EXTRACT
     EXTRACT --> RESOLVE --> IMP
+    RESOLVE --> DEPAPI --> EXT
     EXTRACT --> CALLGRAPH --> REFS
     EXTRACT --> FILES & SYM
     COVER --> COV
@@ -70,7 +73,7 @@ flowchart LR
     EMBED -.->|optional| VEC
     GIT --> GITHIST --> HIST
 
-    FILES & SYM & IMP & REFS & COV & VEC & HIST & META --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK
+    FILES & SYM & IMP & EXT & REFS & COV & VEC & HIST & META --- LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK
 
     LOOKUP & SEARCH & GRAPH & SNIPPET & BLAME & HISTORY & METRICS & KB_COVERAGE & WRITEBACK <--> LLM_AGENTS
 
@@ -85,6 +88,7 @@ flowchart LR
 | Parse | `parser.ts` | Lazily creates one tree-sitter `Parser` per language, caches for reuse |
 | Extract | `extractors/*` | Language-specific visitors that pull symbols, imports, and call refs from the AST |
 | Resolve | `resolver.ts` | Classifies each raw import as internal (resolved to a file ID) or external (third-party / stdlib) |
+| Dependency APIs | `index.ts` dependency API pass | Optional (`--index-deps`) declaration-only indexing from direct dependencies across npm (`.d.ts`), Python (`.pyi` / `py.typed`), Go (direct `go.mod` requirements), and Rust (direct `Cargo.toml` crates); excludes transitive dependencies and implementation bodies |
 | Call-Graph | `call-graph.ts` | Matches raw callee names in `symbol_refs` to concrete symbol IDs; supports topo sort and cycle detection |
 | Coverage | `coverage.ts` | Parses LCOV/Cobertura reports, normalizes per-file/per-line hit data, and persists a run linked to commit SHA/source mtime |
 | Embed | `embedder.ts` | Optional — spawns a Python subprocess running sentence-transformers to produce dense vectors |
@@ -99,6 +103,7 @@ Coverage ingestion accepts reports from auto-detected paths (`coverage/lcov.info
 | Files | `files` | Indexed source files with path, branch, language, hash |
 | Symbols | `symbols`, `symbols_fts` | Named code symbols + FTS5 full-text index |
 | Imports | `file_imports`, `external_deps` | Import declarations resolved to file IDs or external packages |
+| Dependency APIs | `external_symbols` | Exported/public declarations from direct dependency APIs across npm, Python, Go, and Rust (ecosystem/source/package/version + symbol metadata), stored separately from in-repo symbols |
 | Call refs | `symbol_refs` | Call-site edges from caller symbol to callee symbol |
 | Coverage | `coverage_runs`, `coverage_files`, `coverage_lines` | Coverage ingestion run metadata plus normalized per-file and per-line hit data |
 | Embeddings | `symbol_embeddings`, `symbol_semantic_embeddings` | vec0 virtual tables for dense vector search |
@@ -109,12 +114,22 @@ Coverage ingestion accepts reports from auto-detected paths (`coverage/lcov.info
 
 | Tool | Purpose |
 |------|---------|
-| `lore_lookup` | Find symbols by name or files by path (optional branch filter) |
-| `lore_search` | Structural BM25, semantic vector, or fused RRF search |
-| `lore_graph` | Query call, import, module, or inheritance edges (`call` edges include `callee_coverage_percent`) |
-| `lore_snippet` | Return source snippets by file path and line range |
-| `lore_blame` | Return git blame metadata for a line or line range |
-| `lore_history` | Query history by file, commit, author, ref, or recency |
-| `lore_metrics` | Return aggregate index metrics plus global coverage totals and staleness metadata (`coverage_commit`, `current_commit`, `commits_behind`, `stale`) |
-| `lore_coverage` | Return symbol-level coverage, uncovered lines, and staleness metadata for the latest coverage run |
-| `lore_writeback` | Persist symbol summaries into `symbol_summaries` |
+| `kb_lookup` | Find symbols by name or files by path (optional branch filter), including external API symbol matches from `external_symbols` |
+| `kb_search` | Structural BM25, semantic vector, or fused RRF search, with structural results augmented by external symbol-name matches from `external_symbols` |
+| `kb_graph` | Query call, import, module, or inheritance edges (`call` edges include `callee_coverage_percent`) |
+| `kb_snippet` | Return source snippets by file path and line range |
+| `kb_blame` | Return git blame metadata for a line or line range |
+| `kb_history` | Query history by file, commit, author, ref, or recency |
+| `kb_metrics` | Return aggregate index metrics plus global coverage totals and staleness metadata (`coverage_commit`, `current_commit`, `commits_behind`, `stale`) |
+| `kb_coverage` | Return symbol-level coverage, uncovered lines, and staleness metadata for the latest coverage run |
+| `kb_writeback` | Persist symbol summaries into `symbol_summaries` |
+
+External symbol retrieval flow:
+1. Dependency API indexing is opt-in and reads declaration surfaces from direct dependencies only:
+   - npm: top-level `package.json` direct deps (`dependencies` / `devDependencies` / `peerDependencies`)
+   - Python: direct requirements from project dependency manifests, indexed via `.pyi` / `py.typed` declaration sources
+   - Go: direct `require` entries from root `go.mod`
+   - Rust: direct dependency entries from root `Cargo.toml`
+2. Exported dependency declarations are persisted to `external_symbols` with package/version metadata.
+3. Transitive dependencies are excluded in all ecosystems; Lore indexes only the direct boundary.
+4. MCP retrieval paths include `external_symbols` for symbol-facing queries so dependency APIs can be returned alongside in-repo symbols in `kb_lookup` and structural `kb_search`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,10 +23,10 @@ import * as fs from 'node:fs';
 function usage(): never {
   console.error(
     `Usage:
-  lore index --root <dir> --db <path> [--embedding-model <id>] [--history] [--history-depth <n>] [--history-all]
+  lore index --root <dir> --db <path> [--embedding-model <id>] [--index-deps] [--history] [--history-depth <n>] [--history-all]
                          Index a codebase into a knowledge-base SQLite file
   lore mcp --db <path>                          Start the KB MCP server (stdio transport)
-  lore refresh --db <path> --root <dir> [--history] [--history-depth <n>] [--history-all]  Run an incremental index update and exit
+  lore refresh --db <path> --root <dir> [--index-deps] [--history] [--history-depth <n>] [--history-all]  Run an incremental index update and exit
   lore refresh --db <path> --root <dir> --watch Watch for file changes and refresh automatically
   lore refresh --db <path> --root <dir> --poll  Poll for file changes and refresh automatically
   lore hooks --db <path> --root <dir> [--history] [--history-depth <n>] [--history-all]
@@ -38,6 +38,7 @@ Options:
   --root <dir>             Root directory to index (required for index, refresh)
   --db <path>              Path to a Lore knowledge-base SQLite file (required for index, mcp, refresh)
   --embedding-model <id>   Embedding model identifier (default: Qwen/Qwen3-Embedding-4B)
+  --index-deps             Enable dependency API indexing (disabled by default)
   --history                Enable git history ingestion
   --history-depth <n>      Limit commit ingestion to the most recent N commits
   --history-all            Traverse all refs (branches/tags) for history ingestion
@@ -95,6 +96,7 @@ async function main(): Promise<void> {
       return;
     }
     const embeddingModel = flag(args, '--embedding-model');
+    const indexDependencies = args.includes('--index-deps');
     const historyEnabled = args.includes('--history');
     const historyAll = args.includes('--history-all');
     const historyDepthRaw = flag(args, '--history-depth');
@@ -161,6 +163,7 @@ async function main(): Promise<void> {
 
     const shouldEnableHistory = historyEnabled || historyAll || historyDepth !== undefined;
     const options = {
+      indexDependencies,
       ...(embeddingModel && { embeddingModel }),
       ...(shouldEnableHistory && {
         history: {
@@ -179,7 +182,7 @@ async function main(): Promise<void> {
         ...(extensions && { extensions }),
       },
       undefined,
-      Object.keys(options).length > 0 ? options : undefined,
+      options,
     );
     await builder.build();
   } else if (subcommand === 'mcp') {
@@ -242,6 +245,7 @@ async function main(): Promise<void> {
 
     const watchMode = args.includes('--watch');
     const pollMode = args.includes('--poll');
+    const indexDependencies = args.includes('--index-deps');
 
     const historyEnabled = args.includes('--history');
     const historyAll = args.includes('--history-all');
@@ -267,12 +271,14 @@ async function main(): Promise<void> {
       : false;
 
     const walkerConfig = { rootDir };
+    const refreshOptions = {
+      indexDependencies,
+      ...(shouldEnableHistory && { history: historyOption }),
+    };
 
     if (watchMode) {
       const { FileWatcher } = await import('./indexer/watcher.js');
-      const watcher = new FileWatcher(dbPath, walkerConfig, {
-        history: historyOption,
-      });
+      const watcher = new FileWatcher(dbPath, walkerConfig, refreshOptions);
       watcher.start();
       process.stderr.write(
         JSON.stringify({ level: 'info', source: 'cli', message: 'watch mode started', rootDir }) + '\n',
@@ -282,9 +288,7 @@ async function main(): Promise<void> {
       process.on('SIGTERM', () => { watcher.stop(); process.exit(0); });
     } else if (pollMode) {
       const { FilePoller } = await import('./indexer/poller.js');
-      const poller = new FilePoller(dbPath, walkerConfig, {
-        history: historyOption,
-      });
+      const poller = new FilePoller(dbPath, walkerConfig, refreshOptions);
       poller.start();
       process.stderr.write(
         JSON.stringify({ level: 'info', source: 'cli', message: 'poll mode started', rootDir }) + '\n',
@@ -295,9 +299,7 @@ async function main(): Promise<void> {
     } else {
       // Manual refresh: full build if DB doesn't exist yet, otherwise incremental update
       const { IndexBuilder } = await import('./indexer/index.js');
-      const builder = new IndexBuilder(dbPath, walkerConfig, undefined, {
-        ...(shouldEnableHistory && { history: historyOption }),
-      });
+      const builder = new IndexBuilder(dbPath, walkerConfig, undefined, refreshOptions);
 
       const dbExists = fs.existsSync(dbPath);
       if (dbExists) {

--- a/src/indexer/db.ts
+++ b/src/indexer/db.ts
@@ -88,6 +88,21 @@ CREATE TABLE IF NOT EXISTS external_deps (
   UNIQUE(file_id, package)
 );
 
+-- Symbols extracted from direct dependency declarations and public API surfaces.
+CREATE TABLE IF NOT EXISTS external_symbols (
+  id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+  dependency_ecosystem TEXT    NOT NULL DEFAULT 'npm',
+  source_type          TEXT    NOT NULL DEFAULT 'declaration',
+  source_ref           TEXT    NOT NULL DEFAULT '',
+  package_name         TEXT    NOT NULL,
+  package_version      TEXT,
+  symbol_name          TEXT    NOT NULL,
+  symbol_kind          TEXT    NOT NULL,
+  signature            TEXT    NOT NULL DEFAULT '',
+  doc_comment          TEXT,
+  UNIQUE(dependency_ecosystem, package_name, package_version, symbol_name, symbol_kind, signature)
+);
+
 -- Logical modules grouping related files (e.g. Rust crates, Python packages).
 CREATE TABLE IF NOT EXISTS modules (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -221,6 +236,9 @@ CREATE INDEX IF NOT EXISTS idx_annotations_file_id ON annotations(file_id);
 CREATE INDEX IF NOT EXISTS idx_coverage_runs_ingested_at ON coverage_runs(ingested_at);
 CREATE INDEX IF NOT EXISTS idx_coverage_files_path ON coverage_files(file_path);
 CREATE INDEX IF NOT EXISTS idx_coverage_lines_path_line ON coverage_lines(file_path, line_number);
+CREATE INDEX IF NOT EXISTS idx_external_symbols_dependency_ecosystem ON external_symbols(dependency_ecosystem);
+CREATE INDEX IF NOT EXISTS idx_external_symbols_package_name ON external_symbols(package_name);
+CREATE INDEX IF NOT EXISTS idx_external_symbols_symbol_name ON external_symbols(symbol_name);
 `;
 
 // ─── Public API ───────────────────────────────────────────────────────────────

--- a/src/indexer/extractors/types.ts
+++ b/src/indexer/extractors/types.ts
@@ -10,6 +10,14 @@ import type Parser from 'tree-sitter';
 // ─── Raw data types ───────────────────────────────────────────────────────────
 
 /** A symbol (function, class, struct, etc.) extracted from a source file. */
+export interface DeclarationSurface {
+  /** True when symbol is externally visible from the module/package boundary. */
+  isPublic: boolean;
+  /** True when symbol comes from a declaration-only API surface (no implementation body). */
+  isDeclaration: boolean;
+}
+
+/** A symbol (function, class, struct, etc.) extracted from a source file. */
 export interface RawSymbol {
   /** Simple name of the symbol (e.g. `myFunc`, `MyStruct`). */
   name: string;
@@ -23,6 +31,10 @@ export interface RawSymbol {
   signature: string;
   /** Documentation comment immediately preceding the symbol, if extracted by the language extractor. */
   docComment?: string;
+  /** True when declaration is exported from its module. */
+  isExported?: boolean;
+  /** Normalized declaration-surface metadata for dependency API indexing. */
+  declarationSurface?: DeclarationSurface;
   /** Original AST node for the symbol declaration/expression, when available. */
   astNode?: Parser.SyntaxNode;
 }
@@ -156,4 +168,17 @@ export function nodeSignature(node: Parser.SyntaxNode): string {
 /** Returns an empty `ExtractionResult`. */
 export function emptyResult(): ExtractionResult {
   return { symbols: [], imports: [], callRefs: [], envRefs: [], relationships: [], routes: [] };
+}
+
+/**
+ * Returns true when a symbol belongs to the public declaration API surface.
+ *
+ * Falls back to `isExported` so existing extractors remain compatible while
+ * they migrate to `declarationSurface`.
+ */
+export function isPublicDeclarationSurfaceSymbol(symbol: RawSymbol): boolean {
+  if (symbol.declarationSurface) {
+    return symbol.declarationSurface.isPublic && symbol.declarationSurface.isDeclaration;
+  }
+  return symbol.isExported === true;
 }

--- a/src/indexer/extractors/typescript.ts
+++ b/src/indexer/extractors/typescript.ts
@@ -49,29 +49,31 @@ export const TYPESCRIPT_COMPLEXITY_NODE_TYPES: ComplexityNodeTypes = {
 // ─── TypeScriptExtractor ──────────────────────────────────────────────────────
 
 export class TypeScriptExtractor implements SymbolExtractor {
-  extract(tree: Parser.Tree, _source: string, _filePath: string): ExtractionResult {
+  extract(tree: Parser.Tree, source: string, filePath: string): ExtractionResult {
     const result = emptyResult();
+    const declarationMode = filePath.endsWith('.d.ts');
 
     for (const node of walk(tree.rootNode)) {
       switch (node.type) {
         case 'function_declaration':
         case 'generator_function_declaration':
-          result.symbols.push(extractNamedDecl(node, 'function'));
+        case 'function_signature':
+          result.symbols.push(extractNamedDecl(node, 'function', source, declarationMode));
           break;
         case 'class_declaration':
-          result.symbols.push(extractNamedDecl(node, 'class'));
+          result.symbols.push(extractNamedDecl(node, 'class', source, declarationMode));
           result.relationships.push(...extractClassInheritance(node));
           break;
         case 'interface_declaration':
-          result.symbols.push(extractNamedDecl(node, 'interface'));
+          result.symbols.push(extractNamedDecl(node, 'interface', source, declarationMode));
           break;
         case 'type_alias_declaration':
-          result.symbols.push(extractNamedDecl(node, 'type'));
+          result.symbols.push(extractNamedDecl(node, 'type', source, declarationMode));
           break;
         case 'lexical_declaration':
         case 'variable_declaration': {
           // Handle: const foo = () => {} or const foo = function() {}
-          const sym = maybeExtractArrowOrFunctionExpr(node);
+          const sym = maybeExtractArrowOrFunctionExpr(node, source, declarationMode);
           if (sym) result.symbols.push(sym);
           break;
         }
@@ -105,20 +107,30 @@ function extractClassInheritance(node: Parser.SyntaxNode): RawRelationship[] {
   ];
 }
 
-function extractNamedDecl(node: Parser.SyntaxNode, kind: string): RawSymbol {
+function extractNamedDecl(
+  node: Parser.SyntaxNode,
+  kind: string,
+  source: string,
+  declarationMode: boolean,
+): RawSymbol {
   const nameNode = node.childForFieldName('name');
+  const docComment = declarationMode ? extractLeadingDocComment(node, source) : undefined;
   return {
     name: nameNode?.text ?? '',
     kind,
     startLine: node.startPosition.row,
     endLine: node.endPosition.row,
     signature: nodeSignature(node),
+    ...(docComment ? { docComment } : {}),
+    ...(declarationMode && isNodeExported(node) ? { isExported: true } : {}),
     astNode: node,
   };
 }
 
 function maybeExtractArrowOrFunctionExpr(
   node: Parser.SyntaxNode,
+  source: string,
+  declarationMode: boolean,
 ): RawSymbol | null {
   // Look for: const/let/var <name> = <arrow_function | function_expression>
   for (const declarator of node.namedChildren) {
@@ -131,17 +143,41 @@ function maybeExtractArrowOrFunctionExpr(
       valueNode.type === 'function_expression' ||
       valueNode.type === 'generator_function'
     ) {
+      const docComment = declarationMode ? extractLeadingDocComment(node, source) : undefined;
       return {
         name: nameNode.text,
         kind: 'function',
         startLine: node.startPosition.row,
         endLine: node.endPosition.row,
         signature: nodeSignature(node),
+        ...(docComment ? { docComment } : {}),
+        ...(declarationMode && isNodeExported(node) ? { isExported: true } : {}),
         astNode: valueNode,
       };
     }
   }
   return null;
+}
+
+function isNodeExported(node: Parser.SyntaxNode): boolean {
+  let current: Parser.SyntaxNode | null = node;
+  while (current) {
+    if (current.type === 'export_statement') return true;
+    if (current.children.some((child) => child.type === 'export')) return true;
+    if (current.text.trimStart().startsWith('export ')) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function extractLeadingDocComment(node: Parser.SyntaxNode, source: string): string | undefined {
+  let anchor = node;
+  while (anchor.parent && (anchor.parent.type === 'ambient_declaration' || anchor.parent.type === 'export_statement')) {
+    anchor = anchor.parent;
+  }
+  const beforeNode = source.slice(0, anchor.startIndex);
+  const jsDoc = beforeNode.match(/\/\*\*[\s\S]*?\*\/\s*$/);
+  return jsDoc ? jsDoc[0].trim() : undefined;
 }
 
 function extractImport(node: Parser.SyntaxNode): RawImport {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -10,6 +10,7 @@
 
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import {
   openDb,
@@ -29,7 +30,13 @@ import { ingestGitHistory } from './git-history.js';
 import { ParserPool } from './parser.js';
 import { ImportResolver } from './resolver.js';
 import { buildCallGraph } from './call-graph.js';
-import type { ExtractionResult, RawCallRef, RawImport, RawSymbol } from './extractors/types.js';
+import {
+  type ExtractionResult,
+  type RawCallRef,
+  type RawImport,
+  type RawSymbol,
+  isPublicDeclarationSurfaceSymbol,
+} from './extractors/types.js';
 import { CExtractor } from './extractors/c.js';
 import { RustExtractor } from './extractors/rust.js';
 import { PythonExtractor } from './extractors/python.js';
@@ -107,6 +114,12 @@ interface BuildCheckpoint {
   updatedAt: number;
 }
 
+interface IndexBuilderOptions {
+  history?: boolean | { depth?: number; all?: boolean };
+  embeddingModel?: string;
+  indexDependencies?: boolean;
+}
+
 // ─── IndexBuilder ─────────────────────────────────────────────────────────────
 
 /**
@@ -125,13 +138,14 @@ export class IndexBuilder {
   private readonly resolver: ImportResolver;
   private readonly embedder: EmbeddingProvider | null;
   private readonly history: boolean | { depth?: number; all?: boolean };
+  private readonly indexDependencies: boolean;
   private readonly embeddingModel: string;
 
   constructor(
     dbPath: string,
     walkerConfig: WalkerConfig,
     embedder?: EmbeddingProvider,
-    embeddingModelOrOptions?: string | { history?: boolean | { depth?: number; all?: boolean }; embeddingModel?: string },
+    embeddingModelOrOptions?: string | IndexBuilderOptions,
   ) {
     this.dbPath = dbPath;
     this.walkerConfig = walkerConfig;
@@ -152,6 +166,7 @@ export class IndexBuilder {
     }
 
     this.history = opts.history ?? false;
+    this.indexDependencies = opts.indexDependencies ?? false;
   }
 
   // ─── Public API ──────────────────────────────────────────────────────────
@@ -177,6 +192,7 @@ export class IndexBuilder {
       })();
       this.saveBuildCheckpoint(db, branch, files.length, files.length);
       this.resolveImports(db, branch);
+      this.indexDependencyDeclarations(db);
       refreshTestMappings(db, branch);
       buildCallGraph(db);
       this.saveLastKnownHead(db);
@@ -240,6 +256,7 @@ export class IndexBuilder {
       })();
 
       this.resolveImports(db, branch);
+      this.indexDependencyDeclarations(db);
       refreshTestMappings(db, branch);
       if (this.history) {
         const historyOptions =
@@ -472,6 +489,49 @@ export class IndexBuilder {
     }
   }
 
+  private indexDependencyDeclarations(db: Database.Database): void {
+    db.prepare('DELETE FROM external_symbols').run();
+    if (!this.indexDependencies) return;
+
+    const directDependencies = this.loadDirectDependencies();
+    if (directDependencies.size === 0) return;
+    const extractor = EXTRACTORS.typescript;
+    if (!extractor) return;
+
+    const insertExternalSymbol = db.prepare(
+      `INSERT OR IGNORE INTO external_symbols
+         (package_name, package_version, symbol_name, symbol_kind, signature, doc_comment)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+
+    for (const [packageName, declaredVersion] of directDependencies) {
+      const packageDir = path.join(this.walkerConfig.rootDir, 'node_modules', packageName);
+      if (!fs.existsSync(packageDir) || !fs.statSync(packageDir).isDirectory()) continue;
+
+      const packageVersion = this.readInstalledPackageVersion(packageDir) ?? declaredVersion ?? null;
+      const declarationFiles = this.collectDeclarationFiles(packageDir);
+
+      for (const declarationFile of declarationFiles) {
+        const source = fs.readFileSync(declarationFile, 'utf8');
+        const tree = this.pool.parse('typescript', source);
+        if (!tree) continue;
+
+        const result: ExtractionResult = extractor.extract(tree, source, declarationFile);
+        for (const symbol of result.symbols) {
+          if (!this.shouldIndexDependencySymbol(symbol)) continue;
+          insertExternalSymbol.run(
+            packageName,
+            packageVersion,
+            symbol.name,
+            symbol.kind,
+            symbol.signature,
+            symbol.docComment ?? null,
+          );
+        }
+      }
+    }
+  }
+
   private resolveBranch(): string {
     if (this.walkerConfig.branch) return this.walkerConfig.branch;
     return this.readGitValue(['rev-parse', '--abbrev-ref', 'HEAD']) ?? 'HEAD';
@@ -495,6 +555,93 @@ export class IndexBuilder {
     } catch {
       return undefined;
     }
+  }
+
+  private loadDirectDependencies(): Map<string, string | undefined> {
+    const packageJsonPath = path.join(this.walkerConfig.rootDir, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) return new Map();
+
+    const raw = fs.readFileSync(packageJsonPath, 'utf8');
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const deps = new Map<string, string | undefined>();
+    for (const section of [pkg.dependencies, pkg.devDependencies, pkg.peerDependencies]) {
+      if (!section) continue;
+      for (const [name, version] of Object.entries(section)) {
+        if (!deps.has(name)) deps.set(name, version);
+      }
+    }
+    return deps;
+  }
+
+  private readInstalledPackageVersion(packageDir: string): string | undefined {
+    const packageJsonPath = path.join(packageDir, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) return undefined;
+
+    const raw = fs.readFileSync(packageJsonPath, 'utf8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version;
+  }
+
+  private collectDeclarationFiles(packageDir: string): string[] {
+    const declarations: string[] = [];
+    const stack: string[] = [packageDir];
+
+    while (stack.length > 0) {
+      const currentDir = stack.pop();
+      if (!currentDir) continue;
+
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name === 'node_modules') continue;
+
+        const fullPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(fullPath);
+          continue;
+        }
+
+        if (entry.isFile() && fullPath.endsWith('.d.ts')) {
+          declarations.push(fullPath);
+        }
+      }
+    }
+
+    return declarations;
+  }
+
+  private shouldIndexDependencySymbol(symbol: RawSymbol): boolean {
+    if (!isPublicDeclarationSurfaceSymbol(symbol)) return false;
+    if (symbol.declarationSurface) return true;
+    return !this.hasImplementationBody(symbol);
+  }
+
+  private hasImplementationBody(symbol: RawSymbol): boolean {
+    const node = symbol.astNode;
+    if (!node) return false;
+
+    if (
+      node.type === 'arrow_function' ||
+      node.type === 'function_expression' ||
+      node.type === 'generator_function'
+    ) {
+      return true;
+    }
+
+    if (
+      node.type === 'class_declaration' ||
+      node.type === 'interface_declaration' ||
+      node.type === 'type_alias_declaration'
+    ) {
+      return false;
+    }
+
+    const bodyNode = node.childForFieldName('body');
+    if (!bodyNode) return false;
+    return bodyNode.namedChildCount > 0 || bodyNode.text.trim() !== '';
   }
 
   private loadBuildCheckpoint(db: Database.Database, branch: string, totalFiles: number): number {

--- a/src/kb-server/db.ts
+++ b/src/kb-server/db.ts
@@ -113,6 +113,84 @@ export function listSymbols(db: Database.Database, limit = 100, branch?: string)
     .all(limit) as SymbolRow[];
 }
 
+export interface ExternalSymbolRow {
+  id: number;
+  dependency_ecosystem: string;
+  source_type: string;
+  source_ref: string;
+  package_name: string;
+  package_version: string | null;
+  symbol_name: string;
+  symbol_kind: string;
+  signature: string;
+  doc_comment: string | null;
+}
+
+function hasExternalSymbolsTable(db: Database.Database): boolean {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = 'external_symbols' LIMIT 1")
+    .get() as { ok: number } | undefined;
+  return row?.ok === 1;
+}
+
+/** Fetch external symbols whose exported name exactly matches (case-insensitive). */
+export function getExternalSymbolsByName(
+  db: Database.Database,
+  name: string,
+): ExternalSymbolRow[] {
+  if (!hasExternalSymbolsTable(db)) {
+    return [];
+  }
+
+  return db
+    .prepare(
+      `SELECT id,
+              dependency_ecosystem,
+              source_type,
+              source_ref,
+              package_name,
+              package_version,
+              symbol_name,
+              symbol_kind,
+              signature,
+              doc_comment
+         FROM external_symbols
+         WHERE symbol_name = ? COLLATE NOCASE
+         ORDER BY dependency_ecosystem ASC, package_name ASC, package_version ASC, symbol_kind ASC, signature ASC`,
+    )
+    .all(name) as ExternalSymbolRow[];
+}
+
+/** Fetch external symbols whose exported name contains the query fragment. */
+export function searchExternalSymbolsByName(
+  db: Database.Database,
+  nameQuery: string,
+  limit = 100,
+): ExternalSymbolRow[] {
+  if (!hasExternalSymbolsTable(db)) {
+    return [];
+  }
+
+  return db
+    .prepare(
+      `SELECT id,
+              dependency_ecosystem,
+              source_type,
+              source_ref,
+              package_name,
+              package_version,
+              symbol_name,
+              symbol_kind,
+              signature,
+              doc_comment
+         FROM external_symbols
+         WHERE symbol_name LIKE ? COLLATE NOCASE
+         ORDER BY dependency_ecosystem ASC, package_name ASC, package_version ASC, symbol_kind ASC, signature ASC
+         LIMIT ?`,
+    )
+    .all(`%${nameQuery}%`, limit) as ExternalSymbolRow[];
+}
+
 // ─── File helpers ─────────────────────────────────────────────────────────────
 
 export interface FileRow {

--- a/src/kb-server/server.ts
+++ b/src/kb-server/server.ts
@@ -7,15 +7,15 @@
  * and retains a standalone CLI entry point for development/debugging.
  *
  * MCP tools exposed:
- *   lore_lookup    — symbol / file lookup
- *   lore_graph     — call / import graph queries
- *   lore_search    — structural, semantic, and fused search
- *   lore_test_map  — source-file to mapped-test lookup
- *   lore_snippet   — source-code snippet extraction
- *   lore_blame     — git blame metadata for file lines
- *   lore_metrics   — aggregate code metrics
- *   lore_writeback — LLM summary write-back
- *   lore_history   — git commit history queries
+ *   kb_lookup    — symbol / file lookup
+ *   kb_graph     — call / import graph queries
+ *   kb_search    — structural, semantic, and fused search
+ *   kb_test_map  — source-file to mapped-test lookup
+ *   kb_snippet   — source-code snippet extraction
+ *   kb_blame     — git blame metadata for file lines
+ *   kb_metrics   — aggregate code metrics
+ *   kb_writeback — LLM summary write-back
+ *   kb_history   — git commit history queries
  *
  * Standalone usage:
  *   node dist/kb-server/server.js --db <path-to-kb.db>
@@ -102,7 +102,7 @@ function handleCommitStats(db: Database.Database, args: CommitStatsArgs): unknow
 
 /** Optional configuration for `createKbMcpServer`. */
 export interface KbServerOptions {
-  /** Callback invoked after every `lore_search` call with query/mode/latency/result metadata. */
+  /** Callback invoked after every `kb_search` call with query/mode/latency/result metadata. */
   searchObserver?: SearchObserver;
 }
 
@@ -112,7 +112,7 @@ export interface KbServerOptions {
  * Create and return a fully-configured `McpServer` with all KB tools registered.
  *
  * @param db       Read-only SQLite connection to the knowledge-base.
- * @param dbPath   Path to the DB file, needed by `lore_writeback` for write access.
+ * @param dbPath   Path to the DB file, needed by `kb_writeback` for write access.
  * @param embedder Optional live embedding provider for semantic/fused search.
  * @param options  Optional server configuration (e.g. search observer).
  */
@@ -127,7 +127,7 @@ export function createKbMcpServer(
     { capabilities: { tools: {} } },
   );
 
-  // ── lore_lookup ────────────────────────────────────────────────────────────
+  // ── kb_lookup ──────────────────────────────────────────────────────────────
   server.tool(
     lookup.toolDef.name,
     lookup.toolDef.description,
@@ -141,7 +141,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_graph ─────────────────────────────────────────────────────────────
+  // ── kb_graph ───────────────────────────────────────────────────────────────
   server.tool(
     graph.toolDef.name,
     graph.toolDef.description,
@@ -158,7 +158,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_search ────────────────────────────────────────────────────────────
+  // ── kb_search ──────────────────────────────────────────────────────────────
   server.tool(
     search.toolDef.name,
     search.toolDef.description,
@@ -176,7 +176,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_test_map ───────────────────────────────────────────────────────────
+  // ── kb_test_map ─────────────────────────────────────────────────────────────
   server.tool(
     testMap.toolDef.name,
     testMap.toolDef.description,
@@ -189,7 +189,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_snippet ───────────────────────────────────────────────────────────
+  // ── kb_snippet ─────────────────────────────────────────────────────────────
   server.tool(
     snippet.toolDef.name,
     snippet.toolDef.description,
@@ -204,7 +204,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_metrics ───────────────────────────────────────────────────────────
+  // ── kb_metrics ─────────────────────────────────────────────────────────────
   server.tool(
     metrics.toolDef.name,
     metrics.toolDef.description,
@@ -214,7 +214,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_coverage ──────────────────────────────────────────────────────────
+  // ── kb_coverage ────────────────────────────────────────────────────────────
   server.tool(
     coverage.toolDef.name,
     coverage.toolDef.description,
@@ -230,7 +230,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_blame ─────────────────────────────────────────────────────────────
+  // ── kb_blame ───────────────────────────────────────────────────────────────
   server.tool(
     blame.toolDef.name,
     blame.toolDef.description,
@@ -247,7 +247,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_writeback ─────────────────────────────────────────────────────────
+  // ── kb_writeback ───────────────────────────────────────────────────────────
   server.tool(
     writeback.toolDef.name,
     writeback.toolDef.description,
@@ -264,7 +264,7 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_history ───────────────────────────────────────────────────────────
+  // ── kb_history ─────────────────────────────────────────────────────────────
   server.tool(
     history.toolDef.name,
     history.toolDef.description,
@@ -280,9 +280,9 @@ export function createKbMcpServer(
     }),
   );
 
-  // ── lore_commit_stats ──────────────────────────────────────────────────────
+  // ── kb_commit_stats ────────────────────────────────────────────────────────
   server.tool(
-    'lore_commit_stats',
+    'kb_commit_stats',
     'Return git commit analytics for a selected metric.',
     {
       metric: z

--- a/src/kb-server/tools/annotations.ts
+++ b/src/kb-server/tools/annotations.ts
@@ -8,7 +8,7 @@ import type { Database } from '../db.js';
 import { listAnnotations } from '../db.js';
 
 export const toolDef = {
-  name: 'lore_annotations',
+  name: 'kb_annotations',
   description:
     'Return indexed annotations (TODO/FIXME/etc.) by kind, with optional file path filter and result limit.',
   inputSchema: {

--- a/src/kb-server/tools/architecture.ts
+++ b/src/kb-server/tools/architecture.ts
@@ -7,7 +7,7 @@
 import type { Database } from '../db.js';
 
 export const toolDef = {
-  name: 'lore_architecture',
+  name: 'kb_architecture',
   description:
     'Return an architecture overview grouped by path prefix, including component summaries, ' +
     'inter-component edges, entry points, leaf nodes, and external dependency usage.',

--- a/src/kb-server/tools/blame.ts
+++ b/src/kb-server/tools/blame.ts
@@ -12,7 +12,7 @@ import { getFileByPath } from '../db.js';
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_blame',
+  name: 'kb_blame',
   description:
     'Return git blame metadata for a file and line (or line range). ' +
     'The file path must exist in the indexed knowledge base.',

--- a/src/kb-server/tools/coverage.ts
+++ b/src/kb-server/tools/coverage.ts
@@ -14,7 +14,7 @@ import {
 } from '../db.js';
 
 export const toolDef = {
-  name: 'lore_coverage',
+  name: 'kb_coverage',
   description:
     'Return symbol-level coverage percentages, uncovered lines, and staleness metadata ' +
     'for the latest ingested coverage run.',

--- a/src/kb-server/tools/graph.ts
+++ b/src/kb-server/tools/graph.ts
@@ -13,7 +13,7 @@ import { getCoveragePercentBySymbolIds } from '../db.js';
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_graph',
+  name: 'kb_graph',
   description:
     'Query call, import, module, or inheritance graph edges stored in the knowledge-base index. ' +
     'Set `kind` to "call", "import", "module", or "inheritance". ' +

--- a/src/kb-server/tools/history.ts
+++ b/src/kb-server/tools/history.ts
@@ -21,7 +21,7 @@ import {
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_history',
+  name: 'kb_history',
   description:
     'Query git commit history indexed in the knowledge base. ' +
     'Supports four modes: "file" (commits that touched a file path), ' +
@@ -83,7 +83,7 @@ function clampLimit(limit?: number): number {
   return Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
 }
 
-/** Handle a lore_history tool invocation against the open read-only database. */
+/** Handle a kb_history tool invocation against the open read-only database. */
 export function handler(db: Database.Database, args: HistoryArgs): HistoryResult {
   const limit = clampLimit(args.limit);
 

--- a/src/kb-server/tools/lookup.ts
+++ b/src/kb-server/tools/lookup.ts
@@ -5,12 +5,18 @@
  */
 
 import type { Database } from '../db.js';
-import { getSymbolsByName, getFileByPath, listSymbols, listFiles } from '../db.js';
+import {
+  getSymbolsByName,
+  getExternalSymbolsByName,
+  getFileByPath,
+  listSymbols,
+  listFiles,
+} from '../db.js';
 
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_lookup',
+  name: 'kb_lookup',
   description:
     'Look up symbols by name or source files by path in the knowledge-base index. ' +
     'Set `kind` to "symbol" or "file". Returns an array of matching rows.',
@@ -48,8 +54,9 @@ export interface LookupResult {
 /** Resolve a lookup request against the open read-only database. */
 export function handler(db: Database.Database, args: LookupArgs): LookupResult {
   if (args.kind === 'symbol') {
-    const rows = args.query.trim()
-      ? getSymbolsByName(db, args.query, args.branch)
+    const query = args.query.trim();
+    const rows = query
+      ? [...getSymbolsByName(db, query, args.branch), ...getExternalSymbolsByName(db, query)]
       : listSymbols(db, 20, args.branch);
     return { results: rows };
   } else {

--- a/src/kb-server/tools/metrics.ts
+++ b/src/kb-server/tools/metrics.ts
@@ -10,7 +10,7 @@ import { getCoverageStaleness, getLatestCoverageTotals } from '../db.js';
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_metrics',
+  name: 'kb_metrics',
   description:
     'Return aggregate KB metrics or top symbols by stored complexity.',
   inputSchema: {

--- a/src/kb-server/tools/notes.ts
+++ b/src/kb-server/tools/notes.ts
@@ -2,8 +2,8 @@
  * @module kb-server/tools/notes
  *
  * MCP tools:
- * - lore_notes_write: upsert notes by (key, scope)
- * - lore_notes_read: retrieve notes with staleness/recency metadata
+ * - kb_notes_write: upsert notes by (key, scope)
+ * - kb_notes_read: retrieve notes with staleness/recency metadata
  */
 
 import Database from 'better-sqlite3';
@@ -14,7 +14,7 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 200;
 
 export const kbNotesWriteToolDef = {
-  name: 'lore_notes_write',
+  name: 'kb_notes_write',
   description:
     'Upsert an LLM-authored note in the knowledge base by key and scope. ' +
     'Defaults scope to "global" and updates updated_at on existing notes.',
@@ -38,7 +38,7 @@ export const kbNotesWriteToolDef = {
 } as const;
 
 export const kbNotesReadToolDef = {
-  name: 'lore_notes_read',
+  name: 'kb_notes_read',
   description:
     'Read notes by exact key and/or key prefix, optionally filtered by scope. ' +
     'Returns staleness metadata for file-scoped notes and recency metadata for global notes.',

--- a/src/kb-server/tools/routes.ts
+++ b/src/kb-server/tools/routes.ts
@@ -8,7 +8,7 @@ import type { Database } from '../db.js';
 import { listApiRoutes, type ApiRouteRow } from '../db.js';
 
 export const toolDef = {
-  name: 'lore_routes',
+  name: 'kb_routes',
   description:
     'Query extracted API routes/endpoints from the knowledge-base index. ' +
     'Optional filters: `method`, `path_prefix`, and `framework`.',

--- a/src/kb-server/tools/search.ts
+++ b/src/kb-server/tools/search.ts
@@ -18,7 +18,7 @@ import type { EmbeddingProvider } from '../../indexer/embedder.js';
 // ─── Observability ────────────────────────────────────────────────────────────
 
 /**
- * Observation emitted after every `lore_search` invocation.
+ * Observation emitted after every `kb_search` invocation.
  * Consumers can use this to log, collect metrics, or detect search-quality issues.
  */
 export interface SearchObservation {
@@ -46,7 +46,7 @@ export type SearchObserver = (observation: SearchObservation) => void;
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_search',
+  name: 'kb_search',
   description:
     'Search the knowledge-base index for symbols matching a natural-language or code query. ' +
     'mode="structural" uses BM25 FTS5 (fast, exact-ish). ' +

--- a/src/kb-server/tools/snippet.ts
+++ b/src/kb-server/tools/snippet.ts
@@ -12,7 +12,7 @@ import { getFileByPath } from '../db.js';
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_snippet',
+  name: 'kb_snippet',
   description:
     'Return the source lines for a given file path (as recorded in the index). ' +
     'Optionally restrict the output to a line range using `start_line` and `end_line` ' +

--- a/src/kb-server/tools/test-map.ts
+++ b/src/kb-server/tools/test-map.ts
@@ -8,7 +8,7 @@ import type { Database } from '../db.js';
 import { listTestMappingsBySourcePath } from '../db.js';
 
 export const toolDef = {
-  name: 'lore_test_map',
+  name: 'kb_test_map',
   description:
     'Return mapped test files (with confidence values) for a given source file path.',
   inputSchema: {

--- a/src/kb-server/tools/writeback.ts
+++ b/src/kb-server/tools/writeback.ts
@@ -11,11 +11,11 @@ import Database from 'better-sqlite3';
 // ─── Tool definition ──────────────────────────────────────────────────────────
 
 export const toolDef = {
-  name: 'lore_writeback',
+  name: 'kb_writeback',
   description:
     'Persist an LLM-generated natural-language summary for a symbol back into ' +
     'the knowledge-base `symbol_summaries` table.  The summary can be retrieved ' +
-    'later via lore_lookup.',
+    'later via kb_lookup.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,9 +19,10 @@ function freshDb(): string {
  * main() re-executes. Returns once the module is evaluated (main() may still
  * be running asynchronously at that point).
  */
-async function loadCli(args: string[]): Promise<void> {
+async function loadCli(args: string[], applyMocks?: () => void): Promise<void> {
   process.argv = ['node', 'lore', ...args];
   vi.resetModules();
+  applyMocks?.();
   await import('../../src/cli.js');
 }
 
@@ -121,6 +122,22 @@ describe('cli', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('--db'),
       );
+    });
+  });
+
+  describe('index subcommand — dependency indexing option', () => {
+    it('should complete indexing when --index-deps is omitted', async () => {
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+      await waitForFile(dbPath);
+      expect(nodeFs.existsSync(dbPath)).toBe(true);
+    });
+
+    it('should complete indexing when --index-deps is provided', async () => {
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir, '--index-deps']);
+      await waitForFile(dbPath);
+      expect(nodeFs.existsSync(dbPath)).toBe(true);
     });
   });
 
@@ -293,6 +310,13 @@ describe('cli', () => {
   // ── refresh subcommand — manual mode ──────────────────────────────────────
 
   describe('refresh subcommand — manual mode', () => {
+    it('should complete refresh when --index-deps is provided', async () => {
+      const dbPath = freshDb();
+      await loadCli(['refresh', '--db', dbPath, '--root', tmpDir, '--index-deps']);
+      await waitForStderr(stderrSpy, 'refresh complete');
+      expect(nodeFs.existsSync(dbPath)).toBe(true);
+    });
+
     it('should write a structured info log to stderr and exit cleanly when the DB does not yet exist', async () => {
       const dbPath = freshDb();
       await loadCli(['refresh', '--db', dbPath, '--root', tmpDir]);

--- a/tests/indexer/db.test.ts
+++ b/tests/indexer/db.test.ts
@@ -74,6 +74,7 @@ describe('openDb', () => {
     ).map((r) => r.name);
     expect(tables).toContain('files');
     expect(tables).toContain('symbols');
+    expect(tables).toContain('external_symbols');
     expect(tables).toContain('kb_meta');
     expect(tables).toContain('test_mappings');
     expect(tables).toContain('commit_refs');
@@ -129,6 +130,90 @@ describe('openDb', () => {
     expect(
       (db.prepare('SELECT COUNT(*) AS count FROM test_mappings').get() as { count: number }).count,
     ).toBe(0);
+  });
+
+  it('should create external_symbols with expected columns and indexes', () => {
+    db = openDb(dbPath);
+    const columns = db.pragma('table_info(external_symbols)') as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        'dependency_ecosystem',
+        'source_type',
+        'source_ref',
+        'package_name',
+        'package_version',
+        'symbol_name',
+        'symbol_kind',
+        'signature',
+        'doc_comment',
+      ]),
+    );
+
+    const indexes = (
+      db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='external_symbols'").all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        'idx_external_symbols_dependency_ecosystem',
+        'idx_external_symbols_package_name',
+        'idx_external_symbols_symbol_name',
+      ]),
+    );
+  });
+
+  it('should apply default metadata values for external_symbols when omitted', () => {
+    db = openDb(dbPath);
+    db.prepare(
+      `INSERT INTO external_symbols (package_name, package_version, symbol_name, symbol_kind)
+       VALUES ('left-pad', '1.3.0', 'leftPad', 'function')`,
+    ).run();
+
+    const row = db
+      .prepare(
+        `SELECT dependency_ecosystem, source_type, source_ref, signature
+         FROM external_symbols
+         WHERE package_name = 'left-pad'`,
+      )
+      .get() as
+      | {
+          dependency_ecosystem: string;
+          source_type: string;
+          source_ref: string;
+          signature: string;
+        }
+      | undefined;
+
+    expect(row).toEqual({
+      dependency_ecosystem: 'npm',
+      source_type: 'declaration',
+      source_ref: '',
+      signature: '',
+    });
+  });
+
+  it('should enforce unique external_symbols rows for an ecosystem/package/version/symbol signature', () => {
+    db = openDb(dbPath);
+    db.prepare(
+      `INSERT INTO external_symbols
+        (dependency_ecosystem, package_name, package_version, symbol_name, symbol_kind, signature, doc_comment)
+       VALUES ('npm', 'left-pad', '1.3.0', 'leftPad', 'function', 'leftPad(input: string): string', '/** docs */')`,
+    ).run();
+
+    expect(() =>
+      db.prepare(
+        `INSERT INTO external_symbols
+          (dependency_ecosystem, package_name, package_version, symbol_name, symbol_kind, signature)
+         VALUES ('npm', 'left-pad', '1.3.0', 'leftPad', 'function', 'leftPad(input: string): string')`,
+      ).run(),
+    ).toThrow();
+
+    expect(() =>
+      db.prepare(
+        `INSERT INTO external_symbols
+          (dependency_ecosystem, package_name, package_version, symbol_name, symbol_kind, signature)
+         VALUES ('pypi', 'left-pad', '1.3.0', 'leftPad', 'function', 'leftPad(input: string): string')`,
+      ).run(),
+    ).not.toThrow();
   });
 
   it('should enforce foreign keys from coverage tables to coverage runs', () => {

--- a/tests/indexer/extractors/types.test.ts
+++ b/tests/indexer/extractors/types.test.ts
@@ -4,6 +4,7 @@ import {
   walk,
   findFirst,
   nodeSignature,
+  isPublicDeclarationSurfaceSymbol,
 } from '../../../src/indexer/extractors/types.js';
 import { ParserPool } from '../../../src/indexer/parser.js';
 
@@ -106,4 +107,70 @@ describe('nodeSignature', () => {
       expect(sig).not.toContain('{');
     },
   );
+});
+
+describe('isPublicDeclarationSurfaceSymbol', () => {
+  it('should return true when declaration surface is public and declaration-only', () => {
+    expect(
+      isPublicDeclarationSurfaceSymbol({
+        name: 'publicApi',
+        kind: 'function',
+        startLine: 0,
+        endLine: 0,
+        signature: 'function publicApi(): void;',
+        declarationSurface: { isPublic: true, isDeclaration: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when declaration surface is not publicly visible', () => {
+    expect(
+      isPublicDeclarationSurfaceSymbol({
+        name: 'internalApi',
+        kind: 'function',
+        startLine: 0,
+        endLine: 0,
+        signature: 'function internalApi(): void;',
+        declarationSurface: { isPublic: false, isDeclaration: true },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when declaration surface contains implementation details', () => {
+    expect(
+      isPublicDeclarationSurfaceSymbol({
+        name: 'runtimeApi',
+        kind: 'function',
+        startLine: 0,
+        endLine: 0,
+        signature: 'function runtimeApi(): void;',
+        declarationSurface: { isPublic: true, isDeclaration: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('should fall back to isExported when declaration surface metadata is missing', () => {
+    expect(
+      isPublicDeclarationSurfaceSymbol({
+        name: 'legacyExport',
+        kind: 'function',
+        startLine: 0,
+        endLine: 0,
+        signature: 'function legacyExport(): void;',
+        isExported: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when neither declaration metadata nor export flag marks symbol as public', () => {
+    expect(
+      isPublicDeclarationSurfaceSymbol({
+        name: 'legacyPrivate',
+        kind: 'function',
+        startLine: 0,
+        endLine: 0,
+        signature: 'function legacyPrivate(): void;',
+      }),
+    ).toBe(false);
+  });
 });

--- a/tests/indexer/extractors/typescript.test.ts
+++ b/tests/indexer/extractors/typescript.test.ts
@@ -8,12 +8,12 @@ import {
 const pool = new ParserPool();
 const extractor = new TypeScriptExtractor();
 
-function extractFromSource(source: string) {
+function extractFromSource(source: string, filePath = 'inline.ts') {
   const tree = pool.parse('typescript', source);
   if (!tree) {
     throw new Error('TypeScript grammar is unavailable');
   }
-  return extractor.extract(tree, source, 'inline.ts');
+  return extractor.extract(tree, source, filePath);
 }
 
 describe('TypeScriptExtractor', () => {
@@ -39,6 +39,33 @@ describe('TypeScriptExtractor', () => {
   it('should include the original AST node on extracted symbols', () => {
     const result = extractFromSource('export function hello(name: string) { return name; }');
     expect(result.symbols[0]?.astNode?.type).toBe('function_declaration');
+  });
+
+  it('should mark exported declarations and capture leading JSDoc comments', () => {
+    const result = extractFromSource(`
+      /** Public API docs */
+      export declare function depPublic(input: string): string;
+      declare function depPrivate(): void;
+    `, 'inline.d.ts');
+
+    const publicSymbol = result.symbols.find((symbol) => symbol.name === 'depPublic');
+    const privateSymbol = result.symbols.find((symbol) => symbol.name === 'depPrivate');
+    expect(publicSymbol?.isExported).toBe(true);
+    expect(publicSymbol?.docComment).toContain('Public API docs');
+    expect(privateSymbol?.isExported).toBeUndefined();
+  });
+
+  it('should not mark declarations as exported or attach doc comments for non-declaration files', () => {
+    const result = extractFromSource(`
+      /** Runtime docs should not be captured in non-declaration mode */
+      export function runtimePublic(input: string): string {
+        return input;
+      }
+    `, 'inline.ts');
+
+    const runtimeSymbol = result.symbols.find((symbol) => symbol.name === 'runtimePublic');
+    expect(runtimeSymbol?.isExported).toBeUndefined();
+    expect(runtimeSymbol?.docComment).toBeUndefined();
   });
 });
 

--- a/tests/indexer/index.test.ts
+++ b/tests/indexer/index.test.ts
@@ -87,6 +87,41 @@ function querySymbolNamesForFile(dbPath: string, filePath: string, branch: strin
   return rows.map((r) => r.name);
 }
 
+function queryExternalSymbolsForPackage(
+  dbPath: string,
+  packageName: string,
+): Array<{ symbol_name: string; symbol_kind: string; signature: string; doc_comment: string | null; package_version: string | null }> {
+  const db = new Database(dbPath, { readonly: true });
+  const rows = db.prepare(
+    `SELECT symbol_name, symbol_kind, signature, doc_comment, package_version
+     FROM external_symbols
+     WHERE package_name = ?
+     ORDER BY symbol_name`,
+  ).all(packageName) as Array<{
+    symbol_name: string;
+    symbol_kind: string;
+    signature: string;
+    doc_comment: string | null;
+    package_version: string | null;
+  }>;
+  db.close();
+  return rows;
+}
+
+function querySymbolCountByName(dbPath: string, symbolName: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db.prepare('SELECT COUNT(*) AS count FROM symbols WHERE name = ?').get(symbolName) as { count: number };
+  db.close();
+  return row.count;
+}
+
+function queryExternalSymbolCount(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db.prepare('SELECT COUNT(*) AS count FROM external_symbols').get() as { count: number };
+  db.close();
+  return row.count;
+}
+
 function queryRoutesForFile(
   dbPath: string,
   filePath: string,
@@ -121,6 +156,223 @@ function queryTestsForSourceFile(
   db.close();
   return rows;
 }
+
+describe('IndexBuilder — dependency indexing options', () => {
+  let srcDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    srcDir = createTmpSrcDir();
+    dbPath = tmpDbPath();
+  });
+
+  afterEach(() => {
+    try { rmSync(srcDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    const dbDir = join(dbPath, '..');
+    try { rmSync(dbDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('should index project symbols when indexDependencies is omitted', async () => {
+    const builder = new IndexBuilder(dbPath, { rootDir: srcDir, branch: 'main' });
+    await builder.build();
+
+    expect(querySymbolNamesForFile(dbPath, join(srcDir, 'hello.ts'), 'main')).toContain('hello');
+    expect(queryExternalSymbolCount(dbPath)).toBe(0);
+  });
+
+  it('should still build and ingest history when indexDependencies is enabled', async () => {
+    const branch = createGitRepoWithCommit(srcDir);
+    const builder = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir },
+      undefined,
+      { history: true, indexDependencies: true },
+    );
+    await builder.build();
+
+    expect(querySymbolNamesForFile(dbPath, join(srcDir, 'hello.ts'), branch)).toContain('hello');
+    expect(queryCommitCount(dbPath)).toBeGreaterThan(0);
+  });
+
+  it('should index only direct dependency declaration exports into external_symbols', async () => {
+    writeFileSync(
+      join(srcDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        version: '1.0.0',
+        dependencies: {
+          'dep-one': '^1.0.0',
+        },
+      }),
+    );
+
+    const depOneDir = join(srcDir, 'node_modules', 'dep-one');
+    const transitiveDir = join(depOneDir, 'node_modules', 'dep-transitive');
+    mkdirSync(depOneDir, { recursive: true });
+    mkdirSync(transitiveDir, { recursive: true });
+
+    writeFileSync(
+      join(depOneDir, 'package.json'),
+      JSON.stringify({ name: 'dep-one', version: '1.2.3' }),
+    );
+    writeFileSync(
+      join(depOneDir, 'index.d.ts'),
+      `
+      /** Direct dependency public API */
+      export declare function depPublic(input: string): string;
+      export function depImplementation(input: string): string { return input; }
+      declare function depPrivate(): void;
+      `,
+    );
+
+    writeFileSync(
+      join(transitiveDir, 'package.json'),
+      JSON.stringify({ name: 'dep-transitive', version: '9.9.9' }),
+    );
+    writeFileSync(
+      join(transitiveDir, 'index.d.ts'),
+      'export declare function transitiveFn(): void;',
+    );
+
+    const builder = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir, branch: 'main' },
+      undefined,
+      { indexDependencies: true },
+    );
+    await builder.build();
+
+    expect(querySymbolNamesForFile(dbPath, join(srcDir, 'hello.ts'), 'main')).toContain('hello');
+    expect(queryExternalSymbolsForPackage(dbPath, 'dep-one')).toEqual([
+      {
+        symbol_name: 'depPublic',
+        symbol_kind: 'function',
+        signature: 'function depPublic(input: string): string;',
+        doc_comment: '/** Direct dependency public API */',
+        package_version: '1.2.3',
+      },
+    ]);
+    expect(queryExternalSymbolsForPackage(dbPath, 'dep-transitive')).toEqual([]);
+    expect(querySymbolCountByName(dbPath, 'depPublic')).toBe(0);
+  });
+
+  it('should keep declaration-only class, interface, and type exports while excluding implementation bodies', async () => {
+    writeFileSync(
+      join(srcDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        version: '1.0.0',
+        dependencies: {
+          'dep-shapes': '^3.0.0',
+        },
+      }),
+    );
+
+    const depDir = join(srcDir, 'node_modules', 'dep-shapes');
+    mkdirSync(depDir, { recursive: true });
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({ name: 'dep-shapes', version: '3.1.4' }),
+    );
+    writeFileSync(
+      join(depDir, 'index.d.ts'),
+      `
+      export declare class DepClass {
+        run(): void;
+      }
+      export interface DepContract {
+        value: string;
+      }
+      export type DepAlias = string | number;
+      export function depRuntimeImplementation(): string { return "runtime"; }
+      `,
+    );
+
+    const builder = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir, branch: 'main' },
+      undefined,
+      { indexDependencies: true },
+    );
+    await builder.build();
+
+    const symbols = queryExternalSymbolsForPackage(dbPath, 'dep-shapes');
+    expect(symbols.map((symbol) => symbol.symbol_name)).toEqual(['DepAlias', 'DepClass', 'DepContract']);
+    expect(symbols.map((symbol) => symbol.symbol_kind)).toEqual(['type', 'class', 'interface']);
+    expect(symbols.find((symbol) => symbol.symbol_name === 'depRuntimeImplementation')).toBeUndefined();
+  });
+
+  it('should fall back to declared dependency version when installed package metadata is missing', async () => {
+    writeFileSync(
+      join(srcDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        version: '1.0.0',
+        dependencies: {
+          'dep-without-package-json': '^2.5.0',
+        },
+      }),
+    );
+
+    const depDir = join(srcDir, 'node_modules', 'dep-without-package-json');
+    mkdirSync(depDir, { recursive: true });
+    writeFileSync(depDir + '/index.d.ts', 'export declare function depFn(): string;');
+
+    const builder = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir, branch: 'main' },
+      undefined,
+      { indexDependencies: true },
+    );
+    await builder.build();
+
+    expect(queryExternalSymbolsForPackage(dbPath, 'dep-without-package-json')).toEqual([
+      {
+        symbol_name: 'depFn',
+        symbol_kind: 'function',
+        signature: 'function depFn(): string;',
+        doc_comment: null,
+        package_version: '^2.5.0',
+      },
+    ]);
+  });
+
+  it('should clear external symbols when dependency indexing is turned off for a subsequent build', async () => {
+    writeFileSync(
+      join(srcDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        version: '1.0.0',
+        dependencies: {
+          'dep-one': '^1.0.0',
+        },
+      }),
+    );
+    const depDir = join(srcDir, 'node_modules', 'dep-one');
+    mkdirSync(depDir, { recursive: true });
+    writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'dep-one', version: '1.2.3' }));
+    writeFileSync(join(depDir, 'index.d.ts'), 'export declare function depPublic(): void;');
+
+    const builderWithDeps = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir, branch: 'main' },
+      undefined,
+      { indexDependencies: true },
+    );
+    await builderWithDeps.build();
+    expect(queryExternalSymbolCount(dbPath)).toBe(1);
+
+    const builderWithoutDeps = new IndexBuilder(
+      dbPath,
+      { rootDir: srcDir, branch: 'main' },
+      undefined,
+      { indexDependencies: false },
+    );
+    await builderWithoutDeps.build();
+
+    expect(queryExternalSymbolCount(dbPath)).toBe(0);
+  });
+});
 
 describe('IndexBuilder — branch support in build()', () => {
   let srcDir: string;

--- a/tests/kb-server/db.test.ts
+++ b/tests/kb-server/db.test.ts
@@ -11,6 +11,8 @@ import {
   listConfigEntries,
   listTestMappingsBySourcePath,
   getSymbolsByName,
+  getExternalSymbolsByName,
+  searchExternalSymbolsByName,
   listSymbols,
   getSymbolById,
   getCommitBySha,
@@ -53,6 +55,18 @@ function createTestDb(): Database.Database {
       end_line    INTEGER NOT NULL,
       signature   TEXT,
       doc_comment TEXT
+    );
+    CREATE TABLE external_symbols (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      dependency_ecosystem TEXT    NOT NULL DEFAULT 'npm',
+      source_type          TEXT    NOT NULL DEFAULT 'declaration',
+      source_ref           TEXT    NOT NULL DEFAULT '',
+      package_name         TEXT    NOT NULL,
+      package_version      TEXT,
+      symbol_name          TEXT    NOT NULL,
+      symbol_kind          TEXT    NOT NULL,
+      signature            TEXT    NOT NULL DEFAULT '',
+      doc_comment          TEXT
     );
     CREATE TABLE config_entries (
       id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -191,6 +205,38 @@ function insertSymbol(
       'INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, ?, ?, 1, 10)'
     )
     .run(fileId, name, kind);
+  return result.lastInsertRowid as number;
+}
+
+function insertExternalSymbol(
+  db: Database.Database,
+  packageName: string,
+  packageVersion: string | null,
+  symbolName: string,
+  symbolKind: string,
+  signature: string,
+  docComment: string | null,
+  dependencyEcosystem = 'npm',
+  sourceType = 'declaration',
+  sourceRef = '',
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO external_symbols
+        (dependency_ecosystem, source_type, source_ref, package_name, package_version, symbol_name, symbol_kind, signature, doc_comment)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      dependencyEcosystem,
+      sourceType,
+      sourceRef,
+      packageName,
+      packageVersion,
+      symbolName,
+      symbolKind,
+      signature,
+      docComment,
+    );
   return result.lastInsertRowid as number;
 }
 
@@ -574,6 +620,144 @@ describe('getSymbolsByName', () => {
 
   it('should return empty array when branch has no matching symbol', () => {
     expect(getSymbolsByName(db, 'parseConfig', 'nonexistent-branch')).toEqual([]);
+  });
+});
+
+// ─── external symbol helpers ───────────────────────────────────────────────────
+
+describe('external symbol helpers', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    insertExternalSymbol(
+      db,
+      'left-pad',
+      '1.3.0',
+      'leftPad',
+      'function',
+      'function leftPad(input: string): string;',
+      '/** Left-pad a string */',
+    );
+    insertExternalSymbol(
+      db,
+      'dep-utils',
+      '2.0.0',
+      'leftPad',
+      'function',
+      'function leftPad(value: string, size: number): string;',
+      null,
+    );
+    insertExternalSymbol(
+      db,
+      'dep-utils',
+      '2.0.0',
+      'mapValues',
+      'function',
+      'function mapValues<T, U>(values: T[]): U[];',
+      '/** Map values */',
+    );
+  });
+
+  it('should return exact external symbol name matches with metadata', () => {
+    const rows = getExternalSymbolsByName(db, 'leftpad');
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toMatchObject({
+      package_name: 'dep-utils',
+      package_version: '2.0.0',
+      symbol_name: 'leftPad',
+      symbol_kind: 'function',
+      dependency_ecosystem: 'npm',
+      source_type: 'declaration',
+      source_ref: '',
+    });
+    expect(rows[0]).toHaveProperty('signature');
+    expect(rows[0]).toHaveProperty('doc_comment');
+  });
+
+  it('should return filtered external symbol name matches and respect limit', () => {
+    const rows = searchExternalSymbolsByName(db, 'pad', 1);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.symbol_name).toBe('leftPad');
+    expect(rows[0]).toHaveProperty('package_name');
+    expect(rows[0]).toHaveProperty('package_version');
+    expect(rows[0]).toHaveProperty('dependency_ecosystem');
+    expect(rows[0]).toHaveProperty('source_type');
+    expect(rows[0]).toHaveProperty('source_ref');
+  });
+
+  it('should order exact external symbol matches by ecosystem and package and preserve source metadata', () => {
+    insertExternalSymbol(
+      db,
+      'zeta-tools',
+      '0.9.0',
+      'leftPad',
+      'function',
+      'def leftPad(value: str) -> str;',
+      null,
+      'pypi',
+      'manifest',
+      'requirements.txt',
+    );
+
+    const rows = getExternalSymbolsByName(db, 'leftPad');
+    expect(rows.map((row) => `${row.dependency_ecosystem}:${row.package_name}`)).toEqual([
+      'npm:dep-utils',
+      'npm:left-pad',
+      'pypi:zeta-tools',
+    ]);
+    expect(rows[2]).toMatchObject({
+      dependency_ecosystem: 'pypi',
+      source_type: 'manifest',
+      source_ref: 'requirements.txt',
+    });
+  });
+
+  it('should return an empty array when an exact external symbol name is not found', () => {
+    expect(getExternalSymbolsByName(db, 'doesNotExist')).toEqual([]);
+  });
+
+  it('should perform case-insensitive filtered external symbol search', () => {
+    const rows = searchExternalSymbolsByName(db, 'PAD');
+    expect(rows.length).toBe(2);
+    expect(rows.map((row) => row.symbol_name)).toEqual(['leftPad', 'leftPad']);
+  });
+
+  it('should apply the default limit of 100 for filtered external symbol searches', () => {
+    for (let index = 0; index < 120; index += 1) {
+      insertExternalSymbol(
+        db,
+        `pkg-${index}`,
+        '1.0.0',
+        `padSymbol${index}`,
+        'function',
+        `function padSymbol${index}(): void;`,
+        null,
+      );
+    }
+
+    const rows = searchExternalSymbolsByName(db, 'pad');
+    expect(rows.length).toBe(100);
+    expect(rows.every((row) => row.symbol_name.toLowerCase().includes('pad'))).toBe(true);
+  });
+
+  it('should return empty arrays when external_symbols table is unavailable', () => {
+    const noExternalDb = new Database(':memory:');
+    noExternalDb.exec(`
+      CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT NOT NULL, branch TEXT NOT NULL, language TEXT NOT NULL);
+      CREATE TABLE symbols (
+        id INTEGER PRIMARY KEY,
+        file_id INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        start_line INTEGER NOT NULL,
+        end_line INTEGER NOT NULL
+      );
+    `);
+
+    expect(getExternalSymbolsByName(noExternalDb, 'leftPad')).toEqual([]);
+    expect(searchExternalSymbolsByName(noExternalDb, 'left')).toEqual([]);
+    noExternalDb.close();
   });
 });
 

--- a/tests/kb-server/server.test.ts
+++ b/tests/kb-server/server.test.ts
@@ -28,16 +28,16 @@ describe('createKbMcpServer', () => {
 
     // All standard tools should still be registered.
     const toolNames = mockTool.mock.calls.map((call) => call[0]);
-    expect(toolNames).toContain('lore_search');
-    expect(toolNames).toContain('lore_lookup');
+    expect(toolNames).toContain('kb_search');
+    expect(toolNames).toContain('kb_lookup');
   });
 
-  it('should register lore_graph kind schema with module and inheritance values', () => {
+  it('should register kb_graph kind schema with module and inheritance values', () => {
     const db = new Database(':memory:');
 
     createKbMcpServer(db, '/tmp/test.db');
 
-    const graphToolCall = mockTool.mock.calls.find((call) => call[0] === 'lore_graph');
+    const graphToolCall = mockTool.mock.calls.find((call) => call[0] === 'kb_graph');
     expect(graphToolCall).toBeDefined();
 
     const graphSchema = graphToolCall?.[2] as { kind: { safeParse: (v: unknown) => { success: boolean } } };
@@ -48,12 +48,12 @@ describe('createKbMcpServer', () => {
     expect(graphSchema.kind.safeParse('invalid-kind').success).toBe(false);
   });
 
-  it('should register lore_coverage with expected schema fields', () => {
+  it('should register kb_coverage with expected schema fields', () => {
     const db = new Database(':memory:');
 
     createKbMcpServer(db, '/tmp/test.db');
 
-    const coverageToolCall = mockTool.mock.calls.find((call) => call[0] === 'lore_coverage');
+    const coverageToolCall = mockTool.mock.calls.find((call) => call[0] === 'kb_coverage');
     expect(coverageToolCall).toBeDefined();
 
     const coverageSchema = coverageToolCall?.[2] as {
@@ -65,12 +65,12 @@ describe('createKbMcpServer', () => {
     expect(coverageSchema.symbol_id.safeParse('1').success).toBe(false);
   });
 
-  it('should register lore_test_map with expected schema fields', () => {
+  it('should register kb_test_map with expected schema fields', () => {
     const db = new Database(':memory:');
 
     createKbMcpServer(db, '/tmp/test.db');
 
-    const testMapToolCall = mockTool.mock.calls.find((call) => call[0] === 'lore_test_map');
+    const testMapToolCall = mockTool.mock.calls.find((call) => call[0] === 'kb_test_map');
     expect(testMapToolCall).toBeDefined();
 
     const testMapSchema = testMapToolCall?.[2] as {

--- a/tests/kb-server/tools/architecture.test.ts
+++ b/tests/kb-server/tools/architecture.test.ts
@@ -91,9 +91,9 @@ function insertExternalDep(db: Database.Database, fileId: number, pkg: string): 
   db.prepare('INSERT INTO external_deps (file_id, package) VALUES (?, ?)').run(fileId, pkg);
 }
 
-describe('lore_architecture toolDef', () => {
+describe('kb_architecture toolDef', () => {
   it('should expose optional depth and branch properties', () => {
-    expect(toolDef.name).toBe('lore_architecture');
+    expect(toolDef.name).toBe('kb_architecture');
     expect(toolDef.inputSchema.required).toEqual([]);
     expect(toolDef.inputSchema.properties.depth.type).toBe('number');
     expect(toolDef.inputSchema.properties.branch.type).toBe('string');

--- a/tests/kb-server/tools/blame.test.ts
+++ b/tests/kb-server/tools/blame.test.ts
@@ -36,13 +36,13 @@ function insertFile(db: Database.Database, filePath: string, branch: string): vo
   );
 }
 
-describe('lore_blame toolDef', () => {
+describe('kb_blame toolDef', () => {
   it('should expose the expected MCP tool name', () => {
-    expect(toolDef.name).toBe('lore_blame');
+    expect(toolDef.name).toBe('kb_blame');
   });
 });
 
-describe('lore_blame handler', () => {
+describe('kb_blame handler', () => {
   let db: Database.Database;
   const filePath = '/repo/src/main.ts';
 

--- a/tests/kb-server/tools/graph.test.ts
+++ b/tests/kb-server/tools/graph.test.ts
@@ -142,7 +142,7 @@ function insertInheritanceEdge(
 
 // ─── handler (kind=call) ──────────────────────────────────────────────────────
 
-describe('lore_graph toolDef', () => {
+describe('kb_graph toolDef', () => {
   it('should expose kind enum values for call, import, module, and inheritance', () => {
     expect(toolDef.inputSchema.properties.kind.enum).toEqual([
       'call',

--- a/tests/kb-server/tools/history.test.ts
+++ b/tests/kb-server/tools/history.test.ts
@@ -76,7 +76,7 @@ function insertCommitRef(
 
 describe('toolDef', () => {
   it('should have the correct name', () => {
-    expect(toolDef.name).toBe('lore_history');
+    expect(toolDef.name).toBe('kb_history');
   });
 
   it('should have a description string', () => {

--- a/tests/kb-server/tools/lookup.test.ts
+++ b/tests/kb-server/tools/lookup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { handler, type LookupArgs } from '../../../src/kb-server/tools/lookup.js';
+import { handler, toolDef } from '../../../src/kb-server/tools/lookup.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -35,6 +35,18 @@ function createTestDb(): Database.Database {
       cyclomatic   INTEGER NOT NULL,
       max_nesting  INTEGER NOT NULL
     );
+    CREATE TABLE external_symbols (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      dependency_ecosystem TEXT    NOT NULL DEFAULT 'npm',
+      source_type          TEXT    NOT NULL DEFAULT 'declaration',
+      source_ref           TEXT    NOT NULL DEFAULT '',
+      package_name         TEXT    NOT NULL,
+      package_version      TEXT,
+      symbol_name          TEXT    NOT NULL,
+      symbol_kind          TEXT    NOT NULL,
+      signature            TEXT    NOT NULL DEFAULT '',
+      doc_comment          TEXT
+    );
   `);
   return db;
 }
@@ -61,6 +73,20 @@ function insertSymbolMetrics(db: Database.Database, symbolId: number): void {
   ).run(symbolId, 20, 3, 8, 4);
 }
 
+function insertExternalSymbol(
+  db: Database.Database,
+  packageName: string,
+  packageVersion: string | null,
+  symbolName: string,
+  symbolKind: string,
+): void {
+  db.prepare(
+    `INSERT INTO external_symbols
+      (package_name, package_version, symbol_name, symbol_kind, signature)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(packageName, packageVersion, symbolName, symbolKind, `${symbolKind} ${symbolName}()`);
+}
+
 // ─── handler (kind=symbol) ────────────────────────────────────────────────────
 
 describe('lookup handler – kind=symbol', () => {
@@ -83,6 +109,72 @@ describe('lookup handler – kind=symbol', () => {
     expect(result.results[0]).toHaveProperty('param_count');
     expect(result.results[0]).toHaveProperty('cyclomatic');
     expect(result.results[0]).toHaveProperty('max_nesting');
+  });
+
+  it('should keep internal-only symbol lookup results unchanged when no external matches exist', () => {
+    const result = handler(db, { kind: 'symbol', query: 'parseConfig' });
+    expect(result.results.length).toBe(2);
+    expect(
+      result.results.every((row) => !Object.prototype.hasOwnProperty.call(row, 'package_name')),
+    ).toBe(true);
+  });
+
+  it('should return external-only symbol matches with package metadata', () => {
+    insertExternalSymbol(db, 'left-pad', '1.3.0', 'leftPad', 'function');
+    const result = handler(db, { kind: 'symbol', query: 'leftPad' });
+    expect(result.results.length).toBe(1);
+    expect(result.results[0]).toMatchObject({
+      package_name: 'left-pad',
+      package_version: '1.3.0',
+      symbol_name: 'leftPad',
+      symbol_kind: 'function',
+    });
+  });
+
+  it('should return mixed internal and external symbol matches for the same query', () => {
+    insertExternalSymbol(db, 'dep-utils', '2.0.0', 'parseConfig', 'function');
+    const result = handler(db, { kind: 'symbol', query: 'parseConfig' });
+    expect(result.results.length).toBe(3);
+
+    const internalRows = result.results.filter((row) =>
+      Object.prototype.hasOwnProperty.call(row, 'name'),
+    );
+    const externalRows = result.results.filter((row) =>
+      Object.prototype.hasOwnProperty.call(row, 'package_name'),
+    );
+
+    expect(internalRows.length).toBe(2);
+    expect(externalRows.length).toBe(1);
+    expect(externalRows[0]).toMatchObject({
+      package_name: 'dep-utils',
+      package_version: '2.0.0',
+      symbol_name: 'parseConfig',
+    });
+  });
+
+  it('should trim symbol query before matching internal and external symbols', () => {
+    insertExternalSymbol(db, 'dep-utils', '2.0.0', 'parseConfig', 'function');
+    const result = handler(db, { kind: 'symbol', query: '  parseConfig  ' });
+    expect(result.results.length).toBe(3);
+  });
+
+  it('should keep external symbol matches when branch filter is provided', () => {
+    insertExternalSymbol(db, 'dep-utils', '2.0.0', 'parseConfig', 'function');
+    const result = handler(db, { kind: 'symbol', query: 'parseConfig', branch: 'main' });
+
+    const internalRows = result.results.filter((row) =>
+      Object.prototype.hasOwnProperty.call(row, 'name'),
+    );
+    const externalRows = result.results.filter((row) =>
+      Object.prototype.hasOwnProperty.call(row, 'package_name'),
+    );
+
+    expect(internalRows.length).toBe(1);
+    expect(externalRows).toHaveLength(1);
+    expect(externalRows[0]).toMatchObject({
+      package_name: 'dep-utils',
+      symbol_name: 'parseConfig',
+    });
   });
 
   it('should filter symbols by branch when branch is provided', () => {
@@ -153,5 +245,14 @@ describe('lookup handler – kind=file', () => {
   it('should list files filtered by branch when query is empty', () => {
     const result = handler(db, { kind: 'file', query: '', branch: 'main' });
     expect(result.results.length).toBe(2);
+  });
+});
+
+describe('lookup toolDef', () => {
+  it('should expose kb_lookup with required kind and query fields', () => {
+    expect(toolDef.name).toBe('kb_lookup');
+    expect(toolDef.inputSchema.required).toEqual(['kind', 'query']);
+    expect(toolDef.inputSchema.properties.kind.enum).toEqual(['symbol', 'file']);
+    expect(toolDef.inputSchema.properties.query.type).toBe('string');
   });
 });

--- a/tests/kb-server/tools/notes.test.ts
+++ b/tests/kb-server/tools/notes.test.ts
@@ -26,8 +26,8 @@ function removeDbFiles(dbPath: string): void {
 
 describe('notes tool exports', () => {
   it('should expose tool definitions and aliases', () => {
-    expect(kbNotesWriteToolDef.name).toBe('lore_notes_write');
-    expect(kbNotesReadToolDef.name).toBe('lore_notes_read');
+    expect(kbNotesWriteToolDef.name).toBe('kb_notes_write');
+    expect(kbNotesReadToolDef.name).toBe('kb_notes_read');
     expect(writeToolDef).toBe(kbNotesWriteToolDef);
     expect(readToolDef).toBe(kbNotesReadToolDef);
   });

--- a/tests/kb-server/tools/routes.test.ts
+++ b/tests/kb-server/tools/routes.test.ts
@@ -54,8 +54,8 @@ function seedRoutes(db: Database.Database): void {
 }
 
 describe('routes toolDef', () => {
-  it('should expose the lore_routes tool name', () => {
-    expect(toolDef.name).toBe('lore_routes');
+  it('should expose the kb_routes tool name', () => {
+    expect(toolDef.name).toBe('kb_routes');
   });
 });
 

--- a/tests/kb-server/tools/test-map.test.ts
+++ b/tests/kb-server/tools/test-map.test.ts
@@ -94,8 +94,8 @@ describe('test-map handler', () => {
 });
 
 describe('test-map toolDef', () => {
-  it('should expose lore_test_map with source_path required and optional branch', () => {
-    expect(toolDef.name).toBe('lore_test_map');
+  it('should expose kb_test_map with source_path required and optional branch', () => {
+    expect(toolDef.name).toBe('kb_test_map');
     expect(toolDef.inputSchema.required).toEqual(['source_path']);
     expect(toolDef.inputSchema.properties.source_path.type).toBe('string');
     expect(toolDef.inputSchema.properties.branch.type).toBe('string');


### PR DESCRIPTION
## Summary

Add opt-in direct dependency API indexing so Lore captures declaration-level symbols from direct npm dependencies and can surface them in lookup results. This also wires the new dependency-indexing option through CLI flows and updates docs/tool naming references for KB MCP tools. Closes #88

## Changes

- **Indexer and schema (`src/indexer/*`)**
  - Added an `external_symbols` table (plus indexes) to store dependency API symbols separately from in-repo symbols.
  - Extended extraction metadata with declaration-surface helpers and updated the TypeScript extractor to capture exported `.d.ts` declarations and JSDoc.
  - Added `indexDependencies` support to `IndexBuilder`, including direct dependency discovery from root `package.json`, `.d.ts` traversal under each direct package, public/declaration filtering, and package version capture.
  - Cleans and rebuilds `external_symbols` each run so disabling dependency indexing removes stale external symbol rows.
- **CLI and server integration (`src/cli.ts`, `src/kb-server/*`)**
  - Added `--index-deps` handling to `index` and `refresh` command paths.
  - Added external symbol read helpers and merged external exact-name matches into `kb_lookup` symbol responses.
  - Updated tool naming references from `lore_*` to `kb_*` across server/tool definitions touched in this issue branch.
- **Documentation**
  - Updated `README.md` and `docs/architecture.md` with dependency indexing behavior, `--index-deps` usage, `external_symbols` storage, and KB tool naming.
- **Tests**
  - Added/updated Vitest coverage for CLI flag handling, schema changes, declaration extraction behavior, dependency indexing flows (direct-only, transitive exclusion, version fallback, cleanup on disable), and lookup integration of internal + external matches.

## Testing

- Integration verification gate completed successfully for this issue branch.
- Updated Vitest suites validate dependency indexing behavior and `kb_lookup` external symbol retrieval paths.

Closes #88