### PR TITLE
feat(logging): add structured logging for MCP tool calls, startup, and indexing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import {
   loadLspSettingsFromLoreConfig,
   resolveEffectiveLspSettings,
 } from './indexer/lsp/config.js';
+import { initLogger, LogLevel, LOG_LEVEL_NAMES } from './logger.js';
 
 // ─── Argument helpers ─────────────────────────────────────────────────────────
 
@@ -61,6 +62,8 @@ Options:
   --file <path>            Coverage report path (required for ingest-coverage)
   --format <name>          Coverage format: lcov or cobertura (required for ingest-coverage)
   --commit <sha>           Commit SHA to associate with coverage ingestion (default: HEAD)
+  --log-level <level>      Log level: debug, info, warn, error, silent (default: info)
+  --log-file <path>        Path to the structured log file (default: lore.log next to the DB)
   --help, -h               Show this help message`,
   );
   process.exit(1);
@@ -115,6 +118,19 @@ async function main(): Promise<void> {
   }
 
   const subcommand = args[0];
+
+  // ── Initialise logger (applies to all subcommands) ─────────────────────────
+  const logLevelRaw = flag(args, '--log-level');
+  const logFileRaw = flag(args, '--log-file');
+  const dbPathForLog = flag(args, '--db');
+  const resolvedLogLevel = logLevelRaw
+    ? (LOG_LEVEL_NAMES[logLevelRaw.toLowerCase()] ?? LogLevel.INFO)
+    : LogLevel.INFO;
+  const resolvedLogFile = logFileRaw
+    ?? (dbPathForLog
+      ? dbPathForLog.replace(/\.db$/, '.log')
+      : undefined);
+  const log = initLogger({ level: resolvedLogLevel, logFile: resolvedLogFile });
 
   if (subcommand === 'index') {
     const rootDir = flag(args, '--root');
@@ -260,6 +276,8 @@ async function main(): Promise<void> {
       return;
     }
 
+    log.startup('mcp server initializing', { dbPath });
+
     // Dynamically import so tree-shaking keeps the MCP server out of the
     // library entry point for consumers who only need the indexer.
     const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
@@ -276,6 +294,23 @@ async function main(): Promise<void> {
 
     const db = openReadOnly(dbPath);
 
+    // Gather DB stats for startup log
+    const totalFiles = (db.prepare('SELECT COUNT(*) AS cnt FROM files').get() as { cnt: number }).cnt;
+    const totalSymbols = (db.prepare('SELECT COUNT(*) AS cnt FROM symbols').get() as { cnt: number }).cnt;
+    let totalEdges = 0;
+    try {
+      totalEdges = (db.prepare('SELECT COUNT(*) AS cnt FROM call_graph').get() as { cnt: number }).cnt;
+    } catch { /* table may not exist */ }
+    let totalDocs = 0;
+    try {
+      totalDocs = (db.prepare('SELECT COUNT(*) AS cnt FROM documentation').get() as { cnt: number }).cnt;
+    } catch { /* table may not exist */ }
+    let commitCount: number | undefined;
+    try {
+      commitCount = (db.prepare('SELECT COUNT(*) AS cnt FROM commits').get() as { cnt: number }).cnt;
+    } catch { /* commits table may not exist */ }
+    const dbSizeBytes = fs.existsSync(dbPath) ? fs.statSync(dbPath).size : undefined;
+
     // Build optional embedder from model recorded at index time.
     let embedder: import('./indexer/embedder.js').EmbeddingProvider | undefined;
     const modelName = getLoreMeta(db, 'embedding_model') as string | undefined;
@@ -284,7 +319,9 @@ async function main(): Promise<void> {
       try {
         await provider.init();
         embedder = provider;
+        log.startup('embedding model loaded', { embeddingModel: modelName, embeddingReady: true });
       } catch {
+        log.warn('startup', 'embedding model unavailable, falling back to structural search', { embeddingModel: modelName });
         try {
           await provider.dispose();
         } catch {
@@ -293,11 +330,24 @@ async function main(): Promise<void> {
       }
     }
 
-    const server = createLoreMcpServer(db, dbPath, embedder);
+    log.startup('db stats', {
+      dbPath,
+      dbSizeBytes,
+      embeddingModel: modelName ?? null,
+      embeddingReady: !!embedder,
+      totalFiles,
+      totalSymbols,
+      totalDocs,
+      totalEdges,
+      commitCount,
+    });
+
+    const server = createLoreMcpServer(db, dbPath, embedder, { logger: log });
 
     const transport = new StdioServerTransport();
     await server.connect(transport);
 
+    log.startup('mcp server ready', { transport: 'stdio' });
     // Signal readiness on stderr so parent processes can detect it.
     process.stderr.write('READY\n');
   } else if (subcommand === 'refresh') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,7 @@ export {
   listFiles,
 } from './lore-server/db.js';
 export type { SymbolRow, FileRow } from './lore-server/db.js';
+
+// ── Logging ───────────────────────────────────────────────────────────────────
+export { LoreLogger, LogLevel, LOG_LEVEL_NAMES, initLogger, getLogger, resetLogger } from './logger.js';
+export type { LoreLoggerOptions, LogEntry, ToolCallFields, StartupFields } from './logger.js';

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -71,6 +71,7 @@ import { ingestCoverageReport, type CoverageFormat } from './coverage.js';
 import { refreshTestMappings } from './test-mapper.js';
 import type { EffectiveLspSettings } from './lsp/config.js';
 import { LspEnrichmentCoordinator } from './lsp/enrichment.js';
+import { getLogger } from '../logger.js';
 
 // ─── Extractor registry ───────────────────────────────────────────────────────
 
@@ -198,19 +199,26 @@ export class IndexBuilder {
    * the database.
    */
   async build(): Promise<void> {
+    const log = getLogger();
+    const buildStart = performance.now();
     const db = openDb(this.dbPath);
     const branch = this.resolveBranch();
     const lspCoordinator = this.createLspEnrichmentCoordinator();
+    log.indexing('build started', { dbPath: this.dbPath, branch, rootDir: this.walkerConfig.rootDir });
     try {
       this.saveDocsAutoNotesSetting(db);
       const files = await walkFiles(this.walkerConfig);
       const docs = await walkDocumentationFiles(this.walkerConfig);
+      log.indexing('walk complete', { fileCount: files.length, docCount: docs.length });
       if (lspCoordinator) {
         const languages = new Set(files.map((file) => file.language));
         if (this.indexDependencies) languages.add('typescript');
         await lspCoordinator.start(languages);
       }
       const resumeAt = this.loadBuildCheckpoint(db, branch, files.length);
+      if (resumeAt > 0) {
+        log.indexing('resuming from checkpoint', { resumeAt, totalFiles: files.length });
+      }
       db.transaction(() => {
         for (let i = resumeAt; i < files.length; i++) {
           const file = files[i];
@@ -227,6 +235,7 @@ export class IndexBuilder {
         this.removeStaleDocumentation(db, branch, seenDocPaths);
       })();
       this.saveBuildCheckpoint(db, branch, files.length, files.length);
+      log.indexing('files processed, resolving imports');
       this.resolveImports(db, branch);
       await this.indexDependencyDeclarations(db, lspCoordinator);
       await this.enrichProjectSymbolsAndCallRefs(db, branch, files, lspCoordinator);
@@ -234,18 +243,47 @@ export class IndexBuilder {
       buildCallGraph(db);
       this.saveLastKnownHead(db);
       if (this.embedder) {
+        log.indexing('embedding started', { model: this.embeddingModel });
         await this.embedder.init();
         await this.embedStructural(db);
         await this.embedDocumentation(db);
+        log.indexing('embedding complete');
       }
       if (this.history) {
+        log.indexing('git history ingestion started');
         const historyOptions =
           typeof this.history === 'object' ? this.history : undefined;
         await ingestGitHistory(db, this.walkerConfig.rootDir, historyOptions);
         if (this.embedder) {
           await this.embedCommitMessages(db);
         }
+        log.indexing('git history ingestion complete');
       }
+      // Gather final DB stats for the build summary
+      let totalSymbols = 0;
+      try { totalSymbols = (db.prepare('SELECT COUNT(*) AS cnt FROM symbols').get() as { cnt: number }).cnt; } catch { /* table may not exist */ }
+      let totalEdges = 0;
+      try { totalEdges = (db.prepare('SELECT COUNT(*) AS cnt FROM call_graph').get() as { cnt: number }).cnt; } catch { /* table may not exist */ }
+      let totalDocs = 0;
+      try { totalDocs = (db.prepare('SELECT COUNT(*) AS cnt FROM documentation').get() as { cnt: number }).cnt; } catch { /* table may not exist */ }
+      let commitCount: number | undefined;
+      try {
+        commitCount = (db.prepare('SELECT COUNT(*) AS cnt FROM commits').get() as { cnt: number }).cnt;
+      } catch { /* commits table may not exist */ }
+      const dbSizeBytes = fs.existsSync(this.dbPath) ? fs.statSync(this.dbPath).size : undefined;
+      const indexDurationMs = Math.round(performance.now() - buildStart);
+      log.startup('indexing complete', {
+        dbPath: this.dbPath,
+        dbSizeBytes,
+        embeddingModel: this.embeddingModel,
+        embeddingReady: !!this.embedder,
+        totalFiles: files.length,
+        totalSymbols,
+        totalDocs,
+        totalEdges,
+        commitCount,
+        indexDurationMs,
+      });
     } finally {
       if (lspCoordinator) {
         await lspCoordinator.dispose();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,252 @@
+/**
+ * @module logger
+ *
+ * Structured JSON logger for the Lore MCP server and indexer.
+ *
+ * Writes newline-delimited JSON (NDJSON) log entries to a file on disk.
+ * Each entry includes a timestamp, level, component, message, and optional
+ * structured fields (tool name, request/response bodies, latency, status).
+ *
+ * Usage:
+ *   import { LoreLogger, LogLevel } from './logger.js';
+ *   const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: '/tmp/lore.log' });
+ *   log.info('server', 'Server started', { dbPath: '/path/to/db' });
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Log levels ───────────────────────────────────────────────────────────────
+
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  SILENT = 4,
+}
+
+/** Map from lowercase string to `LogLevel` for CLI parsing. */
+export const LOG_LEVEL_NAMES: Record<string, LogLevel> = {
+  debug: LogLevel.DEBUG,
+  info: LogLevel.INFO,
+  warn: LogLevel.WARN,
+  error: LogLevel.ERROR,
+  silent: LogLevel.SILENT,
+};
+
+function levelName(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.DEBUG:
+      return 'debug';
+    case LogLevel.INFO:
+      return 'info';
+    case LogLevel.WARN:
+      return 'warn';
+    case LogLevel.ERROR:
+      return 'error';
+    case LogLevel.SILENT:
+      return 'silent';
+  }
+}
+
+// ─── Log entry types ──────────────────────────────────────────────────────────
+
+/** Base fields present on every log entry. */
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  component: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+/** Extra fields for MCP tool-call logs. */
+export interface ToolCallFields {
+  tool: string;
+  requestBody: unknown;
+  responseBody?: unknown;
+  status: 'success' | 'error';
+  durationMs: number;
+  error?: string;
+}
+
+/** Extra fields for startup / indexing logs. */
+export interface StartupFields {
+  dbPath?: string;
+  dbSizeBytes?: number;
+  embeddingModel?: string | null;
+  embeddingReady?: boolean;
+  totalFiles?: number;
+  totalSymbols?: number;
+  totalDocs?: number;
+  totalEdges?: number;
+  commitCount?: number;
+  indexDurationMs?: number;
+  [key: string]: unknown;
+}
+
+// ─── Logger options ───────────────────────────────────────────────────────────
+
+export interface LoreLoggerOptions {
+  /** Minimum level to emit (default: INFO). */
+  level?: LogLevel;
+  /** Absolute or relative path to the log file. Parent directories are created. */
+  logFile?: string;
+  /**
+   * Maximum size of serialised request/response bodies in characters.
+   * Larger payloads are truncated with a "(truncated)" marker.
+   * Default: 8192.
+   */
+  maxBodySize?: number;
+}
+
+// ─── Logger implementation ────────────────────────────────────────────────────
+
+export class LoreLogger {
+  readonly level: LogLevel;
+  readonly logFile: string | undefined;
+  private fd: number | undefined;
+  private readonly maxBodySize: number;
+
+  constructor(options: LoreLoggerOptions = {}) {
+    this.level = options.level ?? LogLevel.INFO;
+    this.logFile = options.logFile;
+    this.maxBodySize = options.maxBodySize ?? 8192;
+
+    if (this.logFile) {
+      const dir = path.dirname(this.logFile);
+      fs.mkdirSync(dir, { recursive: true });
+      this.fd = fs.openSync(this.logFile, 'a');
+    }
+  }
+
+  // ── Core log methods ─────────────────────────────────────────────────────
+
+  debug(component: string, message: string, extra?: Record<string, unknown>): void {
+    this.write(LogLevel.DEBUG, component, message, extra);
+  }
+
+  info(component: string, message: string, extra?: Record<string, unknown>): void {
+    this.write(LogLevel.INFO, component, message, extra);
+  }
+
+  warn(component: string, message: string, extra?: Record<string, unknown>): void {
+    this.write(LogLevel.WARN, component, message, extra);
+  }
+
+  error(component: string, message: string, extra?: Record<string, unknown>): void {
+    this.write(LogLevel.ERROR, component, message, extra);
+  }
+
+  // ── Specialised helpers ──────────────────────────────────────────────────
+
+  /**
+   * Log an MCP tool invocation with request/response, status, and timing.
+   */
+  toolCall(fields: ToolCallFields): void {
+    const extra: Record<string, unknown> = {
+      tool: fields.tool,
+      requestBody: this.truncateBody(fields.requestBody),
+      status: fields.status,
+      durationMs: fields.durationMs,
+    };
+    if (fields.responseBody !== undefined) {
+      extra.responseBody = this.truncateBody(fields.responseBody);
+    }
+    if (fields.error) {
+      extra.error = fields.error;
+    }
+    const level = fields.status === 'error' ? LogLevel.ERROR : LogLevel.INFO;
+    this.write(level, 'mcp-tool', `${fields.tool} ${fields.status}`, extra);
+  }
+
+  /**
+   * Log a startup event with optional DB / embedding stats.
+   */
+  startup(message: string, fields?: StartupFields): void {
+    this.write(LogLevel.INFO, 'startup', message, fields as Record<string, unknown> | undefined);
+  }
+
+  /**
+   * Log indexing progress or completion.
+   */
+  indexing(message: string, fields?: Record<string, unknown>): void {
+    this.write(LogLevel.INFO, 'indexer', message, fields);
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /** Flush and close the log file descriptor. */
+  close(): void {
+    if (this.fd !== undefined) {
+      fs.closeSync(this.fd);
+      this.fd = undefined;
+    }
+  }
+
+  // ── Internal ─────────────────────────────────────────────────────────────
+
+  private write(
+    level: LogLevel,
+    component: string,
+    message: string,
+    extra?: Record<string, unknown>,
+  ): void {
+    if (level < this.level) return;
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level: levelName(level),
+      component,
+      message,
+      ...extra,
+    };
+
+    const line = JSON.stringify(entry) + '\n';
+
+    if (this.fd !== undefined) {
+      fs.writeSync(this.fd, line);
+    }
+  }
+
+  /**
+   * Truncate large payloads to keep log files manageable.
+   * Returns the original value if within limits, otherwise a truncated string.
+   */
+  private truncateBody(body: unknown): unknown {
+    if (body === undefined || body === null) return body;
+    const serialised = typeof body === 'string' ? body : JSON.stringify(body);
+    if (serialised.length <= this.maxBodySize) return body;
+    return serialised.slice(0, this.maxBodySize) + '...(truncated)';
+  }
+}
+
+// ─── Singleton / global logger ────────────────────────────────────────────────
+
+let _globalLogger: LoreLogger | undefined;
+
+/** Retrieve the global logger instance (creates a no-op SILENT logger if not initialised). */
+export function getLogger(): LoreLogger {
+  if (!_globalLogger) {
+    _globalLogger = new LoreLogger({ level: LogLevel.SILENT });
+  }
+  return _globalLogger;
+}
+
+/** Initialise the global logger. Should be called once at process startup. */
+export function initLogger(options: LoreLoggerOptions): LoreLogger {
+  if (_globalLogger) {
+    _globalLogger.close();
+  }
+  _globalLogger = new LoreLogger(options);
+  return _globalLogger;
+}
+
+/** Reset the global logger (primarily for tests). */
+export function resetLogger(): void {
+  if (_globalLogger) {
+    _globalLogger.close();
+    _globalLogger = undefined;
+  }
+}

--- a/src/lore-server/server.ts
+++ b/src/lore-server/server.ts
@@ -40,6 +40,7 @@ import {
 } from './db.js';
 import { getLoreMeta } from '../indexer/db.js';
 import { SentenceTransformersProvider, type EmbeddingProvider } from '../indexer/embedder.js';
+import { getLogger, type LoreLogger } from '../logger.js';
 import * as lookup from './tools/lookup.js';
 import * as graph from './tools/graph.js';
 import * as search from './tools/search.js';
@@ -110,6 +111,8 @@ function handleCommitStats(db: Database.Database, args: CommitStatsArgs): unknow
 export interface LoreServerOptions {
   /** Callback invoked after every `lore_search` call with query/mode/latency/result metadata. */
   searchObserver?: SearchObserver;
+  /** Logger instance. Falls back to the global logger when omitted. */
+  logger?: LoreLogger;
 }
 
 // ─── Server factory ───────────────────────────────────────────────────────────
@@ -128,10 +131,48 @@ export function createLoreMcpServer(
   embedder?: EmbeddingProvider,
   options?: LoreServerOptions,
 ): McpServer {
+  const log = options?.logger ?? getLogger();
+
   const server = new McpServer(
     { name: 'lore-server', version: '0.1.0' },
     { capabilities: { tools: {} } },
   );
+
+  /**
+   * Wrap an MCP tool handler with structured logging.
+   * Captures request args, response, timing, and success/error status.
+   */
+  function loggedHandler<A>(
+    toolName: string,
+    fn: (args: A) => unknown | Promise<unknown>,
+  ): (args: A) => Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+    return async (args: A) => {
+      const start = performance.now();
+      try {
+        const result = await fn(args);
+        const durationMs = Math.round((performance.now() - start) * 100) / 100;
+        log.toolCall({
+          tool: toolName,
+          requestBody: args,
+          responseBody: result,
+          status: 'success',
+          durationMs,
+        });
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+      } catch (err) {
+        const durationMs = Math.round((performance.now() - start) * 100) / 100;
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.toolCall({
+          tool: toolName,
+          requestBody: args,
+          status: 'error',
+          durationMs,
+          error: errorMessage,
+        });
+        throw err;
+      }
+    };
+  }
 
   // ── lore_lookup ──────────────────────────────────────────────────────────────
   server.tool(
@@ -155,9 +196,7 @@ export function createLoreMcpServer(
       limit: z.number().int().nonnegative().optional().describe('For kind="symbol" with empty query: maximum rows to return.'),
       offset: z.number().int().nonnegative().optional().describe('For kind="symbol" with empty query: rows to skip before returning results.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(await lookup.handler(db, args, embedder)) }],
-    }),
+    loggedHandler(lookup.toolDef.name, (args) => lookup.handler(db, args, embedder)),
   );
 
   // ── lore_graph ───────────────────────────────────────────────────────────────
@@ -188,9 +227,7 @@ export function createLoreMcpServer(
         .optional()
         .describe('Optional max embedding distance threshold for semantic nodes.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(graph.handler(db, args)) }],
-    }),
+    loggedHandler(graph.toolDef.name, (args) => graph.handler(db, args)),
   );
 
   // ── lore_search ──────────────────────────────────────────────────────────────
@@ -217,9 +254,7 @@ export function createLoreMcpServer(
         .describe('Optional documentation kind filter for semantic/fused doc-section results.'),
       branch: z.string().optional().describe('Optional branch to filter results. Query-time retrieval uses SQLite-only persisted data.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(await search.handler(db, args, embedder, options?.searchObserver)) }],
-    }),
+    loggedHandler(search.toolDef.name, (args) => search.handler(db, args, embedder, options?.searchObserver)),
   );
 
   // ── lore_docs ────────────────────────────────────────────────────────────────
@@ -246,9 +281,7 @@ export function createLoreMcpServer(
       limit: z.number().optional().describe('Max rows to return (defaults depend on action).'),
       branch: z.string().optional().describe('Optional branch to filter docs.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(await docs.handler(db, args, embedder)) }],
-    }),
+    loggedHandler(docs.toolDef.name, (args) => docs.handler(db, args, embedder)),
   );
 
   // ── lore_annotations ─────────────────────────────────────────────────────────
@@ -262,9 +295,7 @@ export function createLoreMcpServer(
       path: z.string().optional().describe('Optional exact file path filter.'),
       limit: z.number().optional().describe('Maximum number of results to return (default 20).'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(annotations.handler(db, args)) }],
-    }),
+    loggedHandler(annotations.toolDef.name, (args) => annotations.handler(db, args)),
   );
 
   // ── lore_routes ──────────────────────────────────────────────────────────────
@@ -276,9 +307,7 @@ export function createLoreMcpServer(
       path_prefix: z.string().optional().describe('Optional route path prefix filter.'),
       framework: z.string().optional().describe('Optional framework filter (for example express, fastapi, gin).'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(routes.handler(db, args)) }],
-    }),
+    loggedHandler(routes.toolDef.name, (args) => routes.handler(db, args)),
   );
 
   // ── lore_notes_write ─────────────────────────────────────────────────────────
@@ -295,9 +324,7 @@ export function createLoreMcpServer(
       model: z.string().optional().describe('Model identifier that authored the note.'),
       source_hash: z.string().optional().describe('Optional source hash used for staleness detection.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(notes.writeHandler(dbPath, args)) }],
-    }),
+    loggedHandler(notes.writeToolDef.name, (args) => notes.writeHandler(dbPath, args)),
   );
 
   // ── lore_notes_read ──────────────────────────────────────────────────────────
@@ -310,9 +337,7 @@ export function createLoreMcpServer(
       scope: z.string().optional().describe('Optional scope filter.'),
       limit: z.number().optional().describe('Max notes to return (default 20, max 200).'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(notes.readHandler(db, args)) }],
-    }),
+    loggedHandler(notes.readToolDef.name, (args) => notes.readHandler(db, args)),
   );
 
   // ── lore_architecture ────────────────────────────────────────────────────────
@@ -326,9 +351,7 @@ export function createLoreMcpServer(
         .describe('Optional path depth used to group files into components (default 2).'),
       branch: z.string().optional().describe('Optional branch name to filter architecture output.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(architecture.handler(db, args)) }],
-    }),
+    loggedHandler(architecture.toolDef.name, (args) => architecture.handler(db, args)),
   );
 
   // ── lore_test_map ─────────────────────────────────────────────────────────────
@@ -339,9 +362,7 @@ export function createLoreMcpServer(
       source_path: z.string().describe('Source file path to resolve mapped test files for.'),
       branch: z.string().optional().describe('Optional branch to constrain mappings.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(testMap.handler(db, args)) }],
-    }),
+    loggedHandler(testMap.toolDef.name, (args) => testMap.handler(db, args)),
   );
 
   // ── lore_snippet ─────────────────────────────────────────────────────────────
@@ -354,9 +375,7 @@ export function createLoreMcpServer(
       end_line: z.number().optional().describe('Last line (1-based, inclusive).'),
       branch: z.string().optional().describe('Optional branch to disambiguate the file path.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(snippet.handler(db, args)) }],
-    }),
+    loggedHandler(snippet.toolDef.name, (args) => snippet.handler(db, args)),
   );
 
   // ── lore_metrics ─────────────────────────────────────────────────────────────
@@ -377,9 +396,7 @@ export function createLoreMcpServer(
         .optional()
         .describe(metrics.toolDef.inputSchema.properties.min_cyclomatic.description),
     },
-    async (args: metrics.MetricsArgs = {}) => ({
-      content: [{ type: 'text', text: JSON.stringify(metrics.handler(db, args)) }],
-    }),
+    loggedHandler(metrics.toolDef.name, (args: metrics.MetricsArgs = {}) => metrics.handler(db, args)),
   );
 
   // ── lore_coverage ────────────────────────────────────────────────────────────
@@ -393,9 +410,7 @@ export function createLoreMcpServer(
       branch: z.string().optional().describe('Optional branch filter.'),
       limit: z.number().optional().describe('Maximum symbols to return (default 50).'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(coverage.handler(db, args)) }],
-    }),
+    loggedHandler(coverage.toolDef.name, (args) => coverage.handler(db, args)),
   );
 
   // ── lore_blame ───────────────────────────────────────────────────────────────
@@ -422,9 +437,7 @@ export function createLoreMcpServer(
         .optional()
         .describe('Ownership mode scope. If omitted, inferred from `path`.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(blame.handler(db, args)) }],
-    }),
+    loggedHandler(blame.toolDef.name, (args) => blame.handler(db, args)),
   );
 
   // ── lore_writeback ───────────────────────────────────────────────────────────
@@ -437,11 +450,7 @@ export function createLoreMcpServer(
       model: z.string().describe('Model identifier that generated the summary.'),
       branch: z.string().optional().describe('Optional branch to validate the symbol belongs to.'),
     },
-    async (args) => ({
-      content: [
-        { type: 'text', text: JSON.stringify(writeback.handler(dbPath, args)) },
-      ],
-    }),
+    loggedHandler(writeback.toolDef.name, (args) => writeback.handler(dbPath, args)),
   );
 
   // ── lore_history ─────────────────────────────────────────────────────────────
@@ -455,9 +464,7 @@ export function createLoreMcpServer(
       query: z.string().optional().describe('File path, commit SHA, author name/email, ref, or semantic query text.'),
       limit: z.number().optional().describe('Max results (default 20, max 200).'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(await history.handler(db, args, embedder)) }],
-    }),
+    loggedHandler(history.toolDef.name, (args) => history.handler(db, args, embedder)),
   );
 
   // ── lore_commit_stats ────────────────────────────────────────────────────────
@@ -473,9 +480,7 @@ export function createLoreMcpServer(
       until: z.string().optional().describe('Optional ISO date upper bound (inclusive).'),
       author: z.string().optional().describe('Optional author name/email substring filter.'),
     },
-    async (args) => ({
-      content: [{ type: 'text', text: JSON.stringify(handleCommitStats(db, args)) }],
-    }),
+    loggedHandler('lore_commit_stats', (args: CommitStatsArgs) => handleCommitStats(db, args)),
   );
 
   return server;

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { unlinkSync, existsSync, readFileSync } from 'node:fs';
+import {
+  LoreLogger,
+  LogLevel,
+  LOG_LEVEL_NAMES,
+  initLogger,
+  getLogger,
+  resetLogger,
+  type LogEntry,
+  type ToolCallFields,
+} from '../src/logger.js';
+
+function readLogLines(filePath: string): LogEntry[] {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as LogEntry);
+}
+
+describe('LoreLogger', () => {
+  let logPath: string;
+
+  beforeEach(() => {
+    logPath = join(tmpdir(), `lore-logger-test-${Date.now()}-${Math.random()}.log`);
+    resetLogger();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    if (existsSync(logPath)) unlinkSync(logPath);
+  });
+
+  // ── Basic logging ───────────────────────────────────────────────────────
+
+  it('should write NDJSON log entries to a file', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.info('test', 'hello world');
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.level).toBe('info');
+    expect(lines[0]!.component).toBe('test');
+    expect(lines[0]!.message).toBe('hello world');
+    expect(lines[0]!.timestamp).toBeDefined();
+  });
+
+  it('should respect the minimum log level', () => {
+    const log = new LoreLogger({ level: LogLevel.WARN, logFile: logPath });
+    log.debug('test', 'ignored');
+    log.info('test', 'also ignored');
+    log.warn('test', 'included');
+    log.error('test', 'also included');
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.level).toBe('warn');
+    expect(lines[1]!.level).toBe('error');
+  });
+
+  it('should emit nothing for SILENT level', () => {
+    const log = new LoreLogger({ level: LogLevel.SILENT, logFile: logPath });
+    log.debug('test', 'nope');
+    log.info('test', 'nope');
+    log.warn('test', 'nope');
+    log.error('test', 'nope');
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(0);
+  });
+
+  it('should include extra fields in the log entry', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.info('test', 'with extras', { foo: 'bar', count: 42 });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines[0]!.foo).toBe('bar');
+    expect(lines[0]!.count).toBe(42);
+  });
+
+  // ── Tool call logging ──────────────────────────────────────────────────
+
+  it('should log tool calls with request/response and timing', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.toolCall({
+      tool: 'lore_lookup',
+      requestBody: { kind: 'symbol', query: 'MyClass' },
+      responseBody: { symbols: [] },
+      status: 'success',
+      durationMs: 12.34,
+    });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0]!;
+    expect(entry.component).toBe('mcp-tool');
+    expect(entry.tool).toBe('lore_lookup');
+    expect(entry.status).toBe('success');
+    expect(entry.durationMs).toBe(12.34);
+    expect(entry.requestBody).toEqual({ kind: 'symbol', query: 'MyClass' });
+    expect(entry.responseBody).toEqual({ symbols: [] });
+  });
+
+  it('should log tool call errors at error level', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.toolCall({
+      tool: 'lore_search',
+      requestBody: { query: 'test' },
+      status: 'error',
+      durationMs: 5.0,
+      error: 'table not found',
+    });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.level).toBe('error');
+    expect(lines[0]!.error).toBe('table not found');
+  });
+
+  // ── Startup / indexing helpers ─────────────────────────────────────────
+
+  it('should log startup events with fields', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.startup('server ready', {
+      dbPath: '/tmp/test.db',
+      dbSizeBytes: 1024,
+      embeddingModel: 'test-model',
+      embeddingReady: true,
+      totalFiles: 100,
+      totalSymbols: 500,
+      totalDocs: 10,
+      totalEdges: 200,
+    });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.component).toBe('startup');
+    expect(lines[0]!.totalSymbols).toBe(500);
+    expect(lines[0]!.dbSizeBytes).toBe(1024);
+  });
+
+  it('should log indexing events', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    log.indexing('walk complete', { fileCount: 50, docCount: 5 });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.component).toBe('indexer');
+    expect(lines[0]!.fileCount).toBe(50);
+  });
+
+  // ── Body truncation ────────────────────────────────────────────────────
+
+  it('should truncate large bodies', () => {
+    const log = new LoreLogger({ level: LogLevel.DEBUG, logFile: logPath, maxBodySize: 32 });
+    log.toolCall({
+      tool: 'lore_search',
+      requestBody: { query: 'a'.repeat(100) },
+      responseBody: { results: 'x'.repeat(100) },
+      status: 'success',
+      durationMs: 1,
+    });
+    log.close();
+
+    const lines = readLogLines(logPath);
+    const entry = lines[0]!;
+    expect(typeof entry.requestBody).toBe('string');
+    expect((entry.requestBody as string).endsWith('...(truncated)')).toBe(true);
+    expect(typeof entry.responseBody).toBe('string');
+    expect((entry.responseBody as string).endsWith('...(truncated)')).toBe(true);
+  });
+
+  // ── Global logger ─────────────────────────────────────────────────────
+
+  it('getLogger returns a SILENT no-op logger by default', () => {
+    const log = getLogger();
+    expect(log.level).toBe(LogLevel.SILENT);
+  });
+
+  it('initLogger sets the global logger', () => {
+    const log = initLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    expect(getLogger()).toBe(log);
+    log.info('global', 'test');
+    log.close();
+
+    const lines = readLogLines(logPath);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('resetLogger clears the global logger', () => {
+    initLogger({ level: LogLevel.DEBUG, logFile: logPath });
+    resetLogger();
+    // After reset, getLogger returns a new silent logger
+    expect(getLogger().level).toBe(LogLevel.SILENT);
+  });
+
+  // ── LOG_LEVEL_NAMES ────────────────────────────────────────────────────
+
+  it('should map level name strings to LogLevel values', () => {
+    expect(LOG_LEVEL_NAMES['debug']).toBe(LogLevel.DEBUG);
+    expect(LOG_LEVEL_NAMES['info']).toBe(LogLevel.INFO);
+    expect(LOG_LEVEL_NAMES['warn']).toBe(LogLevel.WARN);
+    expect(LOG_LEVEL_NAMES['error']).toBe(LogLevel.ERROR);
+    expect(LOG_LEVEL_NAMES['silent']).toBe(LogLevel.SILENT);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a structured logging system to Lore so that MCP tool calls, server startup, and indexing progress are recorded to disk as newline-delimited JSON (NDJSON).

## Motivation

When the Lore MCP server is running, there's currently no observability into which tools are called, how they perform, or what happened during startup and indexing. This makes debugging and performance analysis difficult.

## Changes

### New: `src/logger.ts`
- `LoreLogger` class writing NDJSON log entries to a configurable file on disk
- **Log levels:** `debug`, `info`, `warn`, `error`, `silent` (via `LogLevel` enum)
- **`toolCall()`** — structured log for every MCP tool invocation capturing:
  - Tool name, request body, response body
  - `success` / `error` status
  - `durationMs` latency metric
- **`startup()`** — logs DB stats, embedding model readiness, file/symbol/doc/edge counts
- **`indexing()`** — logs walk results, checkpoint resumes, embedding progress, git history ingestion
- Body truncation at 8192 chars (configurable via `maxBodySize`) to prevent unbounded log growth
- Global singleton pattern via `initLogger()` / `getLogger()` / `resetLogger()`

### Modified: `src/lore-server/server.ts`
- All 17 MCP tool handlers wrapped with a `loggedHandler()` helper that captures timing, request/response, and success/error status
- New `LoreServerOptions.logger` field for dependency injection

### Modified: `src/cli.ts`
- New CLI flags: `--log-level <level>` and `--log-file <path>`
  - Log file defaults to `<db-path>.log` (e.g. `lore.db` → `lore.log`)
  - Log level defaults to `info`
- Logger initialized at top of `main()` before any subcommand executes
- MCP startup path emits DB stats, embedding model status, and `mcp server ready` events

### Modified: `src/indexer/index.ts`
- `build()` emits structured logs at each pipeline stage:
  - Walk complete (file + doc counts)
  - Checkpoint resume
  - Import resolution
  - Embedding start/complete
  - Git history ingestion start/complete
  - Final summary with aggregate stats (`totalFiles`, `totalSymbols`, `totalDocs`, `totalEdges`, `commitCount`, `dbSizeBytes`, `indexDurationMs`)

### New: `tests/logger.test.ts`
- 13 unit tests covering all log methods, level filtering, body truncation, and the global singleton

## Example log output

```jsonl
{"timestamp":"2026-03-07T19:52:00.000Z","level":"info","component":"startup","message":"mcp server initializing","dbPath":"/tmp/lore.db"}
{"timestamp":"2026-03-07T19:52:01.000Z","level":"info","component":"startup","message":"db stats","dbPath":"/tmp/lore.db","dbSizeBytes":4194304,"totalFiles":120,"totalSymbols":1500,"totalDocs":25,"totalEdges":800}
{"timestamp":"2026-03-07T19:52:02.000Z","level":"info","component":"mcp-tool","message":"lore_search success","tool":"lore_search","requestBody":{"query":"handleClick","mode":"fused"},"responseBody":{"results":[...]},"status":"success","durationMs":42.15}
```

## Test results

All 760 tests pass, 0 failures. No regressions.