### PR TITLE
refactor(resolution): replace name-based resolution with LSP definition_path + definition_line

### DIFF
--- a/src/indexer/call-graph.ts
+++ b/src/indexer/call-graph.ts
@@ -4,10 +4,9 @@
  * Call-graph and cross-reference resolution utilities operating on the
  * SQLite knowledge-base:
  *
- *  - `resolveSymbolEdges(db)` — resolves raw names in `symbol_refs`,
- *    `type_refs`, and `symbol_relationships` to concrete symbol IDs.
- *  - `normalizeTypeName(raw)` — strips qualifiers/generics/pointers to
- *    produce a bare type name for fallback matching.
+ *  - `resolveSymbolEdges(db)` — resolves unresolved edges in `symbol_refs`,
+ *    `type_refs`, and `symbol_relationships` using LSP-provided
+ *    `definition_path` + `definition_line` for precise matching.
  *  - `topoSort(db)` — topological ordering of files based on `file_imports`
  *    using Kahn's algorithm.
  *  - `detectCycles(db)` — cycle detection over the `file_imports` graph using
@@ -16,114 +15,46 @@
 
 import type { Database } from './db.js';
 
-// ─── normalizeTypeName ────────────────────────────────────────────────────────
-
-/**
- * Produces a bare type name from a raw type reference for fallback matching.
- *
- * Steps:
- * 1. Strip CV qualifiers
- * 2. Strip type-intro keywords (struct, enum, union, class)
- * 3. Strip Rust reference/lifetime syntax
- * 4. Strip pointer/reference suffixes
- * 5. Truncate at first `<`
- * 6. Take the last segment after `::` or `.`
- * 7. Trim whitespace
- */
-export function normalizeTypeName(raw: string): string {
-  let s = raw;
-  // 1. Strip CV qualifiers (word-bounded)
-  s = s.replace(/\b(const|volatile|restrict|mutable)\b/g, '');
-  // 2. Strip type-intro keywords (word-bounded)
-  s = s.replace(/\b(struct|enum|union|class)\b/g, '');
-  // 3. Strip Rust reference/lifetime syntax: &'lifetime_name, &mut, &
-  s = s.replace(/^&'[a-zA-Z_]\w*\s+(mut\s+)?/, '');
-  s = s.replace(/^&mut\s+/, '');
-  s = s.replace(/^&/, '');
-  // 4. Strip pointer/reference suffixes
-  s = s.replace(/[\*&\[\]]+$/, '');
-  // 4b. Function pointer syntax — if there's a remaining (*) pattern, it's not a named type
-  if (/\(\s*\*\s*\)/.test(s)) return '';
-  // 5. Truncate at first `<`
-  const ltIdx = s.indexOf('<');
-  if (ltIdx !== -1) s = s.slice(0, ltIdx);
-  // 6. Take last segment after `::` or `.`
-  const colonIdx = s.lastIndexOf('::');
-  if (colonIdx !== -1) {
-    s = s.slice(colonIdx + 2);
-  } else {
-    const dotIdx = s.lastIndexOf('.');
-    if (dotIdx !== -1) s = s.slice(dotIdx + 1);
-  }
-  // 7. Trim
-  return s.trim();
-}
-
 // ─── resolveSymbolEdges ───────────────────────────────────────────────────────
 
 /**
  * Resolves unresolved edges in `symbol_refs`, `type_refs`, and
- * `symbol_relationships` using name-based and definition-path-based passes.
+ * `symbol_relationships` using LSP-provided definition paths and lines.
  *
- * Replaces the old `buildCallGraph()`.
+ * For each unresolved row with a non-null `definition_path`, finds the symbol
+ * in that file whose `start_line` is closest to the LSP-reported
+ * `definition_line`.  When `definition_line` is unavailable, falls back to
+ * the first symbol in the file (lowest `start_line`).
  */
 export function resolveSymbolEdges(db: Database.Database): void {
-  const nameToSymbols = buildNameMap(db);
-  const pathToSymbols = buildPathMap(db);
+  const pathLineMap = buildPathLineMap(db);
 
-  // ── symbol_refs: name-based, then definition-path ──
-  resolveByNameGeneric(nameToSymbols, {
+  // ── symbol_refs ──
+  resolveByDefinitionPath(pathLineMap, {
     selectUnresolved: db.prepare(
-      `SELECT sr.id, sr.callee_name AS target_name, s.file_id AS source_file_id
-       FROM symbol_refs sr JOIN symbols s ON s.id = sr.caller_id
-       WHERE sr.callee_id IS NULL`,
-    ),
-    update: db.prepare('UPDATE symbol_refs SET callee_id = ? WHERE id = ?'),
-  });
-  resolveByDefinitionPathGeneric(pathToSymbols, {
-    selectUnresolved: db.prepare(
-      `SELECT id, definition_path FROM symbol_refs WHERE callee_id IS NULL AND definition_path IS NOT NULL`,
+      `SELECT id, definition_path, definition_line
+       FROM symbol_refs
+       WHERE callee_id IS NULL AND definition_path IS NOT NULL`,
     ),
     update: db.prepare('UPDATE symbol_refs SET callee_id = ? WHERE id = ?'),
   });
 
-  // ── type_refs: qualified name first, then bare fallback ──
-  resolveByNameGeneric(nameToSymbols, {
+  // ── type_refs ──
+  resolveByDefinitionPath(pathLineMap, {
     selectUnresolved: db.prepare(
-      `SELECT tr.id, tr.type_name AS target_name, COALESCE(s.file_id, tr.file_id) AS source_file_id
-       FROM type_refs tr LEFT JOIN symbols s ON s.id = tr.symbol_id
-       WHERE tr.type_id IS NULL`,
-    ),
-    update: db.prepare('UPDATE type_refs SET type_id = ? WHERE id = ?'),
-  });
-  resolveByNameGeneric(nameToSymbols, {
-    selectUnresolved: db.prepare(
-      `SELECT tr.id, tr.type_name_bare AS target_name, COALESCE(s.file_id, tr.file_id) AS source_file_id
-       FROM type_refs tr LEFT JOIN symbols s ON s.id = tr.symbol_id
-       WHERE tr.type_id IS NULL AND tr.type_name_bare != tr.type_name`,
-    ),
-    update: db.prepare('UPDATE type_refs SET type_id = ? WHERE id = ?'),
-  });
-  resolveByDefinitionPathGeneric(pathToSymbols, {
-    selectUnresolved: db.prepare(
-      `SELECT id, definition_path FROM type_refs WHERE type_id IS NULL AND definition_path IS NOT NULL`,
+      `SELECT id, definition_path, definition_line
+       FROM type_refs
+       WHERE type_id IS NULL AND definition_path IS NOT NULL`,
     ),
     update: db.prepare('UPDATE type_refs SET type_id = ? WHERE id = ?'),
   });
 
   // ── symbol_relationships ──
-  resolveByNameGeneric(nameToSymbols, {
+  resolveByDefinitionPath(pathLineMap, {
     selectUnresolved: db.prepare(
-      `SELECT sr.id, sr.target_symbol_name AS target_name, COALESCE(s.file_id, sr.file_id) AS source_file_id
-       FROM symbol_relationships sr LEFT JOIN symbols s ON s.id = sr.source_symbol_id
-       WHERE sr.target_symbol_id IS NULL`,
-    ),
-    update: db.prepare('UPDATE symbol_relationships SET target_symbol_id = ? WHERE id = ?'),
-    normalizeTargetName: normalizeTypeName,
-  });
-  resolveByDefinitionPathGeneric(pathToSymbols, {
-    selectUnresolved: db.prepare(
-      `SELECT id, definition_path FROM symbol_relationships WHERE target_symbol_id IS NULL AND definition_path IS NOT NULL`,
+      `SELECT id, definition_path, definition_line
+       FROM symbol_relationships
+       WHERE target_symbol_id IS NULL AND definition_path IS NOT NULL`,
     ),
     update: db.prepare('UPDATE symbol_relationships SET target_symbol_id = ? WHERE id = ?'),
   });
@@ -134,26 +65,12 @@ export function buildCallGraph(db: Database.Database): void {
   resolveSymbolEdges(db);
 }
 
-// ─── Shared lookup maps ───────────────────────────────────────────────────────
+// ─── Lookup map ─────────────────────────────────────────────────────────────
 
-function buildNameMap(db: Database.Database): Map<string, Array<{ id: number; file_id: number }>> {
-  const nameToSymbols = new Map<string, Array<{ id: number; file_id: number }>>();
-  const allSymbols = db
-    .prepare('SELECT id, name, file_id FROM symbols')
-    .all() as Array<{ id: number; name: string; file_id: number }>;
-  for (const row of allSymbols) {
-    let list = nameToSymbols.get(row.name);
-    if (!list) {
-      list = [];
-      nameToSymbols.set(row.name, list);
-    }
-    list.push({ id: row.id, file_id: row.file_id });
-  }
-  return nameToSymbols;
-}
-
-function buildPathMap(db: Database.Database): Map<string, Array<{ id: number; start_line: number }>> {
-  const pathToSymbols = new Map<string, Array<{ id: number; start_line: number }>>();
+function buildPathLineMap(
+  db: Database.Database,
+): Map<string, Array<{ id: number; start_line: number }>> {
+  const map = new Map<string, Array<{ id: number; start_line: number }>>();
   const allSymbols = db
     .prepare(
       `SELECT s.id, s.start_line, f.path
@@ -162,67 +79,41 @@ function buildPathMap(db: Database.Database): Map<string, Array<{ id: number; st
     )
     .all() as Array<{ id: number; start_line: number; path: string }>;
   for (const row of allSymbols) {
-    let list = pathToSymbols.get(row.path);
+    let list = map.get(row.path);
     if (!list) {
       list = [];
-      pathToSymbols.set(row.path, list);
+      map.set(row.path, list);
     }
     list.push({ id: row.id, start_line: row.start_line });
   }
-  return pathToSymbols;
+  return map;
 }
 
-// ─── Generic resolution helpers ─────────────────────────────────────────────
+// ─── Resolution helper ──────────────────────────────────────────────────────
 
 interface ResolutionConfig {
   selectUnresolved: Database.Statement;
   update: Database.Statement;
-  normalizeTargetName?: (raw: string) => string;
 }
 
-function resolveByNameGeneric(
-  nameToSymbols: Map<string, Array<{ id: number; file_id: number }>>,
-  config: ResolutionConfig,
-): void {
-  const unresolved = config.selectUnresolved.all() as Array<{
-    id: number;
-    target_name: string;
-    source_file_id: number;
-  }>;
-
-  const updateMany = () => {
-    for (const ref of unresolved) {
-      let candidates = nameToSymbols.get(ref.target_name);
-      if ((!candidates || candidates.length === 0) && config.normalizeTargetName) {
-        const normalized = config.normalizeTargetName(ref.target_name);
-        if (normalized && normalized !== ref.target_name) {
-          candidates = nameToSymbols.get(normalized);
-        }
-      }
-      if (!candidates || candidates.length === 0) continue;
-
-      const sameFile = candidates.find(c => c.file_id === ref.source_file_id);
-      const best = sameFile ?? candidates[0]!;
-      config.update.run(best.id, ref.id);
-    }
-  };
-
-  updateMany();
-}
-
-function resolveByDefinitionPathGeneric(
-  pathToSymbols: Map<string, Array<{ id: number; start_line: number }>>,
+/**
+ * Resolves unresolved rows by matching `definition_path` + `definition_line`
+ * to the closest symbol (by `start_line`) in the target file.
+ */
+function resolveByDefinitionPath(
+  pathLineMap: Map<string, Array<{ id: number; start_line: number }>>,
   config: ResolutionConfig,
 ): void {
   const unresolved = config.selectUnresolved.all() as Array<{
     id: number;
     definition_path: string;
+    definition_line: number | null;
   }>;
 
   if (unresolved.length === 0) return;
 
   for (const ref of unresolved) {
-    const candidates = pathToSymbols.get(ref.definition_path);
+    const candidates = pathLineMap.get(ref.definition_path);
     if (!candidates || candidates.length === 0) continue;
 
     if (candidates.length === 1) {
@@ -230,8 +121,23 @@ function resolveByDefinitionPathGeneric(
       continue;
     }
 
-    const sorted = [...candidates].sort((a, b) => a.start_line - b.start_line);
-    config.update.run(sorted[0]!.id, ref.id);
+    // When definition_line is available, pick the symbol closest by start_line.
+    // Otherwise fall back to the first symbol in the file (lowest start_line).
+    if (ref.definition_line != null) {
+      let bestId = candidates[0]!.id;
+      let bestDist = Math.abs(candidates[0]!.start_line - ref.definition_line);
+      for (let i = 1; i < candidates.length; i++) {
+        const dist = Math.abs(candidates[i]!.start_line - ref.definition_line);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestId = candidates[i]!.id;
+        }
+      }
+      config.update.run(bestId, ref.id);
+    } else {
+      const sorted = [...candidates].sort((a, b) => a.start_line - b.start_line);
+      config.update.run(sorted[0]!.id, ref.id);
+    }
   }
 }
 

--- a/src/indexer/db.ts
+++ b/src/indexer/db.ts
@@ -87,7 +87,8 @@ CREATE TABLE IF NOT EXISTS symbol_refs (
   resolved_type_signature TEXT,
   resolved_return_type TEXT,
   definition_uri TEXT,
-  definition_path TEXT
+  definition_path TEXT,
+  definition_line INTEGER
 );
 
 -- Semantic relationships between symbols (extends, implements, etc.).
@@ -100,7 +101,8 @@ CREATE TABLE IF NOT EXISTS symbol_relationships (
   relationship_type  TEXT    NOT NULL,
   line               INTEGER NOT NULL,
   definition_uri     TEXT,
-  definition_path    TEXT
+  definition_path    TEXT,
+  definition_line    INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_symbol_rels_source ON symbol_relationships(source_symbol_id);
 CREATE INDEX IF NOT EXISTS idx_symbol_rels_type ON symbol_relationships(relationship_type);
@@ -113,16 +115,15 @@ CREATE TABLE IF NOT EXISTS type_refs (
   symbol_id               INTEGER REFERENCES symbols(id) ON DELETE CASCADE,
   type_id                 INTEGER REFERENCES symbols(id),
   type_name               TEXT    NOT NULL,
-  type_name_bare          TEXT    NOT NULL,
   ref_kind                TEXT    NOT NULL DEFAULT 'other',
   ref_line                INTEGER NOT NULL,
   ref_character           INTEGER,
   resolved_type_signature TEXT,
   definition_uri          TEXT,
-  definition_path         TEXT
+  definition_path         TEXT,
+  definition_line         INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_type_refs_type_name ON type_refs(type_name);
-CREATE INDEX IF NOT EXISTS idx_type_refs_type_name_bare ON type_refs(type_name_bare);
 CREATE INDEX IF NOT EXISTS idx_type_refs_symbol_id ON type_refs(symbol_id);
 CREATE INDEX IF NOT EXISTS idx_type_refs_file_id ON type_refs(file_id);
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -32,7 +32,7 @@ import { inferSeededDocNoteKey, buildDocNoteScope } from './docs.js';
 import { ingestGitHistory } from './git-history.js';
 import { ParserPool } from './parser.js';
 import { ImportResolver } from './resolver.js';
-import { buildCallGraph, resolveSymbolEdges, normalizeTypeName } from './call-graph.js';
+import { buildCallGraph, resolveSymbolEdges } from './call-graph.js';
 import {
   type ExtractionResult,
   type RawCallRef,
@@ -622,12 +622,12 @@ export class IndexBuilder {
 
     // Insert type refs (type_id resolved in resolveSymbolEdges phase)
     const insertTypeRef = db.prepare(
-      `INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line, ref_character)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO type_refs (file_id, symbol_id, type_name, ref_kind, ref_line, ref_character)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     );
     for (const ref of result.typeRefs) {
       const symId = symbolIdMap.get(ref.enclosingSymbol) ?? null;
-      insertTypeRef.run(fileId, symId, ref.typeRaw, normalizeTypeName(ref.typeRaw), ref.refKind, ref.line, ref.character ?? null);
+      insertTypeRef.run(fileId, symId, ref.typeRaw, ref.refKind, ref.line, ref.character ?? null);
     }
   }
 
@@ -965,17 +965,17 @@ export class IndexBuilder {
     );
     const updateCallRef = db.prepare(
       `UPDATE symbol_refs
-       SET resolved_type_signature = ?, resolved_return_type = ?, definition_uri = ?, definition_path = ?
+       SET resolved_type_signature = ?, resolved_return_type = ?, definition_uri = ?, definition_path = ?, definition_line = ?
        WHERE id = ?`,
     );
     const updateTypeRef = db.prepare(
       `UPDATE type_refs
-       SET resolved_type_signature = ?, definition_uri = ?, definition_path = ?
+       SET resolved_type_signature = ?, definition_uri = ?, definition_path = ?, definition_line = ?
        WHERE id = ?`,
     );
     const updateRelationship = db.prepare(
       `UPDATE symbol_relationships
-       SET definition_uri = ?, definition_path = ?
+       SET definition_uri = ?, definition_path = ?, definition_line = ?
        WHERE id = ?`,
     );
 
@@ -1074,6 +1074,7 @@ export class IndexBuilder {
               m.resolvedReturnType,
               m.definitionUri,
               m.definitionPath,
+              m.definitionLine,
               tag.rowId,
             );
             break;
@@ -1082,6 +1083,7 @@ export class IndexBuilder {
               m.resolvedTypeSignature,
               m.definitionUri,
               m.definitionPath,
+              m.definitionLine,
               tag.rowId,
             );
             break;
@@ -1089,6 +1091,7 @@ export class IndexBuilder {
             updateRelationship.run(
               m.definitionUri,
               m.definitionPath,
+              m.definitionLine,
               tag.rowId,
             );
             break;

--- a/src/indexer/lsp/enrichment.ts
+++ b/src/indexer/lsp/enrichment.ts
@@ -8,6 +8,7 @@ export interface ResolvedTypeMetadata {
   resolvedReturnType: string | null;
   definitionUri: string | null;
   definitionPath: string | null;
+  definitionLine: number | null;
 }
 
 export interface LspEnrichmentTarget {
@@ -176,12 +177,13 @@ export function hasResolvedTypeMetadata(metadata: ResolvedTypeMetadata): boolean
 function toResolvedTypeMetadata(hoverResult: unknown, definitionResult: unknown): ResolvedTypeMetadata {
   const resolvedTypeSignature = extractHoverText(hoverResult);
   const resolvedReturnType = extractReturnType(resolvedTypeSignature);
-  const definitionUri = extractDefinitionUri(definitionResult);
+  const defLocation = extractDefinitionLocation(definitionResult);
   return {
     resolvedTypeSignature,
     resolvedReturnType,
-    definitionUri,
-    definitionPath: definitionUriToPath(definitionUri),
+    definitionUri: defLocation.uri,
+    definitionPath: definitionUriToPath(defLocation.uri),
+    definitionLine: defLocation.line,
   };
 }
 
@@ -228,20 +230,50 @@ function extractReturnType(signature: string | null): string | null {
   return null;
 }
 
-function extractDefinitionUri(definitionResult: unknown): string | null {
-  if (!definitionResult) return null;
+interface DefinitionLocation {
+  uri: string | null;
+  line: number | null;
+}
+
+function extractDefinitionLocation(definitionResult: unknown): DefinitionLocation {
+  const empty: DefinitionLocation = { uri: null, line: null };
+  if (!definitionResult) return empty;
 
   if (Array.isArray(definitionResult)) {
     for (const entry of definitionResult) {
-      const uri = extractDefinitionUri(entry);
-      if (uri) return uri;
+      const loc = extractDefinitionLocation(entry);
+      if (loc.uri) return loc;
     }
-    return null;
+    return empty;
   }
 
-  if (!isRecord(definitionResult)) return null;
-  if (typeof definitionResult.uri === 'string') return definitionResult.uri;
-  if (typeof definitionResult.targetUri === 'string') return definitionResult.targetUri;
+  if (!isRecord(definitionResult)) return empty;
+
+  // LocationLink: { targetUri, targetRange, targetSelectionRange }
+  if (typeof definitionResult.targetUri === 'string') {
+    return {
+      uri: definitionResult.targetUri,
+      line: extractStartLine(definitionResult.targetSelectionRange ?? definitionResult.targetRange),
+    };
+  }
+
+  // Location: { uri, range }
+  if (typeof definitionResult.uri === 'string') {
+    return {
+      uri: definitionResult.uri,
+      line: extractStartLine(definitionResult.range),
+    };
+  }
+
+  return empty;
+}
+
+/** Extract 0-based start line from an LSP Range object. */
+function extractStartLine(range: unknown): number | null {
+  if (!isRecord(range)) return null;
+  const start = range.start;
+  if (!isRecord(start)) return null;
+  if (typeof start.line === 'number') return start.line;
   return null;
 }
 

--- a/tests/indexer/call-graph.test.ts
+++ b/tests/indexer/call-graph.test.ts
@@ -1,92 +1,131 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeTypeName } from '../../src/indexer/call-graph.js';
+import { resolveSymbolEdges } from '../../src/indexer/call-graph.js';
+import { openDb } from '../../src/indexer/db.js';
+import type { Database } from '../../src/indexer/db.js';
 
-describe('normalizeTypeName', () => {
-  it('should strip pointer suffix', () => {
-    expect(normalizeTypeName('ZSTD_CCtx*')).toBe('ZSTD_CCtx');
+function createDb(): Database.Database {
+  return openDb(':memory:');
+}
+
+function insertFile(db: Database.Database, path: string, branch = 'main'): number {
+  return Number(
+    db.prepare("INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, ?, 'typescript', 0, NULL, '')")
+      .run(path, branch).lastInsertRowid,
+  );
+}
+
+function insertSymbol(db: Database.Database, fileId: number, name: string, kind = 'function', startLine = 1): number {
+  return Number(
+    db.prepare('INSERT INTO symbols (file_id, name, kind, start_line, end_line, signature) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(fileId, name, kind, startLine, startLine + 5, `${kind} ${name}`).lastInsertRowid,
+  );
+}
+
+describe('resolveSymbolEdges – definition_path + definition_line', () => {
+  it('should resolve type_refs by exact definition_path and definition_line', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const widgetId = insertSymbol(db, fileB, 'Widget', 'struct', 10);
+    insertSymbol(db, fileB, 'Other', 'struct', 20);
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path, definition_line)
+       VALUES (?, 'Widget', 'parameter', 3, '/src/b.ts', 10)`,
+    ).run(fileA);
+
+    resolveSymbolEdges(db);
+
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
+    expect(row.type_id).toBe(widgetId);
   });
 
-  it('should strip const qualifier and pointer', () => {
-    expect(normalizeTypeName('const ZSTD_CCtx*')).toBe('ZSTD_CCtx');
+  it('should pick closest symbol when definition_line does not exactly match start_line', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    insertSymbol(db, fileB, 'Alpha', 'struct', 5);
+    const betaId = insertSymbol(db, fileB, 'Beta', 'struct', 20);
+    insertSymbol(db, fileB, 'Gamma', 'struct', 50);
+
+    // LSP reports line 18 — closest to Beta at line 20
+    db.prepare(
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path, definition_line)
+       VALUES (?, 'Beta', 'variable', 1, '/src/b.ts', 18)`,
+    ).run(fileA);
+
+    resolveSymbolEdges(db);
+
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
+    expect(row.type_id).toBe(betaId);
   });
 
-  it('should strip struct keyword', () => {
-    expect(normalizeTypeName('struct Foo')).toBe('Foo');
+  it('should fall back to first symbol when definition_line is null', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const firstId = insertSymbol(db, fileB, 'First', 'struct', 5);
+    insertSymbol(db, fileB, 'Second', 'struct', 20);
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path)
+       VALUES (?, 'First', 'variable', 1, '/src/b.ts')`,
+    ).run(fileA);
+
+    resolveSymbolEdges(db);
+
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
+    expect(row.type_id).toBe(firstId);
   });
 
-  it('should strip enum keyword', () => {
-    expect(normalizeTypeName('enum Bar')).toBe('Bar');
+  it('should leave type_id null when definition_path is null', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line)
+       VALUES (?, 'Unknown', 'variable', 1)`,
+    ).run(fileA);
+
+    resolveSymbolEdges(db);
+
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
+    expect(row.type_id).toBeNull();
   });
 
-  it('should strip Rust &mut reference', () => {
-    expect(normalizeTypeName('&mut Foo')).toBe('Foo');
+  it('should resolve symbol_refs by definition_path + definition_line', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const callerId = insertSymbol(db, fileA, 'caller');
+    const calleeId = insertSymbol(db, fileB, 'callee', 'function', 15);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, callee_name, call_line, definition_path, definition_line)
+       VALUES (?, 'callee', 10, '/src/b.ts', 15)`,
+    ).run(callerId);
+
+    resolveSymbolEdges(db);
+
+    const row = db.prepare('SELECT callee_id FROM symbol_refs').get() as { callee_id: number | null };
+    expect(row.callee_id).toBe(calleeId);
   });
 
-  it('should strip Rust lifetime annotation', () => {
-    expect(normalizeTypeName("&'a Foo")).toBe('Foo');
-  });
+  it('should resolve symbol_relationships by definition_path + definition_line', () => {
+    const db = createDb();
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const derivedId = insertSymbol(db, fileA, 'Derived', 'class');
+    const baseId = insertSymbol(db, fileB, 'Base', 'class', 10);
 
-  it('should strip Rust static mut lifetime', () => {
-    expect(normalizeTypeName("&'static mut Bar")).toBe('Bar');
-  });
+    db.prepare(
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_name, relationship_type, line, definition_path, definition_line)
+       VALUES (?, ?, 'Base', 'extends', 5, '/src/b.ts', 10)`,
+    ).run(fileA, derivedId);
 
-  it('should truncate at generic args', () => {
-    expect(normalizeTypeName('Vec<MyStruct>')).toBe('Vec');
-  });
+    resolveSymbolEdges(db);
 
-  it('should take last segment after :: for std::vector<int>', () => {
-    expect(normalizeTypeName('std::vector<int>')).toBe('vector');
-  });
-
-  it('should take last segment after :: for crate::types::Foo', () => {
-    expect(normalizeTypeName('crate::types::Foo')).toBe('Foo');
-  });
-
-  it('should take last segment after . for MyModule.MyType', () => {
-    expect(normalizeTypeName('MyModule.MyType')).toBe('MyType');
-  });
-
-  it('should truncate nested generics', () => {
-    expect(normalizeTypeName('Option<Box<MyStruct>>')).toBe('Option');
-  });
-
-  it('should preserve unsigned int (compound C type)', () => {
-    expect(normalizeTypeName('unsigned int')).toBe('unsigned int');
-  });
-
-  it('should preserve int32_t', () => {
-    expect(normalizeTypeName('int32_t')).toBe('int32_t');
-  });
-
-  it('should return empty for empty string', () => {
-    expect(normalizeTypeName('')).toBe('');
-  });
-
-  it('should return bare name unchanged', () => {
-    expect(normalizeTypeName('MyType')).toBe('MyType');
-  });
-
-  it('should handle nested generics A<B<C>>', () => {
-    expect(normalizeTypeName('A<B<C>>')).toBe('A');
-  });
-
-  it('should handle Rust &', () => {
-    expect(normalizeTypeName('&Foo')).toBe('Foo');
-  });
-
-  it('should preserve long long (C compound type)', () => {
-    expect(normalizeTypeName('long long')).toBe('long long');
-  });
-
-  it('should handle C function pointer void (*)(int) → empty', () => {
-    expect(normalizeTypeName('void (*)(int)')).toBe('');
-  });
-
-  it('should strip array suffix', () => {
-    expect(normalizeTypeName('int[]')).toBe('int');
-  });
-
-  it('should strip volatile qualifier', () => {
-    expect(normalizeTypeName('volatile int*')).toBe('int');
+    const row = db.prepare('SELECT target_symbol_id FROM symbol_relationships WHERE file_id = ?').get(fileA) as { target_symbol_id: number | null };
+    expect(row.target_symbol_id).toBe(baseId);
   });
 });

--- a/tests/indexer/db-typerefs.test.ts
+++ b/tests/indexer/db-typerefs.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { openDb } from '../../src/indexer/db.js';
-import { resolveSymbolEdges, normalizeTypeName } from '../../src/indexer/call-graph.js';
+import { resolveSymbolEdges } from '../../src/indexer/call-graph.js';
 import type { Database } from '../../src/indexer/db.js';
 
 function createDb(): Database.Database {
@@ -43,26 +43,25 @@ describe('type_refs table', () => {
     expect(columns).toContain('symbol_id');
     expect(columns).toContain('type_id');
     expect(columns).toContain('type_name');
-    expect(columns).toContain('type_name_bare');
     expect(columns).toContain('ref_kind');
     expect(columns).toContain('ref_line');
     expect(columns).toContain('ref_character');
     expect(columns).toContain('resolved_type_signature');
     expect(columns).toContain('definition_uri');
     expect(columns).toContain('definition_path');
+    expect(columns).toContain('definition_line');
+    expect(columns).not.toContain('type_name_bare');
   });
 
   it('should insert type ref with file_id and null symbol_id for file-scope refs', () => {
-    const bare = normalizeTypeName('MyType');
     db.prepare(
-      'INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, NULL, ?, ?, ?, ?)',
-    ).run(fileId, 'MyType', bare, 'variable', 5);
+      'INSERT INTO type_refs (file_id, symbol_id, type_name, ref_kind, ref_line) VALUES (?, NULL, ?, ?, ?)',
+    ).run(fileId, 'MyType', 'variable', 5);
 
     const row = db.prepare('SELECT * FROM type_refs WHERE file_id = ?').get(fileId) as Record<string, unknown>;
     expect(row).toBeDefined();
     expect(row.symbol_id).toBeNull();
     expect(row.type_name).toBe('MyType');
-    expect(row.type_name_bare).toBe('MyType');
     expect(row.ref_kind).toBe('variable');
     expect(row.ref_line).toBe(5);
   });
@@ -70,30 +69,28 @@ describe('type_refs table', () => {
   it('should insert type ref with symbol_id for function-scoped refs', () => {
     const symId = insertSymbol(db, fileId, 'process');
     db.prepare(
-      'INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(fileId, symId, 'Widget', 'Widget', 'parameter', 3);
+      'INSERT INTO type_refs (file_id, symbol_id, type_name, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
+    ).run(fileId, symId, 'Widget', 'parameter', 3);
 
     const row = db.prepare('SELECT * FROM type_refs WHERE symbol_id = ?').get(symId) as Record<string, unknown>;
     expect(row).toBeDefined();
     expect(row.symbol_id).toBe(symId);
   });
 
-  it('should store both type_name (qualified) and type_name_bare (normalized)', () => {
-    const qualified = 'std::vector<int>';
-    const bare = normalizeTypeName(qualified);
+  it('should store definition_path and definition_line from LSP enrichment', () => {
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, qualified, bare, 'variable', 1);
+      'INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path, definition_line) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(fileId, 'Widget', 'variable', 1, '/src/widget.ts', 10);
 
-    const row = db.prepare('SELECT type_name, type_name_bare FROM type_refs WHERE file_id = ?').get(fileId) as Record<string, unknown>;
-    expect(row.type_name).toBe('std::vector<int>');
-    expect(row.type_name_bare).toBe('vector');
+    const row = db.prepare('SELECT definition_path, definition_line FROM type_refs WHERE file_id = ?').get(fileId) as Record<string, unknown>;
+    expect(row.definition_path).toBe('/src/widget.ts');
+    expect(row.definition_line).toBe(10);
   });
 
   it('should cascade-delete type_refs when file is deleted', () => {
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, 'Foo', 'Foo', 'variable', 1);
+      'INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line) VALUES (?, ?, ?, ?)',
+    ).run(fileId, 'Foo', 'variable', 1);
 
     expect((db.prepare('SELECT COUNT(*) AS c FROM type_refs').get() as { c: number }).c).toBe(1);
     db.prepare('DELETE FROM files WHERE id = ?').run(fileId);
@@ -103,8 +100,8 @@ describe('type_refs table', () => {
   it('should cascade-delete type_refs when enclosing symbol is deleted', () => {
     const symId = insertSymbol(db, fileId, 'fn1');
     db.prepare(
-      'INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(fileId, symId, 'Baz', 'Baz', 'parameter', 2);
+      'INSERT INTO type_refs (file_id, symbol_id, type_name, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
+    ).run(fileId, symId, 'Baz', 'parameter', 2);
 
     expect((db.prepare('SELECT COUNT(*) AS c FROM type_refs').get() as { c: number }).c).toBe(1);
     db.prepare('DELETE FROM symbols WHERE id = ?').run(symId);
@@ -134,6 +131,7 @@ describe('symbol_relationships table', () => {
     expect(columns).toContain('line');
     expect(columns).toContain('definition_uri');
     expect(columns).toContain('definition_path');
+    expect(columns).toContain('definition_line');
   });
 
   it('should insert relationship with file_id and line', () => {
@@ -179,58 +177,49 @@ describe('resolveSymbolEdges', () => {
     db = createDb();
   });
 
-  it('should resolve type_refs.type_id by exact type_name match', () => {
-    const fileId = insertFile(db, 'src/a.ts');
-    const widgetId = insertSymbol(db, fileId, 'Widget', 'struct');
-    const processId = insertSymbol(db, fileId, 'process');
+  it('should resolve type_refs.type_id by definition_path + definition_line', () => {
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const widgetId = insertSymbol(db, fileB, 'Widget', 'struct', 10);
 
     db.prepare(
-      'INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(fileId, processId, 'Widget', 'Widget', 'parameter', 3);
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path, definition_line)
+       VALUES (?, 'Widget', 'parameter', 3, '/src/b.ts', 10)`,
+    ).run(fileA);
 
     resolveSymbolEdges(db);
 
-    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileId) as { type_id: number | null };
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
     expect(row.type_id).toBe(widgetId);
   });
 
-  it('should resolve type_refs.type_id by type_name_bare fallback', () => {
-    const fileId = insertFile(db, 'src/a.ts');
-    const fooId = insertSymbol(db, fileId, 'Foo', 'struct');
+  it('should resolve symbol_relationships.target_symbol_id by definition_path + definition_line', () => {
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const baseId = insertSymbol(db, fileB, 'Base', 'class', 10);
+    const derivedId = insertSymbol(db, fileA, 'Derived', 'class');
 
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, 'crate::types::Foo', 'Foo', 'variable', 1);
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_name, relationship_type, line, definition_path, definition_line)
+       VALUES (?, ?, 'Base', 'extends', 5, '/src/b.ts', 10)`,
+    ).run(fileA, derivedId);
 
     resolveSymbolEdges(db);
 
-    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileId) as { type_id: number | null };
-    expect(row.type_id).toBe(fooId);
-  });
-
-  it('should resolve symbol_relationships.target_symbol_id by name match', () => {
-    const fileId = insertFile(db, 'src/a.ts');
-    const baseId = insertSymbol(db, fileId, 'Base', 'class');
-    const derivedId = insertSymbol(db, fileId, 'Derived', 'class');
-
-    db.prepare(
-      'INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_name, relationship_type, line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, derivedId, 'Base', 'extends', 5);
-
-    resolveSymbolEdges(db);
-
-    const row = db.prepare('SELECT target_symbol_id FROM symbol_relationships WHERE file_id = ?').get(fileId) as { target_symbol_id: number | null };
+    const row = db.prepare('SELECT target_symbol_id FROM symbol_relationships WHERE file_id = ?').get(fileA) as { target_symbol_id: number | null };
     expect(row.target_symbol_id).toBe(baseId);
   });
 
-  it('should resolve symbol_refs.callee_id (backward compat)', () => {
-    const fileId = insertFile(db, 'src/a.ts');
-    const callerId = insertSymbol(db, fileId, 'caller');
-    const calleeId = insertSymbol(db, fileId, 'callee');
+  it('should resolve symbol_refs.callee_id by definition_path + definition_line', () => {
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    const callerId = insertSymbol(db, fileA, 'caller');
+    const calleeId = insertSymbol(db, fileB, 'callee', 'function', 15);
 
     db.prepare(
-      'INSERT INTO symbol_refs (caller_id, callee_name, call_line) VALUES (?, ?, ?)',
-    ).run(callerId, 'callee', 10);
+      `INSERT INTO symbol_refs (caller_id, callee_name, call_line, definition_path, definition_line)
+       VALUES (?, 'callee', 10, '/src/b.ts', 15)`,
+    ).run(callerId);
 
     resolveSymbolEdges(db);
 
@@ -238,35 +227,36 @@ describe('resolveSymbolEdges', () => {
     expect(row.callee_id).toBe(calleeId);
   });
 
-  it('should leave type_id null when type name does not match any symbol', () => {
-    const fileId = insertFile(db, 'src/a.ts');
-    insertSymbol(db, fileId, 'process');
+  it('should leave type_id null when definition_path is not set', () => {
+    const fileA = insertFile(db, '/src/a.ts');
 
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, 'ExternalType', 'ExternalType', 'parameter', 1);
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line)
+       VALUES (?, 'ExternalType', 'parameter', 1)`,
+    ).run(fileA);
 
     resolveSymbolEdges(db);
 
-    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileId) as { type_id: number | null };
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
     expect(row.type_id).toBeNull();
   });
 
-  it('should prefer same-file match when multiple symbols have the same name', () => {
-    const fileA = insertFile(db, 'src/a.ts');
-    const fileB = insertFile(db, 'src/b.ts');
-    const widgetA = insertSymbol(db, fileA, 'Widget', 'struct');
-    const widgetB = insertSymbol(db, fileB, 'Widget', 'struct');
-    const processId = insertSymbol(db, fileA, 'process');
+  it('should pick closest symbol when definition_line is off by a few lines', () => {
+    const fileA = insertFile(db, '/src/a.ts');
+    const fileB = insertFile(db, '/src/b.ts');
+    insertSymbol(db, fileB, 'Alpha', 'struct', 5);
+    const betaId = insertSymbol(db, fileB, 'Beta', 'struct', 20);
+    insertSymbol(db, fileB, 'Gamma', 'struct', 50);
 
     db.prepare(
-      'INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(fileA, processId, 'Widget', 'Widget', 'parameter', 3);
+      `INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, definition_path, definition_line)
+       VALUES (?, 'Beta', 'variable', 1, '/src/b.ts', 18)`,
+    ).run(fileA);
 
     resolveSymbolEdges(db);
 
-    const row = db.prepare('SELECT type_id FROM type_refs WHERE symbol_id = ?').get(processId) as { type_id: number | null };
-    expect(row.type_id).toBe(widgetA);
+    const row = db.prepare('SELECT type_id FROM type_refs WHERE file_id = ?').get(fileA) as { type_id: number | null };
+    expect(row.type_id).toBe(betaId);
   });
 });
 
@@ -282,8 +272,8 @@ describe('stale cleanup for type_refs and symbol_relationships', () => {
   it('should delete type_refs by file_id on re-index', () => {
     const fileId = insertFile(db, 'src/a.ts');
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?)',
-    ).run(fileId, 'OldType', 'OldType', 'variable', 1);
+      'INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line) VALUES (?, ?, ?, ?)',
+    ).run(fileId, 'OldType', 'variable', 1);
 
     // Simulate stale cleanup (as processFile does)
     db.prepare('DELETE FROM type_refs WHERE file_id = ?').run(fileId);
@@ -309,8 +299,8 @@ describe('stale cleanup for type_refs and symbol_relationships', () => {
     const widgetId = insertSymbol(db, fileB, 'Widget', 'struct');
 
     db.prepare(
-      'INSERT INTO type_refs (file_id, type_name, type_name_bare, ref_kind, ref_line, type_id) VALUES (?, ?, ?, ?, ?, ?)',
-    ).run(fileA, 'Widget', 'Widget', 'parameter', 1, widgetId);
+      'INSERT INTO type_refs (file_id, type_name, ref_kind, ref_line, type_id) VALUES (?, ?, ?, ?, ?)',
+    ).run(fileA, 'Widget', 'parameter', 1, widgetId);
 
     // Simulate update() stale cleanup for file B
     db.prepare('UPDATE type_refs SET type_id = NULL WHERE type_id IN (SELECT id FROM symbols WHERE file_id = ?)').run(fileB);
@@ -345,5 +335,27 @@ describe('call_character column on symbol_refs', () => {
     const rows = db.pragma('table_info(symbol_refs)') as Array<{ name: string }>;
     const columns = rows.map(r => r.name);
     expect(columns).toContain('call_character');
+  });
+});
+
+// ─── definition_line columns ──────────────────────────────────────────────────
+
+describe('definition_line columns', () => {
+  it('should exist on symbol_refs', () => {
+    const db = createDb();
+    const rows = db.pragma('table_info(symbol_refs)') as Array<{ name: string }>;
+    expect(rows.map(r => r.name)).toContain('definition_line');
+  });
+
+  it('should exist on type_refs', () => {
+    const db = createDb();
+    const rows = db.pragma('table_info(type_refs)') as Array<{ name: string }>;
+    expect(rows.map(r => r.name)).toContain('definition_line');
+  });
+
+  it('should exist on symbol_relationships', () => {
+    const db = createDb();
+    const rows = db.pragma('table_info(symbol_relationships)') as Array<{ name: string }>;
+    expect(rows.map(r => r.name)).toContain('definition_line');
   });
 });

--- a/tests/indexer/index.test.ts
+++ b/tests/indexer/index.test.ts
@@ -1358,7 +1358,7 @@ describe('IndexBuilder — call graph resolution during indexing', () => {
     vi.resetModules();
     const resolveSymbolEdges = vi.fn();
     const buildCallGraph = vi.fn();
-    vi.doMock('../../src/indexer/call-graph.js', () => ({ buildCallGraph, resolveSymbolEdges, normalizeTypeName: (s: string) => s }));
+    vi.doMock('../../src/indexer/call-graph.js', () => ({ buildCallGraph, resolveSymbolEdges }));
     const { IndexBuilder: MockedIndexBuilder } = await import('../../src/indexer/index.js');
 
     const builder = new MockedIndexBuilder(dbPath, { rootDir: srcDir, branch: 'main' });
@@ -1371,7 +1371,7 @@ describe('IndexBuilder — call graph resolution during indexing', () => {
     vi.resetModules();
     const resolveSymbolEdges = vi.fn();
     const buildCallGraph = vi.fn();
-    vi.doMock('../../src/indexer/call-graph.js', () => ({ buildCallGraph, resolveSymbolEdges, normalizeTypeName: (s: string) => s }));
+    vi.doMock('../../src/indexer/call-graph.js', () => ({ buildCallGraph, resolveSymbolEdges }));
     const { IndexBuilder: MockedIndexBuilder } = await import('../../src/indexer/index.js');
     const builder = new MockedIndexBuilder(dbPath, { rootDir: srcDir, branch: 'main' });
     await builder.build();
@@ -1382,7 +1382,7 @@ describe('IndexBuilder — call graph resolution during indexing', () => {
     expect(resolveSymbolEdges).toHaveBeenCalledTimes(2);
   });
 
-  it('should resolve symbol_refs.callee_id for known symbol names during build()', async () => {
+  it('should resolve symbol_refs.callee_id by definition_path during build()', async () => {
     writeFileSync(srcFile, 'export function target() { return "ok"; }\nexport function caller() { return target(); }\n');
     const builder = new IndexBuilder(dbPath, { rootDir: srcDir, branch: 'main' });
     await builder.build();
@@ -1397,8 +1397,19 @@ describe('IndexBuilder — call graph resolution during indexing', () => {
       )
       .get(srcFile, 'main', 'caller') as { id: number } | undefined;
     expect(caller).toBeDefined();
-    db.prepare('INSERT INTO symbol_refs (caller_id, callee_name, call_line) VALUES (?, ?, ?)')
-      .run(caller!.id, 'target', 1);
+
+    const targetSym = db
+      .prepare(
+        `SELECT s.start_line
+         FROM symbols s
+         JOIN files f ON f.id = s.file_id
+         WHERE f.path = ? AND f.branch = ? AND s.name = ?`,
+      )
+      .get(srcFile, 'main', 'target') as { start_line: number } | undefined;
+    expect(targetSym).toBeDefined();
+
+    db.prepare('INSERT INTO symbol_refs (caller_id, callee_name, call_line, definition_path, definition_line) VALUES (?, ?, ?, ?, ?)')
+      .run(caller!.id, 'target', 1, srcFile, targetSym!.start_line);
 
     buildCallGraph(db);
     const row = db

--- a/tests/indexer/lsp/enrichment.test.ts
+++ b/tests/indexer/lsp/enrichment.test.ts
@@ -75,6 +75,7 @@ describe('LspEnrichmentCoordinator', () => {
       resolvedReturnType: 'string',
       definitionUri,
       definitionPath: join(rootDir, 'defs.ts'),
+      definitionLine: null,
     });
     expect(metadata[1]).toEqual(metadata[0]);
 
@@ -129,12 +130,14 @@ describe('LspEnrichmentCoordinator', () => {
       resolvedReturnType: null,
       definitionUri: firstUri,
       definitionPath: join(rootDir, 'first.ts'),
+      definitionLine: null,
     });
     expect(metadata[1]).toEqual({
       resolvedTypeSignature: 'const value: number',
       resolvedReturnType: 'number',
       definitionUri: null,
       definitionPath: null,
+      definitionLine: null,
     });
 
     rmSync(executableDir, { recursive: true, force: true });
@@ -267,6 +270,7 @@ describe('hasResolvedTypeMetadata', () => {
         resolvedReturnType: null,
         definitionUri: null,
         definitionPath: null,
+        definitionLine: null,
       }),
     ).toBe(false);
   });
@@ -278,6 +282,7 @@ describe('hasResolvedTypeMetadata', () => {
         resolvedReturnType: null,
         definitionUri: null,
         definitionPath: null,
+        definitionLine: null,
       }),
     ).toBe(true);
     expect(
@@ -286,6 +291,7 @@ describe('hasResolvedTypeMetadata', () => {
         resolvedReturnType: 'string',
         definitionUri: null,
         definitionPath: null,
+        definitionLine: null,
       }),
     ).toBe(true);
     expect(
@@ -294,6 +300,7 @@ describe('hasResolvedTypeMetadata', () => {
         resolvedReturnType: null,
         definitionUri: 'file:///tmp/file.ts',
         definitionPath: null,
+        definitionLine: null,
       }),
     ).toBe(true);
     expect(
@@ -302,6 +309,7 @@ describe('hasResolvedTypeMetadata', () => {
         resolvedReturnType: null,
         definitionUri: null,
         definitionPath: '/tmp/file.ts',
+        definitionLine: null,
       }),
     ).toBe(true);
   });

--- a/tests/indexer/lsp/indexing-flow.test.ts
+++ b/tests/indexer/lsp/indexing-flow.test.ts
@@ -72,6 +72,7 @@ describe('IndexBuilder LSP indexing flow', () => {
             resolvedReturnType: 'ResolvedReturnType',
             definitionUri: `file://${defsPath}`,
             definitionPath: defsPath,
+            definitionLine: null,
           }));
         });
 

--- a/tests/lore-server/tools/graph.test.ts
+++ b/tests/lore-server/tools/graph.test.ts
@@ -498,8 +498,8 @@ describe('graph handler – kind=type_dependency', () => {
     symbolId = insertSymbol(db, fileId, 'process');
     const targetId = insertSymbol(db, fileId, 'MyStruct', 'struct');
     db.prepare(
-      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line)
-       VALUES (?, ?, ?, 'MyStruct', 'MyStruct', 'parameter', 5)`,
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, ref_kind, ref_line)
+       VALUES (?, ?, ?, 'MyStruct', 'parameter', 5)`,
     ).run(fileId, symbolId, targetId);
   });
 


### PR DESCRIPTION
## Summary

Replaces all name-based symbol resolution (normalizeTypeName, same-file preference, bare-name fallback) with precise LSP-provided `definition_path` + `definition_line` matching. Since LSP is available for all supported languages, the heuristic fallbacks are unnecessary.

## What changed

### Enrichment (`src/indexer/lsp/enrichment.ts`)
- `ResolvedTypeMetadata` gains `definitionLine: number | null`
- Replaced `extractDefinitionUri()` with `extractDefinitionLocation()` that extracts both URI and start line from LSP `Location` (`{ uri, range }`) and `LocationLink` (`{ targetUri, targetSelectionRange }`) responses

### Schema (`src/indexer/db.ts`)
- **Added** `definition_line INTEGER` to `symbol_refs`, `type_refs`, `symbol_relationships`
- **Removed** `type_name_bare TEXT NOT NULL` column from `type_refs`
- **Removed** `idx_type_refs_type_name_bare` index

### Resolution (`src/indexer/call-graph.ts`)
- **Removed** `normalizeTypeName()` — the entire 7-step regex normalization pipeline
- **Removed** `buildNameMap()`, `resolveByNameGeneric()`, and the `normalizeTargetName` callback
- **Removed** same-file preference heuristic
- `resolveSymbolEdges()` now does a single pass per table using `definition_path` + closest-by-`definition_line` matching
- When `definition_line` is available, picks the symbol with the smallest `|start_line - definition_line|` distance (handles decorator/attribute line offsets between LSP and tree-sitter)
- When `definition_line` is null, falls back to first symbol in file (lowest `start_line`)

### Persistence (`src/indexer/index.ts`)
- Removed `normalizeTypeName` import
- `type_refs` INSERT no longer computes `type_name_bare`
- Enrichment UPDATE statements write `definition_line` for `symbol_refs`, `type_refs`, and `symbol_relationships`

## Why

With LSP mandatory for all supported languages, the multi-tier name-based resolution (exact name → bare name fallback → definition-path) had three problems:

1. **Cross-file ambiguity**: when multiple symbols share a bare name (e.g., `Config` in 5 files), `candidates[0]` was insertion-order-dependent
2. **Unnecessary complexity**: `normalizeTypeName` had 7 regex steps across 12 languages, each a potential source of bugs
3. **Redundancy**: LSP already provides the exact definition location — the name-based passes were doing worse work that the LSP pass would override anyway

## Tests

918 tests passing (net +1 new), 33 skipped. 0 type errors.

- **Removed**: 22 `normalizeTypeName` unit tests
- **Replaced**: name-based resolution tests with `definition_path` + `definition_line` tests
- **Added**: `definition_line` column existence tests, closest-symbol-by-line test, null-definition-path test
- **Updated**: all enrichment test expectations for `definitionLine` field