### PR TITLE
chore: release v0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,13 +378,14 @@ npx @jafreck/lore ingest-coverage --db ./lore.db --root ./my-project \
 
 ### Embeddings
 
-Lore optionally generates dense vector embeddings for semantic search using a
-sentence-transformers model. The embedding model is downloaded and managed
-automatically — specify it with `--embedding-model`:
+Lore optionally generates dense vector embeddings for semantic search using
+`@huggingface/transformers` (Transformers.js), which runs ONNX models natively
+in Node.js — no Python or external processes required. Specify the model with
+`--embedding-model`:
 
 ```bash
 npx @jafreck/lore index --root ./my-project --db ./lore.db \
-  --embedding-model 'Qwen/Qwen3-Embedding-4B'
+  --embedding-model 'nomic-ai/nomic-embed-text-v1.5'
 ```
 
 At query time, `lore_search` in `semantic` or `fused` mode embeds the query

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart LR
         DOCNOTES[Doc Note Seeding<br/>README · architecture · ADR]
         LSP[LSP Enrichment<br/>batch-pipelined hover + definition<br/>persisted metadata]
         COVER[Coverage Ingest<br/>LCOV · Cobertura]
-        EMBED[Embedder<br/>sentence-transformers<br/>async init · overlapped batches]
+        EMBED[Embedder<br/>Transformers.js ONNX<br/>async init · overlapped batches]
         GITHIST[Git History Ingest<br/>commits · diffs · refs]
     end
 
@@ -174,7 +174,7 @@ during the LSP enrichment stage.
 | `call-graph.ts` | 3-tier symbol resolution with LSP-first ref resolution and name-based fallback; supports topo sort and cycle detection |
 | `docs.ts` | Discovers docs from default/configured globs, infers kind/title, chunks by heading hierarchy |
 | `coverage.ts` | Parses LCOV/Cobertura reports, normalizes per-file/per-line hit data, persists runs linked to commit SHA/source mtime |
-| `embedder.ts` | Optional — spawns a Python subprocess running sentence-transformers; async initialization with `EmbedderRef` so MCP starts immediately |
+| `embedder.ts` | Optional — uses `@huggingface/transformers` (Transformers.js) to run ONNX embedding models natively in Node.js; async initialization so MCP starts immediately |
 | `process-tracker.ts` | Global registry of spawned child processes; `killAllTracked()` ensures cleanup on SIGINT/SIGTERM/exit |
 | `git-history.ts` | Ingests commits, per-file diffs, and branch/tag refs via `simple-git` |
 | `resolution-method.ts` | Authoritative taxonomy for `resolution_method` column values shared by writers and readers |

