### PR TITLE
fix(api): unlimited listFiles default, filtered name resolution, resolved-edge API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,9 @@ export {
   getFileById,
   getFileByPath,
   listFiles,
+  listResolvedEdges,
 } from './lore-server/db.js';
-export type { SymbolRow, FileRow } from './lore-server/db.js';
+export type { SymbolRow, FileRow, ResolvedEdge, ListResolvedEdgesOptions } from './lore-server/db.js';
 
 // ── Logging ───────────────────────────────────────────────────────────────────
 export { LoreLogger, LogLevel, LOG_LEVEL_NAMES, initLogger, getLogger, resetLogger } from './logger.js';

--- a/src/indexer/call-graph.ts
+++ b/src/indexer/call-graph.ts
@@ -250,21 +250,38 @@ function resolveByContainment(
 // ─── Name-based fallback resolution ───────────────────────────────────────────
 
 /**
- * Builds a map from symbol name → array of { id, file_id } for all symbols.
+ * Symbol kinds that should never be resolved across file boundaries via
+ * the `name_unique` tier.  These are common sources of false positive
+ * edges (e.g. `MIN`, `MAX`, `main`) that inflate SCC sizes.
+ */
+const CROSS_FILE_EXCLUDED_KINDS = new Set([
+  'macro',
+  'constant',
+  'enum_member',
+]);
+
+interface NameMapEntry {
+  id: number;
+  file_id: number;
+  kind: string;
+}
+
+/**
+ * Builds a map from symbol name → array of { id, file_id, kind } for all symbols.
  * Used by the name-based fallback pass.
  */
-function buildNameMap(db: Database.Database): Map<string, Array<{ id: number; file_id: number }>> {
-  const nameToSymbols = new Map<string, Array<{ id: number; file_id: number }>>();
+function buildNameMap(db: Database.Database): Map<string, NameMapEntry[]> {
+  const nameToSymbols = new Map<string, NameMapEntry[]>();
   const allSymbols = db
-    .prepare('SELECT id, name, file_id FROM symbols')
-    .all() as Array<{ id: number; name: string; file_id: number }>;
+    .prepare('SELECT id, name, file_id, kind FROM symbols')
+    .all() as Array<{ id: number; name: string; file_id: number; kind: string }>;
   for (const row of allSymbols) {
     let list = nameToSymbols.get(row.name);
     if (!list) {
       list = [];
       nameToSymbols.set(row.name, list);
     }
-    list.push({ id: row.id, file_id: row.file_id });
+    list.push({ id: row.id, file_id: row.file_id, kind: row.kind });
   }
   return nameToSymbols;
 }
@@ -281,13 +298,15 @@ interface NameFallbackConfig {
  * Resolves remaining unresolved refs by name matching with two confidence tiers:
  *
  * - `name_same_file`: target name matches exactly one symbol in the same file
- * - `name_unique`: target name matches exactly one symbol in the entire index
+ * - `name_unique`: target name matches exactly one symbol in the entire index,
+ *   **excluding** macro/constant/enum_member symbols that commonly produce
+ *   false cross-file edges (e.g. `MIN`, `MAX`, `main`).
  *
  * Non-unique cross-file matches are left as `unresolved`.
  */
 function resolveByNameFallback(
   db: Database.Database,
-  nameToSymbols: Map<string, Array<{ id: number; file_id: number }>>,
+  nameToSymbols: Map<string, NameMapEntry[]>,
   config: NameFallbackConfig,
 ): void {
   const unresolved = config.selectUnresolved.all() as Array<{
@@ -323,9 +342,14 @@ function resolveByNameFallback(
       continue;
     }
 
-    // Tier 2: globally unique match (exactly one symbol with this name)
-    if (candidates.length === 1) {
-      updateResolved.run(candidates[0]!.id, 'name_unique' satisfies ResolutionMethod, ref.id);
+    // Tier 2: globally unique match (exactly one symbol with this name).
+    // Filter out macro/constant/enum_member kinds — these cause false
+    // cross-file edges (e.g. MIN, MAX, main in C/C++).
+    const crossFileEligible = candidates.filter(
+      c => !CROSS_FILE_EXCLUDED_KINDS.has(c.kind),
+    );
+    if (crossFileEligible.length === 1) {
+      updateResolved.run(crossFileEligible[0]!.id, 'name_unique' satisfies ResolutionMethod, ref.id);
       continue;
     }
 

--- a/src/lore-server/db.ts
+++ b/src/lore-server/db.ts
@@ -481,12 +481,22 @@ export function getFileByPath(db: Database.Database, path: string, branch?: stri
   return db.prepare('SELECT * FROM files WHERE path = ?').get(path) as FileRow | undefined;
 }
 
-/** Return all indexed files, optionally limited to `limit` rows. */
-export function listFiles(db: Database.Database, limit = 100, branch?: string): FileRow[] {
+/**
+ * Return all indexed files, optionally filtered and paginated.
+ *
+ * By default no row limit is applied — consumers receive the full file list
+ * without needing to know about an internal pagination ceiling.  Pass an
+ * explicit `limit` to cap the result set.
+ */
+export function listFiles(db: Database.Database, limit?: number, branch?: string): FileRow[] {
   if (branch !== undefined) {
-    return db.prepare('SELECT * FROM files WHERE branch = ? LIMIT ?').all(branch, limit) as FileRow[];
+    return limit !== undefined
+      ? db.prepare('SELECT * FROM files WHERE branch = ? LIMIT ?').all(branch, limit) as FileRow[]
+      : db.prepare('SELECT * FROM files WHERE branch = ?').all(branch) as FileRow[];
   }
-  return db.prepare('SELECT * FROM files LIMIT ?').all(limit) as FileRow[];
+  return limit !== undefined
+    ? db.prepare('SELECT * FROM files LIMIT ?').all(limit) as FileRow[]
+    : db.prepare('SELECT * FROM files').all() as FileRow[];
 }
 
 /** Return indexed files matching an exact path or directory prefix. */
@@ -518,6 +528,102 @@ export function listFilesByPathPrefix(
        LIMIT ?`,
     )
     .all(normalized, likePattern, limit) as FileRow[];
+}
+
+// ─── Resolved call-graph edges ────────────────────────────────────────────────
+
+export interface ResolvedEdge {
+  ref_id: number;
+  caller_id: number;
+  caller_name: string;
+  caller_kind: string;
+  caller_file_id: number;
+  caller_file_path: string;
+  callee_id: number | null;
+  callee_name: string;
+  callee_kind: string | null;
+  callee_file_id: number | null;
+  callee_file_path: string | null;
+  call_line: number;
+  call_character: number | null;
+  call_kind: string;
+  resolution_method: string;
+}
+
+export interface ListResolvedEdgesOptions {
+  /** Only include edges where `callee_id` is resolved (non-NULL). Default: false. */
+  resolvedOnly?: boolean;
+  /** Restrict to edges whose caller belongs to this file. */
+  fileId?: number;
+  /** Filter by caller branch. */
+  branch?: string;
+  /** Maximum rows to return. Default: 100 000. */
+  limit?: number;
+}
+
+/**
+ * Returns pre-resolved call-graph edges from `symbol_refs`, joining through
+ * `symbols` and `files` to denormalize caller/callee metadata.
+ *
+ * Consumers get a ready-to-use edge list without needing to re-resolve
+ * `callee_name` by hand.  The query:
+ *
+ *  - Prefers `callee_id` when populated (LSP-resolved or name-resolved)
+ *  - Includes `resolution_method` so callers can filter by confidence
+ *  - Optionally restricts to a single file (file-scoped queries)
+ *  - Defaults to a high limit (100 000) to avoid silent truncation
+ */
+export function listResolvedEdges(
+  db: Database.Database,
+  options: ListResolvedEdgesOptions = {},
+): ResolvedEdge[] {
+  const where: string[] = [];
+  const params: Array<string | number> = [];
+
+  if (options.resolvedOnly) {
+    where.push('sr.callee_id IS NOT NULL');
+  }
+  if (options.fileId !== undefined) {
+    where.push('sr.file_id = ?');
+    params.push(options.fileId);
+  }
+  if (options.branch !== undefined) {
+    where.push('f_caller.branch = ?');
+    params.push(options.branch);
+  }
+
+  const limit = options.limit ?? 100_000;
+  params.push(limit);
+
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+
+  return db
+    .prepare(
+      `SELECT sr.id          AS ref_id,
+              sr.caller_id,
+              s_caller.name  AS caller_name,
+              s_caller.kind  AS caller_kind,
+              s_caller.file_id AS caller_file_id,
+              f_caller.path  AS caller_file_path,
+              sr.callee_id,
+              sr.callee_name,
+              s_callee.kind  AS callee_kind,
+              s_callee.file_id AS callee_file_id,
+              f_callee.path  AS callee_file_path,
+              sr.call_line,
+              sr.call_character,
+              sr.call_kind,
+              sr.resolution_method
+         FROM symbol_refs sr
+         JOIN symbols s_caller  ON s_caller.id = sr.caller_id
+         JOIN files   f_caller  ON f_caller.id = s_caller.file_id
+         LEFT JOIN symbols s_callee ON s_callee.id = sr.callee_id
+         LEFT JOIN files   f_callee ON f_callee.id = s_callee.file_id
+         ${whereClause}
+         ORDER BY sr.caller_id ASC, sr.call_line ASC
+         LIMIT ?`,
+    )
+    .all(...params) as ResolvedEdge[];
 }
 
 // ─── Documentation helpers ─────────────────────────────────────────────────────

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -65,6 +65,10 @@ describe('public API surface', () => {
     expect(publicApi.openReadOnly).toBeDefined();
   });
 
+  it('should export listResolvedEdges for pre-resolved call-graph edges', () => {
+    expect(publicApi.listResolvedEdges).toBeDefined();
+  });
+
   it('should NOT export internal stage helpers', () => {
     expect((publicApi as any).processFile).toBeUndefined();
     expect((publicApi as any).enrichProjectRefs).toBeUndefined();

--- a/tests/indexer/call-graph.test.ts
+++ b/tests/indexer/call-graph.test.ts
@@ -347,6 +347,89 @@ describe('resolveSymbolEdges – name-based fallback', () => {
     expect(ref.resolution_method).toBe('unresolved');
   });
 
+  it('should NOT resolve via name_unique when the sole candidate is a macro', () => {
+    const db = createDb();
+    const file1 = insertFile(db, 'src/main.c');
+    const file2 = insertFile(db, 'src/defs.h');
+
+    // The only symbol named 'MAX' is a macro in another file
+    insertSymbol(db, file2, 'MAX', 'macro', 1, 1);
+
+    const caller = insertSymbol(db, file1, 'compute', 'function', 1, 10);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line) VALUES (?, ?, 'MAX', 5)`,
+    ).run(caller, file1);
+
+    resolveSymbolEdges(db);
+
+    const ref = db.prepare('SELECT callee_id, resolution_method FROM symbol_refs WHERE caller_id = ?').get(caller) as { callee_id: number | null; resolution_method: string };
+    expect(ref.callee_id).toBeNull();
+    expect(ref.resolution_method).toBe('unresolved');
+  });
+
+  it('should NOT resolve via name_unique when the sole candidate is a constant', () => {
+    const db = createDb();
+    const file1 = insertFile(db, 'src/main.c');
+    const file2 = insertFile(db, 'src/constants.c');
+
+    insertSymbol(db, file2, 'MIN_VALUE', 'constant', 1, 1);
+
+    const caller = insertSymbol(db, file1, 'process', 'function', 1, 10);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line) VALUES (?, ?, 'MIN_VALUE', 5)`,
+    ).run(caller, file1);
+
+    resolveSymbolEdges(db);
+
+    const ref = db.prepare('SELECT callee_id, resolution_method FROM symbol_refs WHERE caller_id = ?').get(caller) as { callee_id: number | null; resolution_method: string };
+    expect(ref.callee_id).toBeNull();
+    expect(ref.resolution_method).toBe('unresolved');
+  });
+
+  it('should resolve via name_unique when an eligible non-macro candidate exists after filtering', () => {
+    const db = createDb();
+    const file1 = insertFile(db, 'src/main.c');
+    const file2 = insertFile(db, 'src/utils.c');
+    const file3 = insertFile(db, 'src/defs.h');
+
+    // Two symbols named 'process': one function (eligible), one macro (excluded)
+    const target = insertSymbol(db, file2, 'process', 'function', 1, 10);
+    insertSymbol(db, file3, 'process', 'macro', 1, 1);
+
+    const caller = insertSymbol(db, file1, 'main', 'function', 1, 10);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line) VALUES (?, ?, 'process', 5)`,
+    ).run(caller, file1);
+
+    resolveSymbolEdges(db);
+
+    const ref = db.prepare('SELECT callee_id, resolution_method FROM symbol_refs WHERE caller_id = ?').get(caller) as { callee_id: number | null; resolution_method: string };
+    expect(ref.callee_id).toBe(target);
+    expect(ref.resolution_method).toBe('name_unique');
+  });
+
+  it('should still resolve macro via name_same_file (same-file is not filtered)', () => {
+    const db = createDb();
+    const file1 = insertFile(db, 'src/main.c');
+
+    // Macro in the same file should still be resolved via name_same_file
+    const target = insertSymbol(db, file1, 'MAX', 'macro', 1, 1);
+    const caller = insertSymbol(db, file1, 'compute', 'function', 5, 15);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line) VALUES (?, ?, 'MAX', 7)`,
+    ).run(caller, file1);
+
+    resolveSymbolEdges(db);
+
+    const ref = db.prepare('SELECT callee_id, resolution_method FROM symbol_refs WHERE caller_id = ?').get(caller) as { callee_id: number | null; resolution_method: string };
+    expect(ref.callee_id).toBe(target);
+    expect(ref.resolution_method).toBe('name_same_file');
+  });
+
   it('should resolve type_ref via name_same_file when no LSP data', () => {
     const db = createDb();
     const file1 = insertFile(db, 'src/file1.ts');

--- a/tests/lore-server/db.test.ts
+++ b/tests/lore-server/db.test.ts
@@ -10,6 +10,7 @@ import {
   getFileByPath,
   listFiles,
   listFilesByPathPrefix,
+  listResolvedEdges,
   listDocs,
   getDocByPath,
   listDocSections,
@@ -656,13 +657,13 @@ describe('listFiles', () => {
     insertFile(db, 'c.ts', 'feat');
   });
 
-  it('should return all files when no branch filter', () => {
-    const rows = listFiles(db, 100);
+  it('should return all files when no branch filter (default limit is large)', () => {
+    const rows = listFiles(db);
     expect(rows.length).toBe(3);
   });
 
   it('should filter by branch when branch is provided', () => {
-    const rows = listFiles(db, 100, 'main');
+    const rows = listFiles(db, undefined, 'main');
     expect(rows.length).toBe(2);
     rows.forEach((r) => expect(r.branch).toBe('main'));
   });
@@ -678,7 +679,7 @@ describe('listFiles', () => {
   });
 
   it('should return an empty array when branch has no files', () => {
-    const rows = listFiles(db, 100, 'nonexistent');
+    const rows = listFiles(db, undefined, 'nonexistent');
     expect(rows).toEqual([]);
   });
 });
@@ -718,6 +719,118 @@ describe('listFilesByPathPrefix', () => {
   it('should respect the limit parameter', () => {
     const rows = listFilesByPathPrefix(db, 'src', undefined, 2);
     expect(rows).toHaveLength(2);
+  });
+});
+
+// ─── listResolvedEdges ────────────────────────────────────────────────────────
+
+describe('listResolvedEdges', () => {
+  function createEdgeDb(): Database.Database {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+      CREATE TABLE files (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        path       TEXT    NOT NULL,
+        branch     TEXT    NOT NULL DEFAULT '',
+        language   TEXT    NOT NULL,
+        size_bytes INTEGER NOT NULL DEFAULT 0,
+        last_hash  TEXT,
+        indexed_at INTEGER NOT NULL DEFAULT 0,
+        UNIQUE(path, branch)
+      );
+      CREATE TABLE symbols (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        file_id    INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+        name       TEXT    NOT NULL,
+        kind       TEXT    NOT NULL,
+        start_line INTEGER NOT NULL,
+        end_line   INTEGER NOT NULL,
+        signature  TEXT,
+        doc_comment TEXT
+      );
+      CREATE TABLE symbol_refs (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        caller_id           INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+        file_id             INTEGER REFERENCES files(id) ON DELETE CASCADE,
+        callee_id           INTEGER REFERENCES symbols(id),
+        callee_name         TEXT    NOT NULL,
+        call_line           INTEGER NOT NULL,
+        call_character      INTEGER,
+        call_kind           TEXT    NOT NULL DEFAULT 'direct',
+        resolution_method   TEXT    NOT NULL DEFAULT 'unresolved'
+      );
+    `);
+    return db;
+  }
+
+  let db: Database.Database;
+  let fileA: number;
+  let fileB: number;
+  let callerSym: number;
+  let calleeSym: number;
+
+  beforeEach(() => {
+    db = createEdgeDb();
+    fileA = Number(db.prepare("INSERT INTO files (path, branch, language) VALUES ('src/a.ts', 'main', 'typescript')").run().lastInsertRowid);
+    fileB = Number(db.prepare("INSERT INTO files (path, branch, language) VALUES ('src/b.ts', 'main', 'typescript')").run().lastInsertRowid);
+    callerSym = Number(db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'doWork', 'function', 1, 20)").run(fileA).lastInsertRowid);
+    calleeSym = Number(db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'helper', 'function', 1, 10)").run(fileB).lastInsertRowid);
+
+    // Resolved edge
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, call_kind, resolution_method)
+       VALUES (?, ?, ?, 'helper', 5, 'direct', 'lsp_definition')`,
+    ).run(callerSym, fileA, calleeSym);
+
+    // Unresolved edge
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line, call_kind, resolution_method)
+       VALUES (?, ?, 'unknown', 12, 'direct', 'unresolved')`,
+    ).run(callerSym, fileA);
+  });
+
+  it('should return all edges by default', () => {
+    const edges = listResolvedEdges(db);
+    expect(edges).toHaveLength(2);
+    expect(edges[0]!.caller_name).toBe('doWork');
+    expect(edges[0]!.callee_id).toBe(calleeSym);
+    expect(edges[0]!.callee_file_path).toBe('src/b.ts');
+    expect(edges[1]!.callee_id).toBeNull();
+  });
+
+  it('should filter to resolved-only edges', () => {
+    const edges = listResolvedEdges(db, { resolvedOnly: true });
+    expect(edges).toHaveLength(1);
+    expect(edges[0]!.resolution_method).toBe('lsp_definition');
+    expect(edges[0]!.callee_name).toBe('helper');
+  });
+
+  it('should filter by file_id', () => {
+    // Add an edge from fileB so there's something to exclude
+    const sym2 = Number(db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'other', 'function', 1, 5)").run(fileB).lastInsertRowid);
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line, call_kind, resolution_method)
+       VALUES (?, ?, 'doWork', 3, 'direct', 'unresolved')`,
+    ).run(sym2, fileB);
+
+    const edgesA = listResolvedEdges(db, { fileId: fileA });
+    expect(edgesA).toHaveLength(2);
+    expect(edgesA.every(e => e.caller_file_id === fileA)).toBe(true);
+
+    const edgesB = listResolvedEdges(db, { fileId: fileB });
+    expect(edgesB).toHaveLength(1);
+    expect(edgesB[0]!.caller_name).toBe('other');
+  });
+
+  it('should respect the limit parameter', () => {
+    const edges = listResolvedEdges(db, { limit: 1 });
+    expect(edges).toHaveLength(1);
+  });
+
+  it('should return empty for non-existent fileId', () => {
+    const edges = listResolvedEdges(db, { fileId: 9999 });
+    expect(edges).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Consumer audit fixes (Lore-owned)

Addresses the Lore-owned items from a consumer audit of the indexer/DB API.

### Changes

**1. `listFiles` default limit → unlimited**
- Removed the hardcoded `limit=100` default that silently truncated results
- `LIMIT` clause is now only added when the caller passes an explicit `limit`
- Consumers no longer need to know about an internal pagination ceiling

**2. Macro/constant filtering in `name_unique` resolution**
- Added `CROSS_FILE_EXCLUDED_KINDS` set (`macro`, `constant`, `enum_member`)
- The `name_unique` cross-file resolution tier now filters out these kinds before resolving
- Prevents false cycle edges from symbols like `MIN`, `MAX`, `main` in C/C++ and other languages
- Same-file resolution (`name_same_file`) is unaffected — macros in the same file still resolve correctly

**3. `symbol_refs.file_id` denormalization**
- Already present in DDL, enrichment migration, indexed, and populated during source indexing — no changes needed

**4. `listResolvedEdges()` API**
- New function returning pre-resolved call-graph edges with full caller/callee metadata
- Supports `resolvedOnly`, `fileId`, `branch`, and `limit` filters
- Consumers get ready-to-use edges without re-resolving `callee_name` by hand
- Exported from public API with `ResolvedEdge` and `ListResolvedEdgesOptions` types

### Testing
- 4 new tests for macro/constant cross-file filtering
- 5 new tests for `listResolvedEdges`
- 1 new API surface assertion
- All 166 tests pass