### PR TITLE
chore: release v0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ await builder.build();
 | `lore_notes_write` | Upsert agent-authored notes by key and scope, with optional source hash for staleness tracking |
 | `lore_notes_read` | Read notes by exact key or key prefix with scope-aware staleness metadata |
 | `lore_architecture` | Build a component-level architecture view with edges, entry/leaf nodes, and external dependency usage |
-| `lore_graph` | Query call/import/module/inheritance/type-dependency edges; call edges include `callee_coverage_percent` |
+| `lore_graph` | Query call/import/module/inheritance/type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries; call edges include `callee_coverage_percent` |
 | `lore_snippet` | Return snippets from indexed source snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata (name, kind, start/end lines) when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |
 | `lore_blame` | Query blame, line-range history, or ownership aggregates with optional symbol targeting, commit-context enrichment, and risk signals |
@@ -588,24 +588,22 @@ CI publish flow:
 - Ensure publish jobs expose that secret as the `NODE_AUTH_TOKEN` environment
   variable before running `npm publish`.
 
-## Release publish workflow (`@jafreck/lore@0.3.0`)
+## Release publish workflow
 
-Publishing is automated by `.github/workflows/publish.yml`. Creating a version
-tag (for example, `v0.3.0`) or publishing a GitHub Release triggers the npm
-publish job.
+Publishing is automated by `.github/workflows/publish.yml`. Publishing a
+GitHub Release triggers the npm publish job.
 
-Release steps for `@jafreck/lore@0.3.0`:
+Release steps:
 
-1. Ensure `package.json` has `"version": "0.3.0"`.
-2. Push the tag: `git tag v0.3.0 && git push origin v0.3.0` (or publish a
-   GitHub Release for `v0.3.0`).
+1. Ensure `package.json` has the target version.
+2. Publish a GitHub Release with the matching `vX.Y.Z` tag.
 3. Confirm the workflow logs show `npm publish --dry-run` output before the
    live `npm publish` step.
 
 Post-publish verification:
 
-- Check the package metadata: `npm view @jafreck/lore version` returns `0.3.0`.
-- Confirm installability: `npm view @jafreck/lore@0.3.0 name version`.
+- Check the package metadata: `npm view @jafreck/lore version`.
+- Confirm installability: `npm view @jafreck/lore@<version> name version`.
 
 ## Benchmarking index performance (500+ file repos)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,6 +175,7 @@ during the LSP enrichment stage.
 | `docs.ts` | Discovers docs from default/configured globs, infers kind/title, chunks by heading hierarchy |
 | `coverage.ts` | Parses LCOV/Cobertura reports, normalizes per-file/per-line hit data, persists runs linked to commit SHA/source mtime |
 | `embedder.ts` | Optional — spawns a Python subprocess running sentence-transformers; async initialization with `EmbedderRef` so MCP starts immediately |
+| `process-tracker.ts` | Global registry of spawned child processes; `killAllTracked()` ensures cleanup on SIGINT/SIGTERM/exit |
 | `git-history.ts` | Ingests commits, per-file diffs, and branch/tag refs via `simple-git` |
 | `resolution-method.ts` | Authoritative taxonomy for `resolution_method` column values shared by writers and readers |
 
@@ -242,7 +243,7 @@ Key optimizations in the indexing pipeline (v0.3.0):
 | `lore_routes` | Query extracted API routes/endpoints with optional method, path prefix, and framework filters |
 | `lore_notes_read` / `lore_notes_write` | Persist notes and read note freshness metadata (`source_hash_mismatch`, `doc_missing`, etc.) |
 | `lore_architecture` | Build a component-level architecture view with edges, entry/leaf nodes, and external dependency usage |
-| `lore_graph` | Query call, import, module, inheritance, or type-dependency edges (`call` edges include `callee_coverage_percent`) |
+| `lore_graph` | Query call, import, module, inheritance, or type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries (`call` edges include `callee_coverage_percent`) |
 | `lore_snippet` | Return snippets from indexed DB-backed file snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |
 | `lore_blame` | Query blame (`mode: "blame"`), line-range evolution (`mode: "history"`), or ownership aggregates (`mode: "ownership"`), including symbol-targeted range resolution |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jafreck/lore",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@elm-tooling/tree-sitter-elm": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Language-aware codebase indexer — tree-sitter parsing, symbol extraction, call-graph construction, and optional embeddings for semantic search",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.3.3

**Version bump:** 0.3.2 → 0.3.3
**Compare range:** [`v0.3.2...release/v0.3.3`](https://github.com/jafreck/Lore/compare/v0.3.2...release/v0.3.3)

### Key changes since v0.3.2

#### Features
- **`target_id` for reverse graph queries** (#151) — `lore_graph` now supports `target_id` for inbound/reverse edge queries across all five graph kinds (call, import, module, inheritance, type_dependency). Enables "who calls X?" and "what depends on X?" questions.

#### Fixes
- **Comprehensive parsing audit — 18 bug fixes** (#148) — Fixed `SYMBOL_NODE_TYPES` completeness in 12 extractors, added missing C++ extraction patterns, eliminated empty-name symbol leaks in 6 extractors, added pipeline-level empty-name guard. Grammar hardening: swapped incompatible `nan`-based grammars for Lua/Zig/Elm, added ESM-only grammar fallback, Zig extractor dual-grammar support.
- **Child process cleanup on kill** (#156) — New `process-tracker` module ensures Python embedding subprocesses and LSP servers are cleaned up on SIGINT/SIGTERM. Signal handler now awaits async `shutdown()` before exiting.

#### Internal
- **Dart support removed** (#148, #150) — No compatible tree-sitter grammar exists for Dart; extractor, LSP entry, fixtures, and tests removed. Language count: 24 → 23.
- **LSP smoke test coverage** (#150) — Real-server smoke tests for TypeScript and Pyright LSPs, including CI execution.
- **Test hardening** (#148) — Removed all `test.skipIf(!result)` patterns; 1,385 tests pass with 0 skipped (excluding LSP smoke).
- **Copilot release draft skill** added.

### Docs refreshed
- **README.md** — Updated `lore_graph` tool description to mention `target_id` for reverse queries; generalized release publish workflow section (removed hardcoded v0.3.0 references).
- **docs/architecture.md** — Updated `lore_graph` tool description; added `process-tracker.ts` to supporting modules table.

### Validation
- Build: ✅ `tsc` clean
- Tests: ✅ 1,385 passed, 0 failures