--- a/docs/benchmark-plan.md
+++ b/docs/benchmark-plan.md
@@ -1,0 +1,756 @@
+# Lore Benchmark Plan
+
+Measure Lore's causal impact on agent performance on real large-codebase tasks.
+
+Primary question:
+
+- Does Lore improve agent success, speed, cost, and navigation efficiency versus non-Lore baselines?
+
+Secondary questions:
+
+- Which task families benefit most?
+- Which Lore capabilities are most associated with gains?
+- Which repo characteristics correlate with larger gains?
+
+---
+
+## Core evaluation principle
+
+Run the same tasks on the same repos with the same agent configuration under different retrieval conditions.
+
+## Comparison arms
+
+### Required arms
+
+1. **Control**
+   - Agent has standard local repo tools only:
+     - file read
+     - grep/text search
+     - directory listing
+     - terminal/test execution as allowed
+   - No Lore tools.
+   - Stub tool entries matching Lore tool names are registered but return `"not available in this configuration"` — this equalizes tool-description prompting across arms so that tool names like `lore_graph` or `lore_test_map` do not implicitly steer reasoning in the Lore arm only.
+
+2. **Semantic baseline**
+   - Same tools as Control.
+   - Generic embedding-based code search over file chunks (e.g., FAISS index built from overlapping ~512-token windows of every source file).
+   - No structural, graph, history, or coverage tools.
+   - Purpose: isolate Lore's structural/graph/history value from its embedding/search value. Without this arm, positive results face the objection "you compared it to grep."
+
+3. **Lore-enabled**
+   - Same tools as Control (real, not stubs).
+   - Lore MCP tools enabled.
+
+### Optional later ablations
+
+Only after the main benchmark is working:
+
+4. **Lore-lite**
+   - Limited Lore surface such as `lore_lookup`, `lore_search`, `lore_snippet`
+
+5. **Lore-full**
+   - Full Lore surface including graph/history/docs/test/coverage/architecture tools
+
+For the main study, Control vs Semantic baseline vs Lore-enabled is the core comparison. The Control vs Lore-enabled pair is sufficient for the pilot.
+
+---
+
+## What to evaluate
+
+## 1. Repo panel
+
+Use a broad repo suite stratified by size, language, and structure.
+
+### Target dimensions
+
+- **Size**
+  - Medium: 20k–100k LOC
+  - Large: 100k–500k LOC
+  - Very large: 500k+ LOC
+
+- **Language mix**
+  - TS/JS
+  - Python
+  - Go
+  - Java/Kotlin
+  - Rust
+  - Polyglot monorepos
+
+- **Structure**
+  - Service repo
+  - Web app
+  - CLI/tooling repo
+  - SDK/library
+  - Monorepo
+
+- **Metadata quality**
+  - Strong docs/tests
+  - Weak docs/tests
+
+- **History richness**
+  - High churn
+  - Stable codebase
+
+### Recommended panel size
+
+- Pilot: 3–5 repos
+- Main benchmark: 12+ repos
+- Stronger claims: 20–30 repos
+
+### Selection guidance
+
+Include repos with:
+- nontrivial call depth
+- cross-module dependencies
+- enough tests or validation commands
+- meaningful commit history
+- realistic navigation burden
+
+---
+
+## 2. Task panel
+
+Use multiple task families, not only bug fixes.
+
+### A. Localization tasks
+Examples:
+- Identify where a feature is implemented
+- Find the owning symbol/file for behavior X
+- Find the handler or call path for API Y
+
+### B. Explanation tasks
+Examples:
+- Explain how request X flows through the system
+- Summarize module responsibilities
+- Explain why a file changed recently
+
+### C. Modification tasks
+Examples:
+- Add logging or validation in the correct path
+- Extend a small feature
+- Fix a scoped defect with acceptance tests
+
+### D. Refactoring tasks
+Examples:
+- Rename or relocate a concept
+- Replace a deprecated API
+- Update all call sites
+- Extract a shared helper
+
+### E. Testing tasks
+Examples:
+- Identify relevant tests for a source file
+- Add a regression test
+- Repair failing tests after a change
+
+### F. History/ownership tasks
+Examples:
+- Find when behavior changed
+- Identify likely owners
+- Explain a recent regression
+
+### G. Coverage/risk tasks
+Examples:
+- Identify risky uncovered areas
+- Propose smallest safe change region
+- Prioritize test additions
+
+### Recommended counts
+
+- 8–12 tasks per repo
+- 100+ total task instances for an initial main study
+- Balanced across families
+
+---
+
+## Task sourcing strategy
+
+Use multiple sources to avoid overfitting.
+
+### Source 1: Real historical tasks
+Derived from:
+- closed issues
+- merged PRs
+- bugfix commits
+- regressions/postmortems
+
+Method:
+- freeze the repo at the commit before the fix
+- give the agent only the task description
+- score whether it reaches the intended fix or a valid equivalent
+
+### Source 2: Synthetic but repo-grounded tasks
+Generated from real repo structure, for example:
+- "Find endpoint handling X"
+- "Add validation to config parser"
+- "Update all callers of Y"
+- "Add tests for uncovered branch in module Z"
+
+These should be grounded in actual code, not invented abstractions.
+
+**Bias control:** Synthetic tasks must be authored or reviewed by someone unfamiliar with Lore's tool surface. Audit the final synthetic task set against the Lore tool list and ensure no more than 30% of synthetic tasks directly correspond to a single Lore tool's optimal query pattern. Include tasks that require multi-hop reasoning Lore doesn't shortcut (e.g., "Find the root cause of this test flake" requires understanding timing, not just call graphs).
+
+### Source 3: Maintainer-authored tasks
+Ask maintainers for representative tasks per repo.
+
+### Recommended mix
+
+- 40% historical
+- 40% synthetic grounded
+- 20% maintainer-authored
+
+---
+
+## Experimental design
+
+## Unit of analysis
+
+One run = one agent attempt on one repo-task pair under one arm.
+
+## Randomization
+
+For each repo-task pair:
+- run the same prompt in all arms
+- randomize arm order
+- randomize task order
+- use multiple seeds per arm
+
+Recommended:
+- 2 seeds for pilot
+- 3 seeds for main benchmark
+
+## Context isolation
+
+Each run must use a **fresh context window** with no carry-over from previous tasks on the same repo. If the system under test is stateful (e.g., cached conversation history, persistent agent memory), explicitly flush state between runs. This prevents later tasks from benefiting from knowledge accumulated during earlier tasks.
+
+## Agent standardization
+
+Hold fixed across arms:
+- same model and exact model version/checkpoint identifier
+- same system prompt (including equal high-level guidance such as "consider architecture, test coverage, history" in all arms)
+- same task prompt template
+- same context budget
+- same token limits
+- same time budget
+- same edit permissions
+- same validation permissions
+
+Only retrieval/tool availability changes.
+
+**Model version pinning:** Record the exact model version/checkpoint identifier (not just the model name). Ideally run all arms for a given repo-task pair within the same 24-hour window to minimize model drift from provider-side updates.
+
+## Environment control
+
+Each run should use:
+- pinned repo SHA
+- fresh checkout or clean reset
+- identical dependency state
+- identical test/build environment
+- isolated artifacts where possible
+
+This avoids contamination across arms.
+
+## Time budget
+
+Use bounded execution, but calibrate budgets empirically in the pilot.
+
+Default starting points:
+- localization/explanation: 20 minutes or 50 tool actions
+- modification/refactor/testing: 45 minutes or 150 tool actions
+
+**Budget calibration:** During the pilot, verify that both arms can typically finish within budget on at least 80% of tasks. If Lore tool calls consume disproportionate budget due to latency, adjust upward. Report results both with and without budget caps so that budget-induced truncation effects are visible.
+
+---
+
+## Metrics
+
+Use a small set of primary metrics and a broader secondary set.
+
+## Primary outcome metrics
+
+### 1. Task success rate
+Score per run:
+- `0`: failed
+- `0.5`: partial
+- `1`: success
+
+Define success separately by task family before running the benchmark.
+
+Examples:
+- localization: correct file/symbol/path found
+- explanation: accurate explanation per rubric
+- modification: change satisfies spec and tests pass
+- refactor: required usages updated and tests pass
+- testing: relevant test added/updated and meaningful
+- history: correct commit/owner/change rationale identified
+
+### 2. Time to success
+Wall-clock time until successful completion.
+
+### 3. Tool-adjusted cost
+Capture:
+- total tokens
+- prompt tokens
+- completion tokens
+- tool calls
+- file reads
+- terminal/test runs
+
+### 4. First-pass accuracy
+Whether the first proposed target file/symbol/change was correct.
+
+This is especially relevant in large repos.
+
+---
+
+## Secondary process metrics
+
+### Navigation efficiency
+- files opened
+- unique files opened
+- lines read
+- dead-end files
+- backtracks
+- time to first correct file
+- time to first correct symbol
+
+### Decisiveness
+- number of candidate files/symbols considered before the final answer
+- trace length normalized by task complexity
+- ratio of exploratory actions to committed actions
+
+This captures whether Lore makes the agent more *decisive* — committing to an answer in fewer steps rather than hedging, backtracking, or producing long exploratory traces.
+
+### Retrieval quality
+For tasks with known targets:
+- whether the relevant file/symbol appeared early in retrieval
+- Recall@k
+- MRR where applicable
+
+### Edit efficiency
+- files edited
+- unnecessary edits
+- revert rate
+- validation iterations
+
+### Validation efficiency
+- number of test runs
+- time to first relevant test
+- irrelevant test execution rate
+
+### Robustness
+- variance across seeds
+- variance across repos
+- failure modes by task family
+
+---
+
+## Human and automatic scoring
+
+Use automatic scoring wherever possible.
+
+## Automatic scoring
+Best for:
+- modification
+- refactor
+- testing
+- exact localization
+- many history tasks
+
+Signals:
+- tests pass
+- expected invariants hold
+- touched files overlap target files
+- required symbol usages updated
+- answer key matched where appropriate
+
+## Rubric scoring
+Needed for:
+- architecture explanations
+- root-cause explanations
+- comparative summaries
+
+Use blinded review:
+- reviewers do not know the arm
+- 2 reviewers per artifact
+- adjudicate disagreements
+
+Rubric dimensions:
+- factual correctness
+- completeness
+- specificity
+- usefulness
+
+### Inter-rater reliability
+
+Compute Cohen's kappa or Krippendorff's alpha on rubric scores during the pilot. Target κ ≥ 0.6. If below, refine the rubric before the main study.
+
+Consider using LLM-as-judge for a cheap first-pass score, calibrated against a human-scored subset (≥20 artifacts). If LLM-judge agreement with humans reaches κ ≥ 0.7, it can replace one of the two human reviewers for the main study.
+
+---
+
+## Instrumentation requirements
+
+Capture the full agent trajectory for every run.
+
+For each run, log:
+- repo name
+- pinned commit SHA
+- task ID
+- task family
+- arm
+- model name and exact version/checkpoint
+- seed
+- start/end timestamps
+- tool calls (with latencies)
+- Lore tool calls and arguments
+- file reads and paths
+- terminal commands
+- tests run
+- produced patch
+- final answer
+- validation results
+- final score
+- token counts
+- budget remaining at completion
+
+Also compute repo-level descriptors:
+- repo size (LOC)
+- language mix
+- doc density
+- test density
+- history density (commits per file)
+- symbol graph size
+- Lore DB size
+- Lore index build time
+
+---
+
+## Repo onboarding protocol
+
+Each repo should follow the same setup process.
+
+### Control arm
+- clone repo at pinned SHA
+- install dependencies
+- register stub Lore tool entries (return "not available") to equalize prompting
+- expose only standard agent tools
+
+### Semantic baseline arm
+- same as Control
+- build generic embedding index over source file chunks
+- expose embedding search tool alongside standard tools
+- same stub Lore tool entries as Control
+
+### Lore-enabled arm
+- same repo SHA
+- same dependency setup
+- build Lore index
+- optionally ingest coverage if available
+- enable real Lore tools (replacing stubs)
+
+Record:
+- indexing time
+- indexing failures
+- unsupported-language gaps
+- embedding availability
+- history/docs/coverage availability
+
+### Lore index quality threshold
+
+Define a minimum index quality gate: ≥70% of source files successfully indexed and symbol count > 0 for each major language present in the repo. Below that threshold, flag the repo-arm pair as `lore_degraded` and analyze separately rather than silently including degraded data.
+
+---
+
+## Handling feature heterogeneity
+
+Some repos will lack:
+- coverage reports
+- strong docs
+- rich history
+- usable LSP
+- full language support
+
+Do not exclude these repos automatically.
+
+Instead annotate capability flags:
+- `has_docs`
+- `has_history`
+- `has_coverage`
+- `has_embeddings`
+- `has_lsp_enrichment`
+- `supported_language_fraction`
+- `lore_index_quality` (percentage of files successfully indexed)
+
+Then analyze outcomes conditional on availability.
+
+---
+
+## Statistical analysis plan
+
+Use paired analyses because each task appears in all arms.
+
+## Primary analyses
+- paired comparison of success rate: Lore-enabled vs Control, Lore-enabled vs Semantic baseline
+- paired comparison of time to success
+- paired comparison of token/tool cost
+
+For the main study at 12–20 repos, prefer simpler paired non-parametric tests:
+- Wilcoxon signed-rank test on per-task-pair differences
+- stratified by task family
+- Bonferroni or Holm correction for multiple comparisons across arms
+
+## Model-based analysis
+
+Reserve mixed-effects models for Phase 3 or when the repo panel reaches 20+. The model specification:
+
+$$
+Outcome \sim Arm + TaskType + RepoSize + LanguageMix + FeatureAvailability + (1|Repo) + (1|Task)
+$$
+
+Examples:
+- logistic mixed model for success
+- linear or log-linear mixed model for time/cost
+- ordinal model for rubric scores
+
+With 12 repos and ~100 task instances, random effects and fixed-effect covariates will be thinly estimated — report both paired tests and model-based results and note agreement or divergence.
+
+## Reporting
+For each metric, report:
+- mean and median by arm
+- effect size (Cohen's d or odds ratio)
+- confidence interval
+- task-family breakdown
+- repo breakdown
+- win rate across repo-task pairs
+
+---
+
+## Failure analysis
+
+Tag failed runs with structured labels:
+- retrieval miss
+- wrong file chosen
+- wrong symbol chosen
+- shallow reasoning
+- stale or incorrect history inference
+- over-trust in retrieval result
+- edit compiles but fails semantics
+- test selection failure
+- validation not attempted
+- task not completed in budget
+
+Compare failure distributions between arms.
+
+---
+
+## Total cost of ownership analysis
+
+Report not only agent run costs but also the cost of Lore itself.
+
+For each repo, capture:
+- Lore index build time (wall-clock and CPU)
+- Lore DB size on disk
+- embedding compute cost (if applicable)
+- incremental re-index time
+
+Report a break-even analysis: "Lore setup cost is amortized after N agent tasks on this repo, assuming M% success rate improvement." This lets adopters decide whether Lore is worthwhile for their usage patterns.
+
+---
+
+## Recommended benchmark slices
+
+### Slice A: Find the right place faster
+Use localization + small modification tasks.
+
+Metrics:
+- first-pass target accuracy
+- files opened
+- time to first correct file
+- time to success
+- decisiveness (candidates considered)
+
+### Slice B: Understand architecture and history
+Use explanation + history tasks.
+
+Metrics:
+- rubric score
+- correct module/commit references
+- time to explanation
+
+### Slice C: Change code safely
+Use modification + refactor + testing tasks.
+
+Metrics:
+- success rate
+- tests passed
+- unnecessary edits
+- validation efficiency
+
+### Slice D: Large monorepo stress test
+Use largest repos only.
+
+Metrics:
+- navigation efficiency
+- cost
+- timeout rate
+- variance
+
+---
+
+## Recommended phased rollout
+
+## Phase 1: Pilot
+Purpose: validate harness, task specs, scoring, and calibrate budgets.
+
+- 3 repos
+- 12–18 tasks each
+- 2 arms: Control vs Lore-enabled
+- 2 seeds
+
+Output:
+- feasibility assessment
+- ambiguity cleanup
+- initial variance estimate
+- initial effect size estimate
+- budget calibration (verify ≥80% of tasks finish within budget in both arms)
+- inter-rater reliability scores (target κ ≥ 0.6 for rubric tasks)
+- task spec schema validation
+
+## Phase 2: Main benchmark
+Purpose: produce credible comparative results.
+
+- 12–20 repos
+- 8–12 tasks per repo
+- 3 arms: Control vs Semantic baseline vs Lore-enabled
+- 3 seeds
+
+Output:
+- primary results with confidence intervals
+- task-family breakdown
+- repo-type breakdown
+- total cost of ownership analysis
+- failure mode comparison
+
+## Phase 3: Optional ablation study
+Purpose: understand which Lore capabilities matter most.
+
+Possible arms:
+- Control
+- Semantic baseline
+- Lore-lite (search/lookup/snippet only)
+- Lore-enabled/full
+- history/docs disabled
+- graph disabled
+
+Output:
+- which categories of Lore capability drive lift
+- interaction effects between capabilities and task families
+
+---
+
+## Practical risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Task leakage from public historical examples | Pin commits; verify task descriptions don't appear in training data |
+| Prompt instability across runs | Fix system prompt, use multiple seeds, report variance |
+| Contamination across arms | Fresh context window per run, flush stateful systems |
+| Ambiguous success rubrics | Predefine criteria per family; validate IRR in pilot |
+| Unsupported-language bias | Annotate `supported_language_fraction`; analyze conditional on coverage |
+| Overfitting synthetic tasks to Lore's API surface | Non-Lore author for synthetic tasks; audit ≤30% single-tool correspondence |
+| Tool-description prompting confound | Stub tools in Control/Semantic arms equalize tool-name exposure |
+| Model version drift | Pin exact checkpoint; run all arms per task within 24h window |
+| Lore index silently degraded | Enforce ≥70% index quality gate; flag `lore_degraded` pairs |
+| Budget asymmetry from Lore latency | Calibrate budgets in pilot; report with and without caps |
+
+---
+
+## Task spec schema
+
+Define this concretely from Phase 1 to force all downstream components (harness, scorer, analysis) to agree on the contract early.
+
+```yaml
+# task-spec.schema.yaml
+id: string           # unique task identifier, e.g. "django-loc-001"
+repo: string         # repo identifier, e.g. "django/django"
+sha: string          # pinned commit SHA
+family: enum         # localization | explanation | modification | refactoring | testing | history | coverage
+source: enum         # historical | synthetic | maintainer
+prompt: string       # task description given to the agent
+context: string      # optional additional context (e.g., error message, issue body)
+budget:
+  max_actions: int   # e.g. 50
+  max_minutes: int   # e.g. 20
+ground_truth:
+  files: list[string]        # expected target files
+  symbols: list[string]      # expected target symbols (optional)
+  patch: string              # path to reference patch (optional)
+  validator: enum            # file_overlap | tests_pass | patch_equivalent | rubric | answer_key
+  answer_key: string         # expected answer text for exact-match tasks (optional)
+  test_commands: list[string] # commands to validate correctness (optional)
+  rubric: string             # path to rubric file for human/LLM scoring (optional)
+arms: list[string]           # which arms to run, e.g. ["control", "semantic", "lore"]
+tags: list[string]           # optional metadata tags for filtering/slicing
+```
+
+Example:
+
+```yaml
+id: "django-loc-001"
+repo: "django/django"
+sha: "a1b2c3d4e5f6"
+family: "localization"
+source: "historical"
+prompt: "Find the file and function that handles CSRF token rotation"
+context: ""
+budget:
+  max_actions: 50
+  max_minutes: 20
+ground_truth:
+  files: ["django/middleware/csrf.py"]
+  symbols: ["rotate_token"]
+  validator: "file_overlap"
+arms: ["control", "semantic", "lore"]
+tags: ["security", "middleware"]
+```
+
+Ship this schema and a validator script in the pilot.
+
+---
+
+## Minimal implementation architecture
+
+Build five pieces:
+
+1. **Task spec format + validator**
+   JSON/YAML describing repo, SHA, prompt, task family, budgets, and validators, plus a schema validator to enforce the contract.
+
+2. **Run harness**
+   Executes the same task in all arms, captures traces, and stores outputs. Manages context isolation (fresh window per run), stub tool registration for non-Lore arms, and budget enforcement.
+
+3. **Scoring pipeline**
+   Automatic validators plus a rubric queue for human/LLM review. Includes IRR computation for rubric-scored artifacts.
+
+4. **Analysis notebook/report generator**
+   Produces per-arm metrics, confidence intervals, failure summaries, and total cost of ownership analysis.
+
+5. **Repo onboarding toolkit**
+   Scripts to clone at SHA, install deps, build Lore index, build generic embedding index, compute repo descriptors, and verify index quality gates.
+
+---
+
+## Recommended first implementation scope
+
+Start with the smallest credible version:
+
+- 5 repos
+- 30 total tasks
+- 2 arms: Control vs Lore-enabled (add Semantic baseline in Phase 2)
+- automatic scoring for localization and modification tasks
+- full trajectory logging
+- concrete task spec schema with validator
+- budget calibration pass
+- stub tool registration in Control arm
+
+That should be enough to determine whether Lore shows a measurable signal and whether the harness works end-to-end.

--- a/docs/benchmark-questions.md
+++ b/docs/benchmark-questions.md
@@ -1,0 +1,238 @@
+# Benchmark Questions: Lore's Unique Value
+
+Questions that Lore's DB can answer but agents cannot easily answer through
+semantic search or grep alone. These form the basis for demonstrating Lore's
+measurable value-add.
+
+The organizing principle: **every question below requires either resolved
+structural relationships, cross-table joins, computed graph properties, or
+aggregated metrics** — none of which are available from text matching or
+embedding similarity alone.
+
+---
+
+## Why these questions are hard without Lore
+
+| Capability | Grep | Semantic search | Lore |
+|---|---|---|---|
+| Distinguish a real call site from a comment/string mention | No — returns all textual matches | Somewhat — ranks by relevance but can't guarantee precision | Yes — resolved `symbol_refs` with `resolution_method` |
+| Transitive call graph traversal | No | No | Yes — multi-hop walk over `symbol_refs` |
+| Exhaustive "all implementors of interface X" | Unreliable — misses renamed re-exports, indirect patterns | Approximate — may miss or hallucinate | Yes — `symbol_relationships` with `relationship_type` |
+| Test → source file mapping | Heuristic (name matching) | No structural basis | Yes — `test_mappings` with confidence scores |
+| Symbol-level coverage | No | No | Yes — `coverage_lines` joined with `symbols` line ranges |
+| Cyclomatic complexity ranking | No | No | Yes — `symbol_metrics` table |
+| Import cycle detection | No | No | Yes — Tarjan's SCC on `file_imports` graph |
+| Ownership distribution | Requires running `git blame` + manual aggregation | No | Yes — pre-indexed `commits` + `commit_files` |
+| API route → handler → callee chain | Fragile pattern matching | Hit or miss | Yes — `api_routes` → `symbols` → `symbol_refs` |
+| "What changed since coverage was measured" | No | No | Yes — `coverage_runs.commit_sha` vs current HEAD |
+
+---
+
+## Question catalog
+
+### Category 1 — Call Graph & Impact Analysis
+
+These require resolved `symbol_refs` with `callee_id` pointing to actual symbol
+definitions, not textual mentions.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 1.1 | What functions directly call `{symbol}`? | `lore_graph(kind=call, direction=inbound)` | `symbol_refs` → `symbols` → `files` | Grep returns mentions in comments, strings, imports — not just call sites. No resolution to definition. |
+| 1.2 | What does `{symbol}` call? (its callee fan-out) | `lore_graph(kind=call, direction=outbound)` | `symbol_refs` → `symbols` → `files` | Same noise problem in reverse. Nested calls inside closures are invisible to text search. |
+| 1.3 | What is the full transitive call chain from `{A}` to `{B}`? | `lore_graph` (iterated) | `symbol_refs` multi-hop | Requires graph traversal — no text operation produces a path. |
+| 1.4 | If I change `{symbol}`, what is the blast radius? (transitive callers) | `lore_graph` (iterated inbound) | `symbol_refs` multi-hop | Grep finds direct mentions only; misses indirect callers of callers. |
+| 1.5 | Which symbols have the highest in-degree? (most-called functions) | `lore_metrics` + `lore_graph` | `symbol_refs` aggregation | Requires counting resolved edges, not text occurrences. |
+| 1.6 | Are there any dead functions? (defined but never called) | `lore_graph` + `lore_lookup` | `symbols` LEFT JOIN `symbol_refs` WHERE callee_id IS NULL | Grep "finds" the definition but can't prove no call exists. |
+
+### Category 2 — Type Hierarchy & Inheritance
+
+These require `symbol_relationships` with `relationship_type` (extends,
+implements, mixes_in, etc.) resolved to concrete symbol IDs.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 2.1 | What classes implement interface `{I}`? | `lore_graph(kind=inheritance)` | `symbol_relationships` | Grep finds `implements I` textually but misses transitive or re-exported implementations, renamed imports, and differs by language syntax. |
+| 2.2 | What is the full inheritance chain for class `{C}`? | `lore_graph(kind=inheritance)` (iterated) | `symbol_relationships` multi-hop | Requires transitive graph walk. |
+| 2.3 | What types does `{symbol}` depend on? (parameter types, return type, field types) | `lore_graph(kind=type_dependency)` | `type_refs` → `symbols` | Grep finds type names as text but can't attribute them to a specific symbol's dependencies. |
+| 2.4 | What symbols use type `{T}` as a parameter, return, or field type? | `lore_graph(kind=type_dependency, direction=inbound)` | `type_refs` WHERE type_name = T | Requires resolved type references, not textual mentions. |
+
+### Category 3 — Import Graph & Module Structure
+
+These require the resolved `file_imports` graph and `modules`/`file_modules`
+tables.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 3.1 | What files does `{file}` import (resolved to actual paths)? | `lore_graph(kind=import)` | `file_imports` → `files` | Grep finds import statements but can't resolve `../utils` or `@scope/package` to actual indexed file paths. |
+| 3.2 | What files import `{file}`? (reverse dependency) | `lore_graph(kind=import, direction=inbound)` | `file_imports` WHERE resolved_id = target | Grep can approximate this but is fragile across re-exports, barrel files, and aliased imports. |
+| 3.3 | Are there circular import dependencies? If so, which files? | `lore_graph` + cycle detection | `file_imports` Tarjan SCC | Requires graph algorithm — no text operation can detect cycles. |
+| 3.4 | What is the topological build order of the codebase? | (internal to indexer) | `file_imports` Kahn's algorithm | Graph algorithm, not searchable. |
+| 3.5 | What external packages does the `{component}` use? | `lore_architecture` | `external_deps` → `files` grouped by path prefix | Grep finds import statements but can't distinguish local from external, compute per-component aggregation, or know what's an external package vs. a workspace module. |
+| 3.6 | Which component has the most inbound import edges? (most depended-on) | `lore_architecture` | `file_imports` + path-prefix grouping | Requires aggregation over resolved import graph. |
+
+### Category 4 — Test Mapping
+
+These require the `test_mappings` table, which links test files to source files
+with confidence scores derived from import analysis, naming conventions, and
+structural heuristics.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 4.1 | What test files should I run after modifying `{source_file}`? | `lore_test_map` | `test_mappings` | Grep can find files with similar names but can't reliably map source→test when naming conventions differ, tests are in a separate tree, or multiple test files cover one source. |
+| 4.2 | Does `{source_file}` have any mapped tests? | `lore_test_map` | `test_mappings` | Same — existence check requires structural mapping. |
+| 4.3 | Which source files have NO test mappings? (untested files) | `lore_test_map` (iterated) or `lore_metrics` | `files` LEFT JOIN `test_mappings` | Grep can't produce a reliable "these files have no tests" list. |
+| 4.4 | What is the average test mapping confidence across the codebase? | `lore_metrics` | `test_mappings` aggregation | Requires computed confidence scores that don't exist in source text. |
+
+### Category 5 — Coverage × Structure
+
+These require joining `coverage_lines`/`coverage_files` with `symbols` line
+ranges — something only possible with pre-indexed structural data.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 5.1 | What is the line coverage of function `{symbol}`? | `lore_coverage` | `coverage_lines` + `symbols` (line range join) | Coverage data isn't in source text. Even if coverage reports exist, mapping report lines to symbol boundaries requires the symbol table. |
+| 5.2 | Which specific lines in `{symbol}` are NOT covered? | `lore_coverage` | `coverage_lines` WHERE hit_count=0 within symbol range | Same — requires coverage data + symbol boundaries. |
+| 5.3 | What are the most complex functions that have LOW coverage? (risk hotspots) | `lore_coverage` + `lore_metrics(mode=complexity)` | `symbol_metrics` + `coverage_lines` | Requires joining two computed tables neither of which exists in source text. |
+| 5.4 | Is the coverage data stale? How many commits behind? | `lore_coverage` | `coverage_runs.commit_sha` vs HEAD | Requires metadata comparison — not in source files. |
+| 5.5 | What is the overall project coverage? Per-file breakdown? | `lore_coverage` | `coverage_files` aggregation | Requires ingested coverage data with structural aggregation. |
+
+### Category 6 — Complexity & Code Health
+
+These require pre-computed `symbol_metrics` (cyclomatic complexity, nesting
+depth, parameter count, line count).
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 6.1 | What are the N most complex functions in the codebase? | `lore_metrics(mode=complexity)` | `symbol_metrics` ORDER BY cyclomatic DESC | Cyclomatic complexity requires AST analysis — it's a computed property, not searchable text. |
+| 6.2 | Which functions exceed a cyclomatic complexity threshold of K? | `lore_metrics(mode=complexity, min_cyclomatic=K)` | `symbol_metrics` WHERE cyclomatic >= K | Same. |
+| 6.3 | What functions have the deepest nesting? | `lore_metrics(mode=complexity)` sorted by max_nesting | `symbol_metrics` ORDER BY max_nesting DESC | Nesting depth is computed from AST, not present in text. |
+| 6.4 | What is the average complexity per module/component? | `lore_metrics` + `lore_architecture` | `symbol_metrics` + `file_modules` | Requires aggregation across two structural tables. |
+| 6.5 | Which functions have high complexity AND many callers? (fragile hotspots) | `lore_metrics` + `lore_graph` | `symbol_metrics` + `symbol_refs` aggregation | Requires joining complexity data with call graph degree. |
+
+### Category 7 — History + Structure Fusion
+
+These require cross-referencing `commits`/`commit_files` with the symbol/file
+graph — something that requires both indexed git metadata and structural
+knowledge.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 7.1 | Who is the likely domain expert for `{file}` or `{directory}`? | `lore_blame(mode=ownership)` | `commits` + `commit_files` aggregated by author | Requires running blame + aggregating ownership shares. Grep can't do this. |
+| 7.2 | What is the ownership distribution for `{component}`? (bus factor) | `lore_blame(mode=ownership)` | commit ownership aggregation | Ownership dispersion and bus factor are computed properties. |
+| 7.3 | What files have changed the most in the last N commits? (churn hotspots) | `lore_history(mode=recent)` + file aggregation | `commit_files` grouped by file_path | Requires aggregation over indexed commit data. |
+| 7.4 | Is `{file}` high-risk? (recently changed, many authors, high churn) | `lore_blame(mode=ownership)` | risk signals from blame aggregation | Composite risk score requires multiple aggregated signals. |
+| 7.5 | What commits touched both `{file_A}` and `{file_B}`? (co-change coupling) | `lore_history` | `commit_files` self-join | Requires set intersection over commit-file associations. |
+| 7.6 | What was the last commit that modified function `{symbol}`? | `lore_blame(mode=history)` + symbol resolution | blame + `symbols` line range | Requires mapping a symbol name to its line range, then querying line-level history. |
+| 7.7 | Find commits related to "{natural language description}" | `lore_history(mode=semantic)` | `commit_embeddings` vec0 | Semantic search over commit messages — grep can find keywords but can't match conceptual intent. |
+
+### Category 8 — API Route Intelligence
+
+These require the `api_routes` table which maps HTTP method + path → handler
+function → source file, extracted from framework-specific patterns.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 8.1 | What API endpoints does this codebase expose? | `lore_routes` | `api_routes` | Grep can find route decorators/registrations but can't reliably extract method+path+handler across different frameworks (Express, FastAPI, Gin, etc.). |
+| 8.2 | What handler function processes `{METHOD} {path}`? | `lore_routes(method, path_prefix)` | `api_routes` → `symbols` | Requires structured route extraction, not text matching. |
+| 8.3 | What is the full call chain from `POST /users` through to the database layer? | `lore_routes` → `lore_graph(kind=call)` (iterated) | `api_routes` → `symbol_refs` multi-hop | Requires chaining route lookup → handler → call graph traversal. Two structural queries that grep can't compose. |
+| 8.4 | What middleware is applied to routes under `{path_prefix}`? | `lore_routes(path_prefix)` | `api_routes.middleware` | Middleware chains are framework-specific and often applied implicitly — not greppable. |
+| 8.5 | Are there any routes with no test coverage? | `lore_routes` + `lore_coverage` | `api_routes` → `symbols` → `coverage_lines` | Requires joining three tables: routes, symbols, coverage. |
+
+### Category 9 — Architecture Overview
+
+These require aggregation across the full `files`, `symbols`, `file_imports`,
+`modules`, `external_deps`, and `docs` tables — a whole-codebase view.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 9.1 | What are the high-level components of this codebase and how do they relate? | `lore_architecture` | all structural tables aggregated | Architecture is emergent from import/module/symbol structure — not greppable. |
+| 9.2 | Which components are entry points (nothing depends on them internally)? | `lore_architecture` | `file_imports` inbound degree = 0 | Requires computing in-degree across the import graph. |
+| 9.3 | Which components are leaf nodes (they depend on no other internal components)? | `lore_architecture` | `file_imports` outbound degree = 0 | Same — requires out-degree computation. |
+| 9.4 | What documentation exists for each component? | `lore_architecture` + `lore_docs` | `docs` + path-prefix grouping | Documentation density per component requires structural aggregation. |
+| 9.5 | How large is this codebase? (files, symbols, import edges, per-language breakdown) | `lore_metrics(mode=aggregate)` | COUNT over multiple tables | Precise counts with structural breakdown — not a search problem. |
+
+### Category 10 — Annotation Intelligence
+
+These require the `annotations` table with symbol linkage.
+
+| # | Question | Lore tools | DB tables | Why grep/semantic fails |
+|---|----------|------------|-----------|------------------------|
+| 10.1 | What are all TODOs/FIXMEs in `{component}`, grouped by kind? | `lore_annotations(kind, path)` | `annotations` grouped by kind | Grep can find TODO/FIXME text but can't attribute them to components, link them to symbols, or reliably distinguish annotation kinds. |
+| 10.2 | Which TODOs are inside high-complexity functions? | `lore_annotations` + `lore_metrics` | `annotations` + `symbol_metrics` join | Requires cross-referencing annotation position with symbol boundaries and complexity data. |
+| 10.3 | What's the distribution of annotation kinds across the codebase? | `lore_annotations` | `annotations` GROUP BY kind | Aggregation query, not a search. |
+
+### Category 11 — Composite / Multi-Hop Questions
+
+These are the highest-value questions — they require **chaining multiple Lore
+capabilities** and would take an agent many tool calls, backtracking, and
+uncertain grep heuristics to approximate.
+
+| # | Question | Lore tools chained | Why this is hard without Lore |
+|---|----------|-------------------|------------------------------|
+| 11.1 | "I need to modify `{symbol}`. What test files should I run, what is the coverage of those test paths, and who should review the change?" | `lore_lookup` → `lore_test_map` → `lore_coverage` → `lore_blame(ownership)` | Requires four structural lookups that each depend on the previous result. An agent would need to manually discover test files, run coverage, parse blame — possibly 10+ tool calls with uncertain results. |
+| 11.2 | "What is the riskiest function in the codebase?" (high complexity + low coverage + high churn + many callers) | `lore_metrics(complexity)` + `lore_coverage` + `lore_blame(ownership)` + `lore_graph(call)` | Composite risk ranking over four independent dimensions. No single search can surface this. |
+| 11.3 | "Trace the full request path from `GET /api/users` to the database, and tell me which segments are covered by tests." | `lore_routes` → `lore_graph(call)` (iterated) → `lore_coverage` per symbol → `lore_test_map` per file | Requires route resolution, multi-hop call traversal, per-symbol coverage lookup, and test mapping — all chained. |
+| 11.4 | "What would break if I deleted `{file}`?" | `lore_graph(import, inbound)` → `lore_graph(call, inbound)` for each exported symbol | Requires computing the full reverse dependency closure: who imports this file, then who calls functions defined here. Grep can find textual imports but misses re-exports and transitive dependents. |
+| 11.5 | "Find all symbols that have been added in the last 10 commits, have no test mapping, and have complexity > 5." | `lore_history(recent)` → `lore_lookup` (symbols in changed files) → `lore_test_map` → `lore_metrics(complexity)` | Requires correlating recent history with symbol extraction, coverage gaps, and complexity — four independent data sources. |
+| 11.6 | "What interface implementations exist in the codebase, and which of those implementations are missing test coverage?" | `lore_graph(inheritance)` → `lore_coverage` per implementation | Requires inheritance graph query, then per-symbol coverage lookup. |
+| 11.7 | "Summarize the architecture, then identify which component has the highest technical debt." (debt = complexity × annotation density × inverse test coverage) | `lore_architecture` → `lore_metrics` → `lore_annotations` → `lore_coverage` | Full architecture sweep combined with three quantitative signals. |
+
+---
+
+## Priority tiers for benchmark implementation
+
+### Tier 1 — Core differentiators (implement first)
+Questions that most clearly separate Lore from grep/semantic search:
+- **1.1, 1.2** (direct callers/callees) — the simplest graph question
+- **1.4** (blast radius) — multi-hop, genuinely impossible without graph
+- **2.1** (interface implementations) — exhaustive structural query
+- **3.1, 3.2** (resolved imports/reverse deps) — resolved, not textual
+- **4.1** (test mapping) — unique Lore capability
+- **5.1, 5.2** (symbol coverage) — requires two data sources
+- **6.1** (complexity ranking) — computed, not searchable
+- **8.1, 8.2** (route lookup) — structured extraction
+
+### Tier 2 — High-value composites (implement second)
+Questions that demonstrate multi-hop chaining:
+- **11.1** (modify workflow: tests + coverage + ownership)
+- **11.3** (request trace with coverage)
+- **11.4** (deletion impact)
+- **7.1** (domain expert identification)
+- **5.3** (risk hotspots: complexity × coverage)
+
+### Tier 3 — Architecture and overview (implement third)
+Questions that require whole-codebase aggregation:
+- **9.1** (component map)
+- **9.5** (codebase metrics)
+- **6.4** (complexity per component)
+- **11.7** (technical debt ranking)
+
+---
+
+## Mapping to benchmark task families
+
+| Task family (from benchmark-plan.md) | Best questions to use | Expected Lore advantage |
+|---|---|---|
+| **A. Localization** | 1.1, 1.2, 2.1, 3.2, 8.2 | Agent finds the right symbol/file in 1 tool call vs. 5–10 greps with false positives |
+| **B. Explanation** | 9.1, 11.3, 7.1, 2.2 | Agent produces accurate structural explanations rather than guessing from file names |
+| **C. Modification** | 1.4, 4.1, 11.1, 3.1 | Agent knows what to test, what's affected, and who to ask |
+| **D. Refactoring** | 1.4, 2.1, 2.4, 11.4 | Agent finds all usage sites and inheritance chains — exhaustive, not heuristic |
+| **E. Testing** | 4.1, 4.3, 5.1, 5.2, 5.3 | Agent targets untested and uncovered areas precisely |
+| **F. History/ownership** | 7.1, 7.2, 7.3, 7.6 | Agent identifies owners and change history without running git commands |
+| **G. Coverage/risk** | 5.3, 6.1, 6.5, 11.2, 8.5 | Agent finds risky code without manually parsing coverage reports |
+
+---
+
+## Evaluation criteria for each question
+
+For each benchmark question, score:
+
+1. **Correctness** — Does the answer match ground truth? (precision + recall for list answers)
+2. **Completeness** — Are all relevant items found? (critical for "all callers" / "all implementations")
+3. **Speed** — How many tool calls / tokens / wall-clock seconds to reach the answer?
+4. **Noise** — How many false positives were included? (especially relevant for grep baseline)
+5. **Composability** — For multi-hop questions: did the agent successfully chain the steps?
+
+The key metric per question is **Recall@complete** — did the agent find ALL correct
+answers? This is where Lore's structural guarantees (resolved refs, not text
+matches) should show the largest gap versus grep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jafreck/lore",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@elm-tooling/tree-sitter-elm": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Language-aware codebase indexer — tree-sitter parsing, symbol extraction, call-graph construction, and optional embeddings for semantic search",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## v0.3.4

