### PR TITLE
fix: ensure child processes are cleaned up when lore is killed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
   resolveEffectiveLspSettings,
 } from './indexer/lsp/config.js';
 import { initLogger, LogLevel, LOG_LEVEL_NAMES } from './logger.js';
+import { killAllTracked } from './process-tracker.js';
 import { LoreRuntime } from './runtime.js';
 
 // ─── Argument helpers ─────────────────────────────────────────────────────────
@@ -132,6 +133,12 @@ async function main(): Promise<void> {
       ? dbPathForLog.replace(/\.[^.]+$/, '.log')
       : undefined);
   const log = initLogger({ level: resolvedLogLevel, logFile: resolvedLogFile });
+
+  // Safety-net: kill tracked child processes (Python embedder, LSP servers)
+  // when the process exits for any reason. Sub-commands that create a
+  // LoreRuntime install their own signal handlers with graceful shutdown;
+  // this covers one-shot flows (index, refresh) where no runtime exists.
+  process.once('exit', () => killAllTracked());
 
   if (subcommand === 'index') {
     const rootDir = flag(args, '--root');

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,3 +80,6 @@ export type { SymbolRow, FileRow, ResolvedEdge, ListResolvedEdgesOptions } from 
 // ── Logging ───────────────────────────────────────────────────────────────────
 export { LoreLogger, LogLevel, LOG_LEVEL_NAMES, initLogger, getLogger, resetLogger } from './logger.js';
 export type { LoreLoggerOptions, LogEntry, ToolCallFields, StartupFields } from './logger.js';
+
+// ── Process lifecycle ─────────────────────────────────────────────────────────
+export { trackProcess, untrackProcess, killAllTracked, trackedCount } from './process-tracker.js';

--- a/src/indexer/embedder.ts
+++ b/src/indexer/embedder.ts
@@ -12,6 +12,7 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import * as readline from 'node:readline';
+import { trackProcess } from '../process-tracker.js';
 
 // ─── Public interface ─────────────────────────────────────────────────────────
 
@@ -189,6 +190,7 @@ export class SentenceTransformersProvider implements EmbeddingProvider {
     this.proc = spawn(this.pythonBin, ['-c', BOOTSTRAP_SCRIPT, this.modelName], {
       stdio: ['pipe', 'pipe', 'inherit'],
     });
+    trackProcess(this.proc);
 
     this.rl = readline.createInterface({ input: this.proc.stdout! });
 

--- a/src/indexer/lsp/client.ts
+++ b/src/indexer/lsp/client.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { trackProcess } from '../../process-tracker.js';
 
 interface JsonRpcRequest {
   jsonrpc: '2.0';
@@ -96,6 +97,7 @@ export class LspClient {
       env: this.options.processEnv ?? process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     }) as ChildProcessWithoutNullStreams;
+    trackProcess(child);
 
     this.child = child;
     this.started = true;

--- a/src/process-tracker.ts
+++ b/src/process-tracker.ts
@@ -1,0 +1,57 @@
+/**
+ * @module process-tracker
+ *
+ * Global registry of spawned child processes.
+ *
+ * Long-lived subprocess owners (embedder, LSP clients) call `trackProcess()`
+ * after spawning, and `untrackProcess()` (or rely on the automatic `exit`
+ * listener) when the child terminates.
+ *
+ * On `SIGINT` / `SIGTERM`, `killAllTracked()` sends `SIGTERM` to every live
+ * child so that Python sub-interpreters, language servers, etc. are never
+ * orphaned — even if the async `dispose()` paths are interrupted.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+
+const tracked = new Set<ChildProcess>();
+
+/**
+ * Register a child process for cleanup-on-exit tracking.
+ *
+ * An `'exit'` listener is installed automatically so the process is removed
+ * from the set once it terminates.
+ */
+export function trackProcess(proc: ChildProcess): void {
+  tracked.add(proc);
+  proc.once('exit', () => {
+    tracked.delete(proc);
+  });
+}
+
+/** Explicitly remove a process from tracking (e.g. after a graceful close). */
+export function untrackProcess(proc: ChildProcess): void {
+  tracked.delete(proc);
+}
+
+/**
+ * Send `SIGTERM` to every tracked child process and clear the set.
+ *
+ * This is intentionally synchronous so it can be called from signal handlers
+ * and the `process.on('exit')` hook.
+ */
+export function killAllTracked(): void {
+  for (const proc of tracked) {
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      /* already exited — ignore */
+    }
+  }
+  tracked.clear();
+}
+
+/** Number of processes currently tracked (exposed for tests). */
+export function trackedCount(): number {
+  return tracked.size;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,6 +15,7 @@ import type { EmbeddingProvider } from './indexer/embedder.js';
 import type { EffectiveLspSettings } from './indexer/lsp/config.js';
 import type { WalkerConfig } from './indexer/walker.js';
 import { getLogger, type LoreLogger } from './logger.js';
+import { killAllTracked } from './process-tracker.js';
 
 // ─── RuntimeConfig ────────────────────────────────────────────────────────────
 
@@ -188,25 +189,38 @@ export class LoreRuntime {
   }
 
   /**
-   * Register process-level signal handlers (`SIGINT`, `SIGTERM`) that call
-   * `shutdown()` and exit. Convenience for CLI entry points.
+   * Register process-level signal handlers (`SIGINT`, `SIGTERM`) that
+   * gracefully tear down all managed resources before exiting.
+   *
+   * A second signal while shutdown is in progress forces an immediate exit.
+   * As a safety net, `killAllTracked()` runs synchronously on the `exit`
+   * event to SIGTERM any child processes that slipped past the async path
+   * (e.g. LSP servers spawned by an in-flight pipeline stage).
    */
   installSignalHandlers(): void {
+    let shuttingDown = false;
+
     const handler = () => {
-      // Stop refresher synchronously to match CLI expectations.
-      if (this._refresher) {
-        this._refresher.stop();
-        this._refresher = null;
+      if (shuttingDown) {
+        // Second signal — force-kill children and bail.
+        killAllTracked();
+        process.exit(1);
       }
-      // Dispose embedder best-effort in background, then exit.
-      if (this._embedder) {
-        this._embedder.dispose().catch(() => { /* best-effort */ });
-        this._embedder = null;
-      }
-      this._started = false;
-      process.exit(0);
+      shuttingDown = true;
+
+      this.shutdown()
+        .catch(() => { /* best-effort */ })
+        .finally(() => {
+          killAllTracked();
+          process.exit(0);
+        });
     };
+
     process.on('SIGINT', handler);
     process.on('SIGTERM', handler);
+
+    // Last-resort: kill any children that are still alive when the
+    // process is about to exit (covers unexpected exits / unhandled errors).
+    process.once('exit', () => killAllTracked());
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1001,7 +1001,7 @@ describe('cli', () => {
 
       // Clean up: trigger the registered SIGINT handler to stop the watcher.
       process.emit('SIGINT');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
 
     it('should NOT immediately exit when watch mode starts (process stays alive)', async () => {
@@ -1022,7 +1022,7 @@ describe('cli', () => {
       await waitForStderr(stderrSpy, 'watch mode started');
 
       process.emit('SIGINT');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
 
     it('should call process.exit(0) when SIGTERM is received', async () => {
@@ -1031,7 +1031,7 @@ describe('cli', () => {
       await waitForStderr(stderrSpy, 'watch mode started');
 
       process.emit('SIGTERM');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
   });
 
@@ -1054,7 +1054,7 @@ describe('cli', () => {
       expect(parsed.rootDir).toBe(tmpDir);
 
       process.emit('SIGINT');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
 
     it('should NOT immediately exit when poll mode starts (process stays alive)', async () => {
@@ -1073,7 +1073,7 @@ describe('cli', () => {
       await waitForStderr(stderrSpy, 'poll mode started');
 
       process.emit('SIGINT');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
 
     it('should call process.exit(0) when SIGTERM is received', async () => {
@@ -1082,7 +1082,7 @@ describe('cli', () => {
       await waitForStderr(stderrSpy, 'poll mode started');
 
       process.emit('SIGTERM');
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
   });
 });

--- a/tests/process-tracker.test.ts
+++ b/tests/process-tracker.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import {
+  trackProcess,
+  untrackProcess,
+  killAllTracked,
+  trackedCount,
+} from '../src/process-tracker.js';
+
+describe('process-tracker', () => {
+  // Clean slate before each test so leaked tracked processes in one test
+  // don't affect another.
+  beforeEach(() => {
+    killAllTracked();
+  });
+
+  it('trackProcess increases the tracked count', () => {
+    const child = spawn('sleep', ['60']);
+    expect(trackedCount()).toBe(0);
+    trackProcess(child);
+    expect(trackedCount()).toBe(1);
+    child.kill();
+  });
+
+  it('untrackProcess removes a tracked process', () => {
+    const child = spawn('sleep', ['60']);
+    trackProcess(child);
+    expect(trackedCount()).toBe(1);
+    untrackProcess(child);
+    expect(trackedCount()).toBe(0);
+    child.kill();
+  });
+
+  it('auto-untrack on exit removes the process from the set', async () => {
+    // Spawn a short-lived command so we can wait for exit.
+    const child = spawn('true');
+    trackProcess(child);
+    expect(trackedCount()).toBe(1);
+
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    expect(trackedCount()).toBe(0);
+  });
+
+  it('killAllTracked sends SIGTERM to all tracked processes', async () => {
+    const a = spawn('sleep', ['60']);
+    const b = spawn('sleep', ['60']);
+    trackProcess(a);
+    trackProcess(b);
+    expect(trackedCount()).toBe(2);
+
+    killAllTracked();
+    expect(trackedCount()).toBe(0);
+
+    // Both should eventually exit.
+    await Promise.all([
+      new Promise<void>((resolve) => a.once('exit', () => resolve())),
+      new Promise<void>((resolve) => b.once('exit', () => resolve())),
+    ]);
+  });
+
+  it('killAllTracked is safe to call with no tracked processes', () => {
+    expect(trackedCount()).toBe(0);
+    killAllTracked(); // should not throw
+    expect(trackedCount()).toBe(0);
+  });
+
+  it('killAllTracked is safe to call when a process already exited', async () => {
+    const child = spawn('true');
+    trackProcess(child);
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    // Process already exited and auto-untracked.
+    expect(trackedCount()).toBe(0);
+    killAllTracked(); // should not throw
+  });
+});


### PR DESCRIPTION
## Problem

When Lore receives SIGINT/SIGTERM, the signal handler in `installSignalHandlers()` called `process.exit(0)` **synchronously** without awaiting the embedder's async `dispose()`. This left the Python embedding subprocess (and any LSP servers spawned by in-flight pipeline stages) as orphaned processes.

## Solution

### New module: `src/process-tracker.ts`

A lightweight global registry that tracks every spawned child process. `killAllTracked()` sends SIGTERM to all of them synchronously — safe for use in signal and `exit` event handlers.

### Changes

- **`embedder.ts` + `lsp/client.ts`**: Call `trackProcess()` after every `spawn()` so the tracker knows about Python and LSP server processes. Processes auto-untrack when they exit.
- **`runtime.ts` `installSignalHandlers()`**: Now **awaits `shutdown()`** (which properly disposes the embedder with its 5s graceful timeout and stops the refresher) before calling `process.exit()`. A second signal force-exits immediately. `killAllTracked()` runs as a last-resort safety net on the process `exit` event.
- **`cli.ts`**: Registers `process.once('exit', killAllTracked)` covering one-shot subcommands (`index`, `refresh`) that don't create a `LoreRuntime`.
- **`index.ts`**: Exports the process tracker API for library consumers.

### Tests

- Updated CLI signal-handler tests to `await` the now-async exit via `vi.waitFor()`.
- Added `tests/process-tracker.test.ts` with 6 tests covering track/untrack/auto-cleanup/killAll.

All 1385 tests pass.