### PR TITLE
fix(extractors): address type-ref review issues across extractors and indexer

### DIFF
--- a/src/indexer/extractors/cpp.ts
+++ b/src/indexer/extractors/cpp.ts
@@ -114,7 +114,7 @@ export class CppExtractor implements SymbolExtractor {
           break;
         }
         case 'alignof_expression': {
-          extractCppSizeofTypeRef(node, result.typeRefs, 'sizeof');
+          extractCppSizeofTypeRef(node, result.typeRefs, 'other');
           break;
         }
         case 'sizeof_pack_expression': {
@@ -257,7 +257,6 @@ function classifyCallee(
 
   // Field expression:  obj.method(...)  /  ptr->method(...)
   if (fnNode.type === 'field_expression') {
-    const fieldName = fnNode.childForFieldName('field')?.text ?? fnNode.text;
     return { calleeName: fnNode.text, isIndirect: false, callKind: 'direct' };
   }
 

--- a/src/indexer/extractors/csharp.ts
+++ b/src/indexer/extractors/csharp.ts
@@ -260,9 +260,10 @@ function extractCsCastTypeRef(node: Parser.SyntaxNode, refs: RawTypeRef[]): void
 }
 
 function extractCsAsCastTypeRef(node: Parser.SyntaxNode, refs: RawTypeRef[]): void {
-  // expr as Type
-  const typeNode = node.namedChildren.find(c =>
+  // expr as Type — the type is the *last* matching child (first is the expression)
+  const candidates = node.namedChildren.filter(c =>
     c.type === 'identifier' || c.type === 'generic_name' || c.type === 'qualified_name' || c.type === 'nullable_type');
+  const typeNode = candidates[candidates.length - 1];
   if (!typeNode) return;
   const enclosing = findEnclosingSymbolName(node, CS_SYMBOL_NODE_TYPES);
   emitCsTypeRef(refs, enclosing, typeNode, 'cast');

--- a/src/indexer/extractors/dart.ts
+++ b/src/indexer/extractors/dart.ts
@@ -184,12 +184,13 @@ function extractDartInheritance(
 
 function extractDartTypeName(typeNode: Parser.SyntaxNode): string | null {
   if (typeNode.type === 'type_identifier' || typeNode.type === 'identifier') return typeNode.text;
+  if (typeNode.type === 'type_name') return typeNode.text;
   return null;
 }
 
 const emitDartTypeRef = createTypeRefEmitter({
   extractTypeName: extractDartTypeName,
-  genericNodeType: 'type_identifier',
+  genericNodeType: 'type_name',
   argListNodeType: 'type_arguments',
 });
 
@@ -197,8 +198,8 @@ function extractDartFunctionTypeRefs(funcNode: Parser.SyntaxNode, refs: RawTypeR
   const funcName = funcNode.childForFieldName('name')?.text ??
     funcNode.namedChildren.find(c => c.type === 'identifier')?.text ?? '';
   // Return type  
-  const returnType = funcNode.childForFieldName('type') ?? funcNode.namedChildren.find(c => c.type === 'type_identifier');
-  if (returnType && returnType.type === 'type_identifier') {
+  const returnType = funcNode.childForFieldName('type') ?? funcNode.namedChildren.find(c => c.type === 'type_identifier' || c.type === 'type_name');
+  if (returnType) {
     emitDartTypeRef(refs, funcName, returnType, 'return');
   }
   // Parameters

--- a/src/indexer/extractors/java.ts
+++ b/src/indexer/extractors/java.ts
@@ -253,8 +253,6 @@ function extractJavaFieldTypeRefs(classNode: Parser.SyntaxNode, refs: RawTypeRef
 function extractJavaLocalVarTypeRefs(node: Parser.SyntaxNode, refs: RawTypeRef[]): void {
   const typeNode = node.childForFieldName('type');
   if (!typeNode) return;
-  const typeName = extractJavaTypeName(typeNode);
-  if (!typeName) return;
   const enclosing = findEnclosingSymbolName(node, JAVA_SYMBOL_NODE_TYPES);
   emitJavaTypeRef(refs, enclosing, typeNode, 'variable');
 }

--- a/src/indexer/extractors/kotlin.ts
+++ b/src/indexer/extractors/kotlin.ts
@@ -172,17 +172,14 @@ const emitKotlinTypeRef = createTypeRefEmitter({
 function extractKotlinFunctionTypeRefs(funcNode: Parser.SyntaxNode, refs: RawTypeRef[]): void {
   const funcName = funcNode.childForFieldName('name')?.text ??
     funcNode.namedChildren.find(c => c.type === 'simple_identifier')?.text ?? '';
-  // Parameters
+  // Parameters — use emitter so generic args are extracted
   const params = funcNode.namedChildren.find(c => c.type === 'function_value_parameters');
   if (params) {
     for (const param of params.namedChildren) {
       if (param.type === 'parameter') {
         const typeNode = param.childForFieldName('type');
         if (typeNode) {
-          const typeName = extractKotlinTypeName(typeNode);
-          if (typeName) {
-            refs.push({ enclosingSymbol: funcName, typeRaw: typeName, refKind: 'parameter', line: typeNode.startPosition.row, character: typeNode.startPosition.column });
-          }
+          emitKotlinTypeRef(refs, funcName, typeNode, 'parameter');
         }
       }
     }
@@ -192,10 +189,7 @@ function extractKotlinFunctionTypeRefs(funcNode: Parser.SyntaxNode, refs: RawTyp
   const returnType = funcNode.childForFieldName('return_type')
     ?? funcNode.namedChildren.find(c => c.type === 'user_type' && c !== funcNode.childForFieldName('name'));
   if (returnType) {
-    const typeName = extractKotlinTypeName(returnType);
-    if (typeName) {
-      refs.push({ enclosingSymbol: funcName, typeRaw: typeName, refKind: 'return', line: returnType.startPosition.row, character: returnType.startPosition.column });
-    }
+    emitKotlinTypeRef(refs, funcName, returnType, 'return');
   }
 }
 

--- a/src/indexer/extractors/php.ts
+++ b/src/indexer/extractors/php.ts
@@ -13,7 +13,6 @@ import {
   type RawRelationship,
   type RawSymbol,
   type RawTypeRef,
-  type TypeRefKind,
   type SymbolExtractor,
   emptyResult,
   findEnclosingSymbolName,
@@ -69,10 +68,6 @@ export class PhpExtractor implements SymbolExtractor {
         case 'object_creation_expression': {
           const ref = extractNewCallRef(node);
           if (ref) result.callRefs.push(ref);
-          break;
-        }
-        case 'cast_expression': {
-          extractPhpCastTypeRef(node, result.typeRefs);
           break;
         }
       }
@@ -260,23 +255,4 @@ function extractPhpClassFieldTypeRefs(classNode: Parser.SyntaxNode, refs: RawTyp
       }
     }
   }
-}
-
-/** PHP cast types that are always primitives and will never resolve to a user-defined symbol. */
-const PHP_PRIMITIVE_CAST_TYPES = new Set([
-  'int', 'integer', 'float', 'double', 'real',
-  'string', 'binary', 'bool', 'boolean',
-  'array', 'object', 'unset',
-]);
-
-function extractPhpCastTypeRef(node: Parser.SyntaxNode, refs: RawTypeRef[]): void {
-  // (Type)$expr — the cast type is the first child
-  const typeNode = node.childForFieldName('type') ?? node.namedChildren[0];
-  if (!typeNode) return;
-  const typeName = typeNode.text;
-  if (!typeName) return;
-  // PHP casts are always primitives (int, string, etc.) — skip them since they never resolve
-  if (PHP_PRIMITIVE_CAST_TYPES.has(typeName.toLowerCase())) return;
-  const enclosing = findEnclosingSymbolName(node, PHP_SYMBOL_NODE_TYPES);
-  refs.push({ enclosingSymbol: enclosing, typeRaw: typeName, refKind: 'cast', line: typeNode.startPosition.row, character: typeNode.startPosition.column });
 }

--- a/src/indexer/extractors/swift.ts
+++ b/src/indexer/extractors/swift.ts
@@ -198,20 +198,16 @@ const emitSwiftTypeRef = createTypeRefEmitter({
 
 function extractSwiftFunctionTypeRefs(funcNode: Parser.SyntaxNode, refs: RawTypeRef[]): void {
   const funcName = funcNode.childForFieldName('name')?.text ?? '';
-  // Parameters
-  const params = funcNode.namedChildren.find(c => c.type === 'parameter');
-  if (!params) {
-    // Look for parameter clause
-    for (const child of funcNode.namedChildren) {
-      if (child.type === 'function_parameter' || child.type === 'parameter') {
-        const typeAnnotation = child.childForFieldName('type');
-        if (typeAnnotation) emitSwiftTypeRef(refs, funcName, typeAnnotation, 'parameter');
-      }
+  // Parameters — walk all children looking for parameter nodes
+  for (const child of funcNode.namedChildren) {
+    if (child.type === 'function_parameter' || child.type === 'parameter') {
+      const typeAnnotation = child.childForFieldName('type');
+      if (typeAnnotation) emitSwiftTypeRef(refs, funcName, typeAnnotation, 'parameter');
     }
   }
-  // Return type
-  const returnClause = funcNode.namedChildren.find(c => c.type === 'function_result' || c.type === 'type_identifier' || c.type === 'user_type');
-  if (returnClause?.type === 'function_result') {
+  // Return type — only match function_result to avoid grabbing parameter types
+  const returnClause = funcNode.namedChildren.find(c => c.type === 'function_result');
+  if (returnClause) {
     const typeNode = returnClause.namedChildren[0];
     if (typeNode) emitSwiftTypeRef(refs, funcName, typeNode, 'return');
   }

--- a/src/indexer/extractors/types.ts
+++ b/src/indexer/extractors/types.ts
@@ -308,6 +308,34 @@ export function extractGenericTypeArgs(
 }
 
 /**
+ * Unwraps wrapper types (nullable, reference, pointer, array, optional, slice)
+ * to find the inner type node that may carry generic arguments.
+ *
+ * When `extractTypeName` descends through these wrappers internally but
+ * `extractGenericTypeArgs` is called on the outer node, generic args would be
+ * lost because the outer node's type doesn't match `genericNodeType`.
+ */
+const WRAPPER_NODE_TYPES = new Set([
+  'nullable_type',
+  'optional_type',
+  'reference_type',
+  'pointer_type',
+  'slice_type',
+  'array_type',
+]);
+
+function unwrapToGenericNode(node: Parser.SyntaxNode, genericNodeType: string): Parser.SyntaxNode {
+  let current = node;
+  while (WRAPPER_NODE_TYPES.has(current.type) && current.type !== genericNodeType) {
+    const inner = current.namedChildren.find(c =>
+      c.type !== 'mutable_specifier' && c.type !== 'lifetime');
+    if (!inner) break;
+    current = inner;
+  }
+  return current;
+}
+
+/**
  * Creates a type-ref emitter function that encapsulates the standard
  * three-step pattern used by most language extractors:
  *
@@ -352,7 +380,11 @@ export function createTypeRefEmitter(config: {
       line: typeNode.startPosition.row,
       character: typeNode.startPosition.column,
     });
-    const genericArgs = extractGenericTypeArgs(typeNode, genericNodeType, argListNodeType);
+    // Unwrap wrapper types (nullable, optional, reference, etc.) before
+    // checking for generic args — extractTypeName may have already descended
+    // through these wrappers, so the outer node won't match genericNodeType.
+    const innerNode = unwrapToGenericNode(typeNode, genericNodeType);
+    const genericArgs = extractGenericTypeArgs(innerNode, genericNodeType, argListNodeType);
     for (const arg of genericArgs) {
       refs.push({
         enclosingSymbol: enclosing,

--- a/src/indexer/extractors/typescript.ts
+++ b/src/indexer/extractors/typescript.ts
@@ -324,11 +324,20 @@ function extractTsClassInheritanceTypeRefs(classNode: Parser.SyntaxNode, refs: R
   if (!className) return;
   const heritageNode = classNode.namedChildren.find(c => c.type === 'class_heritage');
   if (!heritageNode) return;
+  // extends clause
   const extendsClause = heritageNode.namedChildren.find(c => c.type === 'extends_clause');
-  if (!extendsClause) return;
-  const target = extendsClause.namedChildren[0];
-  if (target) {
-    refs.push({ enclosingSymbol: className, typeRaw: target.text, refKind: 'bound', line: extendsClause.startPosition.row, character: extendsClause.startPosition.column });
+  if (extendsClause) {
+    const target = extendsClause.namedChildren[0];
+    if (target) {
+      refs.push({ enclosingSymbol: className, typeRaw: target.text, refKind: 'bound', line: extendsClause.startPosition.row, character: extendsClause.startPosition.column });
+    }
+  }
+  // implements clause
+  const implementsClause = heritageNode.namedChildren.find(c => c.type === 'implements_clause');
+  if (implementsClause) {
+    for (const child of implementsClause.namedChildren) {
+      refs.push({ enclosingSymbol: className, typeRaw: child.text, refKind: 'bound', line: child.startPosition.row, character: child.startPosition.column });
+    }
   }
 }
 
@@ -359,6 +368,15 @@ function extractTsClassMethodTypeRefs(classNode: Parser.SyntaxNode, refs: RawTyp
 
 function extractTsInterfaceTypeRefs(ifaceNode: Parser.SyntaxNode, refs: RawTypeRef[]): void {
   const name = ifaceNode.childForFieldName('name')?.text ?? '';
+  // Interface extends clause: interface Foo extends Bar, Baz
+  const heritageNode = ifaceNode.namedChildren.find(c => c.type === 'extends_type_clause');
+  if (heritageNode) {
+    for (const child of heritageNode.namedChildren) {
+      if (child.type === 'type_identifier' || child.type === 'generic_type' || child.type === 'nested_type_identifier') {
+        refs.push({ enclosingSymbol: name, typeRaw: child.text, refKind: 'bound', line: child.startPosition.row, character: child.startPosition.column });
+      }
+    }
+  }
   const body = ifaceNode.childForFieldName('body');
   if (!body) return;
   for (const child of body.namedChildren) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -513,6 +513,10 @@ export class IndexBuilder {
       ).run(fileId);
       db.prepare('DELETE FROM symbol_relationships WHERE file_id = ?').run(fileId);
       db.prepare('DELETE FROM type_refs WHERE file_id = ?').run(fileId);
+      // NULL out cross-file FK references that point to symbols in this file
+      db.prepare('UPDATE symbol_refs SET callee_id = NULL WHERE callee_id IN (SELECT id FROM symbols WHERE file_id = ?)').run(fileId);
+      db.prepare('UPDATE type_refs SET type_id = NULL WHERE type_id IN (SELECT id FROM symbols WHERE file_id = ?)').run(fileId);
+      db.prepare('UPDATE symbol_relationships SET target_symbol_id = NULL WHERE target_symbol_id IN (SELECT id FROM symbols WHERE file_id = ?)').run(fileId);
       db.prepare('DELETE FROM symbols WHERE file_id = ?').run(fileId);
       db.prepare('DELETE FROM file_imports WHERE file_id = ?').run(fileId);
       db.prepare('DELETE FROM external_deps WHERE file_id = ?').run(fileId);

--- a/src/lore-server/tools/graph.ts
+++ b/src/lore-server/tools/graph.ts
@@ -81,7 +81,7 @@ export interface GraphArgs {
 }
 
 export interface GraphEdge {
-  source_id: number;
+  source_id: number | null;
   source_name: string;
   source_branch: string;
   target_id: number | null;


### PR DESCRIPTION
## Summary

Addresses all issues identified in the type-refs code review, grouped by severity.

### Critical

- **FK constraint violation in `processFile()`**: Added the same three `UPDATE ... SET ... = NULL` statements (for `symbol_refs.callee_id`, `type_refs.type_id`, `symbol_relationships.target_symbol_id`) before `DELETE FROM symbols` in `processFile()`, matching the `update()` path. Prevents FK constraint crashes during `build()` on codebases with cross-file type references.

### High

- **Swift**: Fixed inverted parameter extraction — removed the `if (!params)` guard that caused parameters to only be extracted when none exist.
- **Kotlin**: Routed function param/return type-refs through `emitKotlinTypeRef` instead of manual `refs.push(...)`, so `extractGenericTypeArgs` is called for generic parameters (e.g. `List<String>` now emits the `generic_arg` for `String`).
- **C#**: Fixed `extractCsAsCastTypeRef` to use the **last** matching child (the type) instead of the first (the expression) for `as` casts.
- **Dart**: Changed `genericNodeType` from `'type_identifier'` (a leaf node) to `'type_name'` so generic type arguments are actually extracted.

### Medium

- **Generic args through wrapper types**: Added `unwrapToGenericNode()` in `createTypeRefEmitter` that descends through nullable/optional/reference/pointer/slice/array wrapper nodes before calling `extractGenericTypeArgs`. Fixes generic arg loss in Kotlin, Swift, C#, Rust, Go, and TypeScript.
- **TypeScript**: Added `bound` type-ref emission for interface `extends` clauses and class `implements` clauses.
- **Swift**: Restricted return type search to `function_result` nodes only, preventing parameter types from being incorrectly matched.
- **Dart**: Removed overly restrictive `type_identifier`-only guard on return types — generic return types (e.g. `Future<Widget>`) are no longer silently skipped.
- **`GraphEdge.source_id`**: Changed type from `number` to `number | null` to match the nullable SQL column.

### Low

- **C++**: Removed unused `fieldName` variable in `classifyCallee`.
- **C++**: Tagged `alignof_expression` as `'other'` instead of `'sizeof'` (no `'alignof'` variant exists in `TypeRefKind`).
- **PHP**: Removed dead `extractPhpCastTypeRef` function and its call site — PHP casts are always primitives and never resolve.
- **Java**: Removed redundant `extractJavaTypeName` guard in `extractJavaLocalVarTypeRefs` (the emitter already handles null).

### Not addressed (noted for follow-up)

- **Kotlin**: First delegation specifier always tagged `extends` even when all supertypes are interfaces — requires semantic analysis to distinguish.
- **No test coverage** for `sizeof` TypeRefKind despite C and C++ extractors emitting it.
- **No end-to-end test** for `processFile` re-index with cross-file resolved refs.

---

**Test results**: 940 passed, 33 skipped (49 test files) ✅  
**TypeScript**: `tsc --noEmit` clean ✅