**Version bump**: `0.3.3` → `0.3.4`
**Compare range**: [`v0.3.3...release/v0.3.4`](https://github.com/jafreck/Lore/compare/v0.3.3...release/v0.3.4)

### Key changes since v0.3.3

#### Features

- **Native Node.js embeddings** (#158) — Replaced the Python subprocess embedding system (`SentenceTransformersProvider` + `torch` + `sentence-transformers`) with `TransformersJsProvider` using `@huggingface/transformers`. Embedding models now run natively in Node.js via ONNX Runtime — no Python, pip, or torch installation required. Lore is now fully self-contained on Node >= 22.

- **New default embedding model** — Changed from `Qwen/Qwen3-Embedding-4B` (4B params, requires GPU + Python) to `nomic-ai/nomic-embed-text-v1.5` (0.1B params, 768-dim, runs on CPU, ONNX-ready, supports Matryoshka dimension reduction).

#### Breaking changes

- `SentenceTransformersProvider` removed from public API → use `TransformersJsProvider`
- `Qwen3EmbeddingProvider` factory removed
- `ensurePythonDeps` removed (no longer needed)
- Default embedding model changed to `nomic-ai/nomic-embed-text-v1.5`

#### Docs refreshed

- **README.md** — Updated embeddings section to reflect Transformers.js usage and new default model
- **docs/architecture.md** — Updated embedder module description and pipeline diagram label

#### Internal

- Removed `src/indexer/ensure-python-deps.ts` and its tests
- Added `@huggingface/transformers@^3.8.1` dependency

### Validation

- `tsc --noEmit` — clean
- `npm run build` — clean
- `vitest run` — **1,372 passed**, 2 skipped (LSP smoke), 0 failed