### PR TITLE
feat: graph analysis primitives (symbol SCC, connected components, clustering, summary)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,8 @@ function usage(): never {
                          Install git hooks for automatic refresh on commit/merge/checkout
   lore ingest-coverage --db <path> --root <dir> --file <path> --format <lcov|cobertura> [--commit <sha>]
                          Ingest an explicit coverage report file into the knowledge base
+  lore analyze --db <path> [--mode <mode>] [--edge-kinds <kind>] [--branch <name>] [--max-lines <n>]
+                         Run graph analysis on the knowledge-base (cycles, components, clusters, summary)
 
 Options:
   --root <dir>             Root directory to index (required for index, refresh)
@@ -575,6 +577,68 @@ async function main(): Promise<void> {
     const { IndexBuilder } = await import('./indexer/index.js');
     const builder = new IndexBuilder(dbPath, { rootDir });
     await builder.ingestCoverage(reportPath, format, commitSha);
+  } else if (subcommand === 'analyze') {
+    const dbPath = flag(args, '--db');
+    if (!dbPath) {
+      console.error('Error: --db <path> is required for the analyze subcommand.\n');
+      usage();
+      return;
+    }
+
+    const mode = flag(args, '--mode') ?? 'summary';
+    const validModes = ['cycles', 'components', 'clusters', 'summary'];
+    if (!validModes.includes(mode)) {
+      console.error(`Error: --mode must be one of: ${validModes.join(', ')}\n`);
+      usage();
+      return;
+    }
+
+    const edgeKindsRaw = flag(args, '--edge-kinds') ?? 'both';
+    const validEdgeKinds = ['call', 'type', 'both'];
+    if (!validEdgeKinds.includes(edgeKindsRaw)) {
+      console.error(`Error: --edge-kinds must be one of: ${validEdgeKinds.join(', ')}\n`);
+      usage();
+      return;
+    }
+    const edgeKinds = edgeKindsRaw as 'call' | 'type' | 'both';
+
+    const branch = flag(args, '--branch');
+    const maxLinesRaw = flag(args, '--max-lines');
+    let maxLines: number | undefined;
+    if (maxLinesRaw !== undefined) {
+      const parsed = Number(maxLinesRaw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        console.error('Error: --max-lines must be a positive number.\n');
+        usage();
+        return;
+      }
+      maxLines = Math.floor(parsed);
+    }
+
+    const { openReadOnly } = await import('./lore-server/db.js');
+    const {
+      detectSymbolCycles,
+      findConnectedComponents,
+      clusterSymbols,
+      buildCodebaseSummary,
+    } = await import('./indexer/graph-analysis.js');
+
+    const db = openReadOnly(dbPath);
+    const opts = { edgeKinds, branch };
+
+    let result: unknown;
+    if (mode === 'cycles') {
+      result = detectSymbolCycles(db, opts);
+    } else if (mode === 'components') {
+      result = findConnectedComponents(db, { ...opts, scope: 'symbol' });
+    } else if (mode === 'clusters') {
+      result = clusterSymbols(db, { ...opts, maxLinesPerCluster: maxLines });
+    } else {
+      result = buildCodebaseSummary(db, { ...opts, maxLinesPerModule: maxLines });
+    }
+
+    db.close();
+    console.log(JSON.stringify(result, null, 2));
   } else {
     console.error(`Unknown subcommand: ${subcommand}\n`);
     usage();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,22 @@ export { IndexBuilder } from './indexer/index.js';
 export { openDb, setLoreMeta, getLoreMeta, createVec0Tables } from './indexer/db.js';
 export type { Database } from './indexer/db.js';
 export { resolveSymbolEdges, topoSort, detectCycles } from './indexer/call-graph.js';
+export {
+  detectSymbolCycles,
+  findConnectedComponents,
+  clusterSymbols,
+  buildCodebaseSummary,
+} from './indexer/graph-analysis.js';
+export type {
+  EdgeKind,
+  GraphAnalysisOptions,
+  ConnectedComponentsOptions,
+  ClusterOptions,
+  SymbolCluster,
+  CodebaseSummaryOptions,
+  CodebaseSummary,
+  ModuleSummary,
+} from './indexer/graph-analysis.js';
 export { walkFiles, detectLanguageForPath } from './indexer/walker.js';
 export type { WalkerConfig, FileEntry } from './indexer/walker.js';
 export { ImportResolver } from './indexer/resolver.js';
@@ -74,8 +90,19 @@ export {
   getFileByPath,
   listFiles,
   listResolvedEdges,
+  listTypeRefs,
+  listSymbolRelationships,
 } from './lore-server/db.js';
-export type { SymbolRow, FileRow, ResolvedEdge, ListResolvedEdgesOptions } from './lore-server/db.js';
+export type {
+  SymbolRow,
+  FileRow,
+  ResolvedEdge,
+  ListResolvedEdgesOptions,
+  TypeRefEdge,
+  ListTypeRefsOptions,
+  SymbolRelationshipEdge,
+  ListSymbolRelationshipsOptions,
+} from './lore-server/db.js';
 
 // ── Logging ───────────────────────────────────────────────────────────────────
 export { LoreLogger, LogLevel, LOG_LEVEL_NAMES, initLogger, getLogger, resetLogger } from './logger.js';

--- a/src/indexer/graph-analysis.ts
+++ b/src/indexer/graph-analysis.ts
@@ -1,0 +1,781 @@
+/**
+ * @module indexer/graph-analysis
+ *
+ * Higher-level graph analysis primitives operating on the SQLite
+ * knowledge-base:
+ *
+ *  - `detectSymbolCycles(db, opts)` — Tarjan's SCC on the symbol adjacency
+ *    graph (call_refs, type_refs, or both).
+ *  - `findConnectedComponents(db, opts)` — union-find connected components
+ *    at file or symbol scope.
+ *  - `clusterSymbols(db, opts)` — partitions the call graph into bounded-
+ *    size coherent chunks via SCC contraction, same-file merge, greedy
+ *    edge-weight consolidation, and affinity folding.
+ *  - `buildCodebaseSummary(db, opts)` — condensed dependency summary with
+ *    per-module files, symbol counts, line spans, and SCCs.
+ */
+
+import type { Database } from './db.js';
+import type { ResolutionMethod } from './resolution-method.js';
+import { RESOLVED_METHODS } from './resolution-method.js';
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export type EdgeKind = 'call' | 'type' | 'both';
+
+export interface GraphAnalysisOptions {
+  /** Which edge kinds to traverse. Default: 'both'. */
+  edgeKinds?: EdgeKind;
+  /** Resolution methods to include. Default: RESOLVED_METHODS. */
+  methods?: ResolutionMethod[];
+  /** Branch filter. */
+  branch?: string;
+}
+
+// ─── Edge loading (shared) ────────────────────────────────────────────────────
+
+interface SymbolEdge {
+  source: number;
+  target: number;
+}
+
+/**
+ * Loads resolved symbol-level edges from the database.
+ * Returns only edges where both source and target are non-NULL and the
+ * resolution_method passes the configured filter.
+ */
+function loadSymbolEdges(
+  db: Database.Database,
+  options: GraphAnalysisOptions = {},
+): SymbolEdge[] {
+  const edgeKinds = options.edgeKinds ?? 'both';
+  const methods = options.methods ?? [...RESOLVED_METHODS];
+  const branch = options.branch;
+
+  if (methods.length === 0) return [];
+
+  const placeholders = methods.map(() => '?').join(', ');
+  const edges: SymbolEdge[] = [];
+
+  if (edgeKinds === 'call' || edgeKinds === 'both') {
+    const where = [`sr.callee_id IS NOT NULL`, `sr.resolution_method IN (${placeholders})`];
+    const params: Array<string | number> = [...methods];
+
+    if (branch !== undefined) {
+      where.push('f.branch = ?');
+      params.push(branch);
+    }
+
+    const rows = db.prepare(
+      `SELECT sr.caller_id AS source, sr.callee_id AS target
+         FROM symbol_refs sr
+         JOIN symbols s ON s.id = sr.caller_id
+         JOIN files f ON f.id = s.file_id
+        WHERE ${where.join(' AND ')}`,
+    ).all(...params) as SymbolEdge[];
+    edges.push(...rows);
+  }
+
+  if (edgeKinds === 'type' || edgeKinds === 'both') {
+    const where = [`tr.type_id IS NOT NULL`, `tr.resolution_method IN (${placeholders})`];
+    const params: Array<string | number> = [...methods];
+
+    if (branch !== undefined) {
+      where.push('f.branch = ?');
+      params.push(branch);
+    }
+
+    const rows = db.prepare(
+      `SELECT tr.symbol_id AS source, tr.type_id AS target
+         FROM type_refs tr
+         JOIN files f ON f.id = tr.file_id
+        WHERE tr.symbol_id IS NOT NULL AND ${where.join(' AND ')}`,
+    ).all(...params) as SymbolEdge[];
+    edges.push(...rows);
+  }
+
+  return edges;
+}
+
+// ─── detectSymbolCycles ───────────────────────────────────────────────────────
+
+/**
+ * Detects strongly connected components (mutual recursion, circular type
+ * dependencies) in the **symbol** adjacency graph using Tarjan's algorithm.
+ *
+ * Returns arrays of symbol IDs where each SCC has 2+ members (or a single
+ * member with a self-edge).
+ */
+export function detectSymbolCycles(
+  db: Database.Database,
+  options: GraphAnalysisOptions = {},
+): number[][] {
+  const edges = loadSymbolEdges(db, options);
+
+  // Build directed adjacency list
+  const adjacency = new Map<number, number[]>();
+  const allNodes = new Set<number>();
+
+  for (const { source, target } of edges) {
+    allNodes.add(source);
+    allNodes.add(target);
+    let list = adjacency.get(source);
+    if (!list) {
+      list = [];
+      adjacency.set(source, list);
+    }
+    list.push(target);
+  }
+
+  // Tarjan's SCC
+  let index = 0;
+  const indices = new Map<number, number>();
+  const lowlink = new Map<number, number>();
+  const onStack = new Set<number>();
+  const stack: number[] = [];
+  const sccs: number[][] = [];
+
+  function strongConnect(v: number): void {
+    indices.set(v, index);
+    lowlink.set(v, index);
+    index++;
+    stack.push(v);
+    onStack.add(v);
+
+    for (const w of adjacency.get(v) ?? []) {
+      if (!indices.has(w)) {
+        strongConnect(w);
+        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v)!, indices.get(w)!));
+      }
+    }
+
+    if (lowlink.get(v) === indices.get(v)) {
+      const scc: number[] = [];
+      let w: number;
+      do {
+        w = stack.pop()!;
+        onStack.delete(w);
+        scc.push(w);
+      } while (w !== v);
+
+      if (scc.length > 1) {
+        sccs.push(scc);
+      } else {
+        // Single-node SCC — only report if self-loop exists
+        const selfLoop = (adjacency.get(scc[0]!) ?? []).includes(scc[0]!);
+        if (selfLoop) sccs.push(scc);
+      }
+    }
+  }
+
+  for (const node of allNodes) {
+    if (!indices.has(node)) {
+      strongConnect(node);
+    }
+  }
+
+  return sccs;
+}
+
+// ─── findConnectedComponents ──────────────────────────────────────────────────
+
+export interface ConnectedComponentsOptions extends GraphAnalysisOptions {
+  /** Scope of the analysis. Default: 'symbol'. */
+  scope?: 'file' | 'symbol';
+}
+
+/**
+ * Finds connected components in the **undirected** graph of files or symbols
+ * using a union-find (disjoint set) data structure.
+ *
+ * Returns arrays of IDs where each component has 2+ members.
+ */
+export function findConnectedComponents(
+  db: Database.Database,
+  options: ConnectedComponentsOptions = {},
+): number[][] {
+  const scope = options.scope ?? 'symbol';
+
+  if (scope === 'file') {
+    return findFileComponents(db, options);
+  }
+  return findSymbolComponents(db, options);
+}
+
+function findFileComponents(
+  db: Database.Database,
+  options: GraphAnalysisOptions,
+): number[][] {
+  const branch = options.branch;
+
+  const allFiles = (
+    branch !== undefined
+      ? db.prepare('SELECT id FROM files WHERE branch = ?').all(branch)
+      : db.prepare('SELECT id FROM files').all()
+  ) as Array<{ id: number }>;
+
+  const edges = (
+    branch !== undefined
+      ? db.prepare(
+          `SELECT fi.file_id AS source, fi.resolved_id AS target
+             FROM file_imports fi
+             JOIN files f ON f.id = fi.file_id
+            WHERE fi.resolved_id IS NOT NULL AND f.branch = ?`,
+        ).all(branch)
+      : db.prepare(
+          `SELECT fi.file_id AS source, fi.resolved_id AS target
+             FROM file_imports fi
+            WHERE fi.resolved_id IS NOT NULL`,
+        ).all()
+  ) as SymbolEdge[];
+
+  const uf = new UnionFind<number>();
+  for (const f of allFiles) uf.makeSet(f.id);
+  for (const { source, target } of edges) uf.union(source, target);
+
+  return uf.components().filter(c => c.length > 1);
+}
+
+function findSymbolComponents(
+  db: Database.Database,
+  options: GraphAnalysisOptions,
+): number[][] {
+  const edges = loadSymbolEdges(db, options);
+
+  const uf = new UnionFind<number>();
+  for (const { source, target } of edges) {
+    uf.makeSet(source);
+    uf.makeSet(target);
+    uf.union(source, target);
+  }
+
+  return uf.components().filter(c => c.length > 1);
+}
+
+/** Simple union-find with path compression and union by rank. */
+class UnionFind<T> {
+  private parent = new Map<T, T>();
+  private rank = new Map<T, number>();
+
+  makeSet(x: T): void {
+    if (!this.parent.has(x)) {
+      this.parent.set(x, x);
+      this.rank.set(x, 0);
+    }
+  }
+
+  find(x: T): T {
+    let root = x;
+    while (this.parent.get(root) !== root) {
+      root = this.parent.get(root)!;
+    }
+    // Path compression
+    let curr = x;
+    while (curr !== root) {
+      const next = this.parent.get(curr)!;
+      this.parent.set(curr, root);
+      curr = next;
+    }
+    return root;
+  }
+
+  union(a: T, b: T): void {
+    this.makeSet(a);
+    this.makeSet(b);
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra === rb) return;
+    const rankA = this.rank.get(ra)!;
+    const rankB = this.rank.get(rb)!;
+    if (rankA < rankB) {
+      this.parent.set(ra, rb);
+    } else if (rankA > rankB) {
+      this.parent.set(rb, ra);
+    } else {
+      this.parent.set(rb, ra);
+      this.rank.set(ra, rankA + 1);
+    }
+  }
+
+  components(): T[][] {
+    const groups = new Map<T, T[]>();
+    for (const x of this.parent.keys()) {
+      const root = this.find(x);
+      let list = groups.get(root);
+      if (!list) {
+        list = [];
+        groups.set(root, list);
+      }
+      list.push(x);
+    }
+    return [...groups.values()];
+  }
+}
+
+// ─── clusterSymbols ───────────────────────────────────────────────────────────
+
+export interface ClusterOptions extends GraphAnalysisOptions {
+  /** Maximum total line span per cluster. Default: 500. */
+  maxLinesPerCluster?: number;
+}
+
+export interface SymbolCluster {
+  /** Cluster index (0-based). */
+  id: number;
+  /** Symbol IDs belonging to this cluster. */
+  symbolIds: number[];
+  /** Total line count across all symbols. */
+  totalLines: number;
+  /** File IDs that have at least one symbol in this cluster. */
+  fileIds: number[];
+  /** Number of internal edges (edges within the cluster). */
+  internalEdges: number;
+  /** Number of external edges (edges crossing cluster boundaries). */
+  externalEdges: number;
+}
+
+interface SymbolInfo {
+  id: number;
+  fileId: number;
+  lines: number;
+}
+
+/**
+ * Partition the symbol call graph into bounded-size coherent clusters.
+ *
+ * Algorithm:
+ * 1. Contract SCCs (mutually dependent symbols → same cluster)
+ * 2. Merge same-file symbols into one cluster per file
+ * 3. Greedy merge by edge weight (respecting maxLines)
+ * 4. Fold undersized clusters into their heaviest-edge neighbor
+ */
+export function clusterSymbols(
+  db: Database.Database,
+  options: ClusterOptions = {},
+): SymbolCluster[] {
+  const maxLines = options.maxLinesPerCluster ?? 500;
+  const branch = options.branch;
+
+  // Load all symbols with line spans
+  const symbolRows = (
+    branch !== undefined
+      ? db.prepare(
+          `SELECT s.id, s.file_id, (s.end_line - s.start_line + 1) AS lines
+             FROM symbols s JOIN files f ON f.id = s.file_id
+            WHERE f.branch = ?`,
+        ).all(branch)
+      : db.prepare(
+          'SELECT id, file_id, (end_line - start_line + 1) AS lines FROM symbols',
+        ).all()
+  ) as SymbolInfo[];
+
+  if (symbolRows.length === 0) return [];
+
+  const symbolById = new Map<number, SymbolInfo>();
+  for (const s of symbolRows) symbolById.set(s.id, s);
+
+  const edges = loadSymbolEdges(db, options);
+
+  // Filter edges to only include symbols we loaded
+  const validEdges = edges.filter(e => symbolById.has(e.source) && symbolById.has(e.target));
+
+  // Step 1: SCC contraction — assign each symbol to a cluster
+  const sccs = detectSymbolCycles(db, options);
+  const clusterOf = new Map<number, number>(); // symbol → cluster representative
+  let nextCluster = 0;
+
+  for (const scc of sccs) {
+    const cid = nextCluster++;
+    for (const sid of scc) clusterOf.set(sid, cid);
+  }
+  // Assign singletons
+  for (const s of symbolRows) {
+    if (!clusterOf.has(s.id)) {
+      clusterOf.set(s.id, nextCluster++);
+    }
+  }
+
+  // Step 2: Same-file merge — merge clusters whose symbols share a file
+  const fileToClusterIds = new Map<number, Set<number>>();
+  for (const s of symbolRows) {
+    const cid = clusterOf.get(s.id)!;
+    let set = fileToClusterIds.get(s.fileId);
+    if (!set) {
+      set = new Set();
+      fileToClusterIds.set(s.fileId, set);
+    }
+    set.add(cid);
+  }
+
+  // Use union-find for merging
+  const clusterUf = new UnionFind<number>();
+  for (const cid of new Set(clusterOf.values())) clusterUf.makeSet(cid);
+
+  for (const clusterIds of fileToClusterIds.values()) {
+    const ids = [...clusterIds];
+    for (let i = 1; i < ids.length; i++) {
+      // Only merge if combined size stays within bounds
+      const rootA = clusterUf.find(ids[0]!);
+      const rootB = clusterUf.find(ids[i]!);
+      if (rootA !== rootB) {
+        const sizeA = clusterLineCount(rootA, clusterOf, clusterUf, symbolById);
+        const sizeB = clusterLineCount(rootB, clusterOf, clusterUf, symbolById);
+        if (sizeA + sizeB <= maxLines) {
+          clusterUf.union(rootA, rootB);
+        }
+      }
+    }
+  }
+
+  // Step 3: Greedy merge by edge weight
+  const crossEdgeWeights = new Map<string, number>();
+  for (const { source, target } of validEdges) {
+    const ca = clusterUf.find(clusterOf.get(source)!);
+    const cb = clusterUf.find(clusterOf.get(target)!);
+    if (ca === cb) continue;
+    const key = ca < cb ? `${ca}:${cb}` : `${cb}:${ca}`;
+    crossEdgeWeights.set(key, (crossEdgeWeights.get(key) ?? 0) + 1);
+  }
+
+  // Sort by edge weight descending and greedily merge
+  const sortedPairs = [...crossEdgeWeights.entries()]
+    .sort((a, b) => b[1] - a[1]);
+
+  for (const [key] of sortedPairs) {
+    const [aStr, bStr] = key.split(':');
+    const ca = clusterUf.find(Number(aStr));
+    const cb = clusterUf.find(Number(bStr));
+    if (ca === cb) continue;
+    const sizeA = clusterLineCount(ca, clusterOf, clusterUf, symbolById);
+    const sizeB = clusterLineCount(cb, clusterOf, clusterUf, symbolById);
+    if (sizeA + sizeB <= maxLines) {
+      clusterUf.union(ca, cb);
+    }
+  }
+
+  // Step 4: Fold undersized clusters (<30 lines) into heaviest neighbor
+  const MIN_CLUSTER_LINES = 30;
+  const finalClusters = new Map<number, number[]>(); // root → symbol ids
+  for (const s of symbolRows) {
+    const root = clusterUf.find(clusterOf.get(s.id)!);
+    let list = finalClusters.get(root);
+    if (!list) {
+      list = [];
+      finalClusters.set(root, list);
+    }
+    list.push(s.id);
+  }
+
+  // Find undersized clusters and their best merge target
+  for (const [root, symbolIds] of finalClusters) {
+    const totalLines = symbolIds.reduce((sum, id) => sum + (symbolById.get(id)?.lines ?? 0), 0);
+    if (totalLines >= MIN_CLUSTER_LINES) continue;
+
+    // Find the neighbor cluster with the most edges
+    let bestNeighbor: number | undefined;
+    let bestWeight = 0;
+    for (const { source, target } of validEdges) {
+      const cs = clusterUf.find(clusterOf.get(source)!);
+      const ct = clusterUf.find(clusterOf.get(target)!);
+      if (cs === root && ct !== root) {
+        const neighborLines = clusterLineCount(ct, clusterOf, clusterUf, symbolById);
+        if (neighborLines + totalLines <= maxLines) {
+          const key = root < ct ? `${root}:${ct}` : `${ct}:${root}`;
+          const w = crossEdgeWeights.get(key) ?? 1;
+          if (w > bestWeight) {
+            bestWeight = w;
+            bestNeighbor = ct;
+          }
+        }
+      } else if (ct === root && cs !== root) {
+        const neighborLines = clusterLineCount(cs, clusterOf, clusterUf, symbolById);
+        if (neighborLines + totalLines <= maxLines) {
+          const key = root < cs ? `${root}:${cs}` : `${cs}:${root}`;
+          const w = crossEdgeWeights.get(key) ?? 1;
+          if (w > bestWeight) {
+            bestWeight = w;
+            bestNeighbor = cs;
+          }
+        }
+      }
+    }
+
+    if (bestNeighbor !== undefined) {
+      clusterUf.union(root, bestNeighbor);
+    }
+  }
+
+  // Build final result
+  const resultMap = new Map<number, { symbolIds: number[]; fileIds: Set<number>; totalLines: number }>();
+  for (const s of symbolRows) {
+    const root = clusterUf.find(clusterOf.get(s.id)!);
+    let entry = resultMap.get(root);
+    if (!entry) {
+      entry = { symbolIds: [], fileIds: new Set(), totalLines: 0 };
+      resultMap.set(root, entry);
+    }
+    entry.symbolIds.push(s.id);
+    entry.fileIds.add(s.fileId);
+    entry.totalLines += s.lines;
+  }
+
+  // Count internal/external edges per cluster
+  const results: SymbolCluster[] = [];
+  let idx = 0;
+  for (const entry of resultMap.values()) {
+    const memberSet = new Set(entry.symbolIds);
+    let internalEdges = 0;
+    let externalEdges = 0;
+    for (const { source, target } of validEdges) {
+      const sIn = memberSet.has(source);
+      const tIn = memberSet.has(target);
+      if (sIn && tIn) internalEdges++;
+      else if (sIn || tIn) externalEdges++;
+    }
+    results.push({
+      id: idx++,
+      symbolIds: entry.symbolIds,
+      totalLines: entry.totalLines,
+      fileIds: [...entry.fileIds],
+      internalEdges,
+      externalEdges,
+    });
+  }
+
+  return results.sort((a, b) => b.totalLines - a.totalLines);
+}
+
+function clusterLineCount(
+  clusterRoot: number,
+  clusterOf: Map<number, number>,
+  uf: UnionFind<number>,
+  symbolById: Map<number, SymbolInfo>,
+): number {
+  let total = 0;
+  for (const [symId, cid] of clusterOf) {
+    if (uf.find(cid) === clusterRoot) {
+      total += symbolById.get(symId)?.lines ?? 0;
+    }
+  }
+  return total;
+}
+
+// ─── buildCodebaseSummary ─────────────────────────────────────────────────────
+
+export interface CodebaseSummaryOptions extends GraphAnalysisOptions {
+  /** Maximum lines per module for clustering. Default: 500. */
+  maxLinesPerModule?: number;
+}
+
+export interface ModuleSummary {
+  /** Module index. */
+  id: number;
+  /** File paths in this module. */
+  files: string[];
+  /** Total symbol count. */
+  symbolCount: number;
+  /** Total line span. */
+  totalLines: number;
+  /** IDs of modules this module depends on. */
+  dependsOn: number[];
+  /** IDs of modules that depend on this module. */
+  dependedOnBy: number[];
+}
+
+export interface CodebaseSummary {
+  /** Total indexed files. */
+  totalFiles: number;
+  /** Total indexed symbols. */
+  totalSymbols: number;
+  /** Total resolved edges. */
+  totalEdges: number;
+  /** Modules grouped by clustering. */
+  modules: ModuleSummary[];
+  /** Connected component groups (module IDs). */
+  connectedComponents: number[][];
+  /** Strongly connected component groups (module IDs). */
+  cyclicGroups: number[][];
+}
+
+/**
+ * Produces a condensed dependency summary of the codebase — the "30-second
+ * architecture overview."
+ *
+ * Combines symbol clustering with inter-module edge analysis and SCC/CC
+ * detection at the module level.
+ */
+export function buildCodebaseSummary(
+  db: Database.Database,
+  options: CodebaseSummaryOptions = {},
+): CodebaseSummary {
+  const branch = options.branch;
+
+  // Counts
+  const totalFiles = (
+    branch !== undefined
+      ? db.prepare('SELECT COUNT(*) AS cnt FROM files WHERE branch = ?').get(branch)
+      : db.prepare('SELECT COUNT(*) AS cnt FROM files').get()
+  ) as { cnt: number };
+
+  const totalSymbols = (
+    branch !== undefined
+      ? db.prepare('SELECT COUNT(*) AS cnt FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.branch = ?').get(branch)
+      : db.prepare('SELECT COUNT(*) AS cnt FROM symbols').get()
+  ) as { cnt: number };
+
+  const totalEdges = (
+    branch !== undefined
+      ? db.prepare(
+          `SELECT COUNT(*) AS cnt FROM symbol_refs sr
+           JOIN symbols s ON s.id = sr.caller_id
+           JOIN files f ON f.id = s.file_id
+           WHERE sr.callee_id IS NOT NULL AND f.branch = ?`,
+        ).get(branch)
+      : db.prepare('SELECT COUNT(*) AS cnt FROM symbol_refs WHERE callee_id IS NOT NULL').get()
+  ) as { cnt: number };
+
+  // Cluster symbols into modules
+  const clusters = clusterSymbols(db, {
+    ...options,
+    maxLinesPerCluster: options.maxLinesPerModule ?? 500,
+  });
+
+  if (clusters.length === 0) {
+    return {
+      totalFiles: totalFiles.cnt,
+      totalSymbols: totalSymbols.cnt,
+      totalEdges: totalEdges.cnt,
+      modules: [],
+      connectedComponents: [],
+      cyclicGroups: [],
+    };
+  }
+
+  // Build symbol → cluster mapping
+  const symbolToCluster = new Map<number, number>();
+  for (const c of clusters) {
+    for (const sid of c.symbolIds) {
+      symbolToCluster.set(sid, c.id);
+    }
+  }
+
+  // Load file paths for each cluster
+  const filePathById = new Map<number, string>(
+    (
+      branch !== undefined
+        ? db.prepare('SELECT id, path FROM files WHERE branch = ?').all(branch)
+        : db.prepare('SELECT id, path FROM files').all()
+    ).map((r: any) => [r.id, r.path]),
+  );
+
+  // Build module summaries
+  const edges = loadSymbolEdges(db, options);
+  const moduleAdj = new Map<number, Set<number>>(); // module → set of modules it depends on
+  const moduleRevAdj = new Map<number, Set<number>>(); // module → set of modules that depend on it
+
+  for (const c of clusters) {
+    moduleAdj.set(c.id, new Set());
+    moduleRevAdj.set(c.id, new Set());
+  }
+
+  for (const { source, target } of edges) {
+    const cm = symbolToCluster.get(source);
+    const cn = symbolToCluster.get(target);
+    if (cm === undefined || cn === undefined || cm === cn) continue;
+    moduleAdj.get(cm)!.add(cn);
+    moduleRevAdj.get(cn)!.add(cm);
+  }
+
+  const modules: ModuleSummary[] = clusters.map(c => ({
+    id: c.id,
+    files: c.fileIds.map(fid => filePathById.get(fid) ?? `file:${fid}`).sort(),
+    symbolCount: c.symbolIds.length,
+    totalLines: c.totalLines,
+    dependsOn: [...(moduleAdj.get(c.id) ?? [])].sort((a, b) => a - b),
+    dependedOnBy: [...(moduleRevAdj.get(c.id) ?? [])].sort((a, b) => a - b),
+  }));
+
+  // Module-level connected components
+  const moduleUf = new UnionFind<number>();
+  for (const c of clusters) moduleUf.makeSet(c.id);
+  for (const { source, target } of edges) {
+    const cm = symbolToCluster.get(source);
+    const cn = symbolToCluster.get(target);
+    if (cm !== undefined && cn !== undefined && cm !== cn) {
+      moduleUf.union(cm, cn);
+    }
+  }
+  const connectedComponents = moduleUf.components().filter(c => c.length > 1);
+
+  // Module-level SCCs
+  const moduleSccAdj = new Map<number, number[]>();
+  for (const c of clusters) moduleSccAdj.set(c.id, []);
+  for (const [mid, deps] of moduleAdj) {
+    moduleSccAdj.set(mid, [...deps]);
+  }
+
+  const cyclicGroups = tarjanScc(moduleSccAdj);
+
+  return {
+    totalFiles: totalFiles.cnt,
+    totalSymbols: totalSymbols.cnt,
+    totalEdges: totalEdges.cnt,
+    modules,
+    connectedComponents,
+    cyclicGroups,
+  };
+}
+
+/** Generic Tarjan's SCC for number-keyed adjacency. */
+function tarjanScc(adjacency: Map<number, number[]>): number[][] {
+  let index = 0;
+  const indices = new Map<number, number>();
+  const lowlink = new Map<number, number>();
+  const onStack = new Set<number>();
+  const stack: number[] = [];
+  const sccs: number[][] = [];
+
+  function strongConnect(v: number): void {
+    indices.set(v, index);
+    lowlink.set(v, index);
+    index++;
+    stack.push(v);
+    onStack.add(v);
+
+    for (const w of adjacency.get(v) ?? []) {
+      if (!indices.has(w)) {
+        strongConnect(w);
+        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v)!, indices.get(w)!));
+      }
+    }
+
+    if (lowlink.get(v) === indices.get(v)) {
+      const scc: number[] = [];
+      let w: number;
+      do {
+        w = stack.pop()!;
+        onStack.delete(w);
+        scc.push(w);
+      } while (w !== v);
+
+      if (scc.length > 1) {
+        sccs.push(scc);
+      } else {
+        const selfLoop = (adjacency.get(scc[0]!) ?? []).includes(scc[0]!);
+        if (selfLoop) sccs.push(scc);
+      }
+    }
+  }
+
+  for (const node of adjacency.keys()) {
+    if (!indices.has(node)) {
+      strongConnect(node);
+    }
+  }
+
+  return sccs;
+}

--- a/src/lore-server/db.ts
+++ b/src/lore-server/db.ts
@@ -557,6 +557,9 @@ export interface ListResolvedEdgesOptions {
   fileId?: number;
   /** Filter by caller branch. */
   branch?: string;
+  /** Allowlist of resolution methods to include. When set, only edges whose
+   *  `resolution_method` is in this list are returned. */
+  methods?: string[];
   /** Maximum rows to return. Default: 100 000. */
   limit?: number;
 }
@@ -591,6 +594,11 @@ export function listResolvedEdges(
     where.push('f_caller.branch = ?');
     params.push(options.branch);
   }
+  if (options.methods !== undefined && options.methods.length > 0) {
+    const ph = options.methods.map(() => '?').join(', ');
+    where.push(`sr.resolution_method IN (${ph})`);
+    params.push(...options.methods);
+  }
 
   const limit = options.limit ?? 100_000;
   params.push(limit);
@@ -624,6 +632,204 @@ export function listResolvedEdges(
          LIMIT ?`,
     )
     .all(...params) as ResolvedEdge[];
+}
+
+// ─── Type-ref edges ───────────────────────────────────────────────────────────
+
+export interface TypeRefEdge {
+  ref_id: number;
+  symbol_id: number | null;
+  symbol_name: string | null;
+  symbol_kind: string | null;
+  symbol_file_id: number | null;
+  symbol_file_path: string | null;
+  type_id: number | null;
+  type_name: string;
+  type_name_bare: string;
+  type_kind: string | null;
+  type_file_id: number | null;
+  type_file_path: string | null;
+  ref_kind: string;
+  ref_line: number;
+  ref_character: number | null;
+  resolution_method: string;
+}
+
+export interface ListTypeRefsOptions {
+  /** Only include edges where `type_id` is resolved (non-NULL). Default: false. */
+  resolvedOnly?: boolean;
+  /** Restrict to edges from this file. */
+  fileId?: number;
+  /** Filter by branch. */
+  branch?: string;
+  /** Allowlist of resolution methods to include. */
+  methods?: string[];
+  /** Maximum rows to return. Default: 100 000. */
+  limit?: number;
+}
+
+/**
+ * Returns type-reference edges from `type_refs`, joining through
+ * `symbols` and `files` to denormalize source/target metadata.
+ */
+export function listTypeRefs(
+  db: Database.Database,
+  options: ListTypeRefsOptions = {},
+): TypeRefEdge[] {
+  const where: string[] = [];
+  const params: Array<string | number> = [];
+
+  if (options.resolvedOnly) {
+    where.push('tr.type_id IS NOT NULL');
+  }
+  if (options.fileId !== undefined) {
+    where.push('tr.file_id = ?');
+    params.push(options.fileId);
+  }
+  if (options.branch !== undefined) {
+    where.push('f_src.branch = ?');
+    params.push(options.branch);
+  }
+  if (options.methods !== undefined && options.methods.length > 0) {
+    const ph = options.methods.map(() => '?').join(', ');
+    where.push(`tr.resolution_method IN (${ph})`);
+    params.push(...options.methods);
+  }
+
+  const limit = options.limit ?? 100_000;
+  params.push(limit);
+
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+
+  return db
+    .prepare(
+      `SELECT tr.id           AS ref_id,
+              tr.symbol_id,
+              s_src.name      AS symbol_name,
+              s_src.kind      AS symbol_kind,
+              s_src.file_id   AS symbol_file_id,
+              f_src.path      AS symbol_file_path,
+              tr.type_id,
+              tr.type_name,
+              tr.type_name_bare,
+              s_dst.kind      AS type_kind,
+              s_dst.file_id   AS type_file_id,
+              f_dst.path      AS type_file_path,
+              tr.ref_kind,
+              tr.ref_line,
+              tr.ref_character,
+              tr.resolution_method
+         FROM type_refs tr
+         JOIN files f_src ON f_src.id = tr.file_id
+         LEFT JOIN symbols s_src ON s_src.id = tr.symbol_id
+         LEFT JOIN symbols s_dst ON s_dst.id = tr.type_id
+         LEFT JOIN files   f_dst ON f_dst.id = s_dst.file_id
+         ${whereClause}
+         ORDER BY tr.file_id ASC, tr.ref_line ASC
+         LIMIT ?`,
+    )
+    .all(...params) as TypeRefEdge[];
+}
+
+// ─── Symbol-relationship edges ────────────────────────────────────────────────
+
+export interface SymbolRelationshipEdge {
+  ref_id: number;
+  source_symbol_id: number | null;
+  source_name: string | null;
+  source_kind: string | null;
+  source_file_id: number | null;
+  source_file_path: string | null;
+  target_symbol_id: number | null;
+  target_symbol_name: string;
+  target_kind: string | null;
+  target_file_id: number | null;
+  target_file_path: string | null;
+  relationship_type: string;
+  line: number;
+  character: number | null;
+  resolution_method: string;
+}
+
+export interface ListSymbolRelationshipsOptions {
+  /** Only include edges where `target_symbol_id` is resolved (non-NULL). Default: false. */
+  resolvedOnly?: boolean;
+  /** Restrict to edges from this file. */
+  fileId?: number;
+  /** Filter by branch. */
+  branch?: string;
+  /** Filter by relationship type (e.g. 'extends', 'implements'). */
+  relationshipType?: string;
+  /** Allowlist of resolution methods to include. */
+  methods?: string[];
+  /** Maximum rows to return. Default: 100 000. */
+  limit?: number;
+}
+
+/**
+ * Returns symbol-relationship edges (extends, implements, etc.) from
+ * `symbol_relationships`, joining through `symbols` and `files`.
+ */
+export function listSymbolRelationships(
+  db: Database.Database,
+  options: ListSymbolRelationshipsOptions = {},
+): SymbolRelationshipEdge[] {
+  const where: string[] = [];
+  const params: Array<string | number> = [];
+
+  if (options.resolvedOnly) {
+    where.push('rel.target_symbol_id IS NOT NULL');
+  }
+  if (options.fileId !== undefined) {
+    where.push('rel.file_id = ?');
+    params.push(options.fileId);
+  }
+  if (options.branch !== undefined) {
+    where.push('f_src.branch = ?');
+    params.push(options.branch);
+  }
+  if (options.relationshipType !== undefined) {
+    where.push('rel.relationship_type = ?');
+    params.push(options.relationshipType);
+  }
+  if (options.methods !== undefined && options.methods.length > 0) {
+    const ph = options.methods.map(() => '?').join(', ');
+    where.push(`rel.resolution_method IN (${ph})`);
+    params.push(...options.methods);
+  }
+
+  const limit = options.limit ?? 100_000;
+  params.push(limit);
+
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+
+  return db
+    .prepare(
+      `SELECT rel.id               AS ref_id,
+              rel.source_symbol_id,
+              s_src.name           AS source_name,
+              s_src.kind           AS source_kind,
+              s_src.file_id        AS source_file_id,
+              f_src.path           AS source_file_path,
+              rel.target_symbol_id,
+              rel.target_symbol_name,
+              s_dst.kind           AS target_kind,
+              s_dst.file_id        AS target_file_id,
+              f_dst.path           AS target_file_path,
+              rel.relationship_type,
+              rel.line,
+              rel.character,
+              rel.resolution_method
+         FROM symbol_relationships rel
+         JOIN files f_src ON f_src.id = rel.file_id
+         LEFT JOIN symbols s_src ON s_src.id = rel.source_symbol_id
+         LEFT JOIN symbols s_dst ON s_dst.id = rel.target_symbol_id
+         LEFT JOIN files   f_dst ON f_dst.id = s_dst.file_id
+         ${whereClause}
+         ORDER BY rel.file_id ASC, rel.line ASC
+         LIMIT ?`,
+    )
+    .all(...params) as SymbolRelationshipEdge[];
 }
 
 // ─── Documentation helpers ─────────────────────────────────────────────────────

--- a/src/lore-server/tool-registry.ts
+++ b/src/lore-server/tool-registry.ts
@@ -232,6 +232,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
   const [
     lookup,
     graph,
+    graphAnalysis,
     search,
     docsMod,
     routes,
@@ -248,6 +249,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
   ] = await Promise.all([
     import('./tools/lookup.js'),
     import('./tools/graph.js'),
+    import('./tools/graph-analysis.js'),
     import('./tools/search.js'),
     import('./tools/docs.js'),
     import('./tools/routes.js'),
@@ -271,6 +273,10 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     {
       def: graph.toolDef,
       handlerFactory: (deps) => (args) => graph.handler(deps.db, args),
+    },
+    {
+      def: graphAnalysis.toolDef,
+      handlerFactory: (deps) => (args) => graphAnalysis.handler(deps.db, args),
     },
     {
       def: search.toolDef,

--- a/src/lore-server/tools/graph-analysis.ts
+++ b/src/lore-server/tools/graph-analysis.ts
@@ -1,0 +1,118 @@
+/**
+ * @module lore-server/tools/graph-analysis
+ *
+ * MCP tool: run graph analysis primitives (symbol cycles, connected
+ * components, symbol clustering, codebase summary).
+ */
+
+import type { Database } from '../db.js';
+import {
+  detectSymbolCycles,
+  findConnectedComponents,
+  clusterSymbols,
+  buildCodebaseSummary,
+} from '../../indexer/graph-analysis.js';
+import type {
+  EdgeKind,
+  SymbolCluster,
+  CodebaseSummary,
+} from '../../indexer/graph-analysis.js';
+
+// ─── Tool definition ──────────────────────────────────────────────────────────
+
+export const toolDef = {
+  name: 'lore_analyze',
+  description:
+    'Run graph analysis on the knowledge-base. Supports four modes: ' +
+    '"cycles" (symbol-level strongly connected components / mutual recursion), ' +
+    '"components" (connected components at file or symbol level), ' +
+    '"clusters" (partition symbol graph into bounded-size coherent chunks), ' +
+    '"summary" (condensed codebase dependency overview with modules, SCCs, and components).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      mode: {
+        type: 'string',
+        enum: ['cycles', 'components', 'clusters', 'summary'],
+        description:
+          'Analysis mode. "cycles": symbol-level SCC detection; "components": connected components; ' +
+          '"clusters": bounded-size symbol clustering; "summary": full codebase summary.',
+      },
+      edge_kinds: {
+        type: 'string',
+        enum: ['call', 'type', 'both'],
+        description: 'Which edge types to traverse. Default: "both".',
+      },
+      scope: {
+        type: 'string',
+        enum: ['file', 'symbol'],
+        description: 'Scope for components mode. Default: "symbol".',
+      },
+      branch: {
+        type: 'string',
+        description: 'Optional branch filter.',
+      },
+      max_lines: {
+        type: 'number',
+        description: 'Maximum lines per cluster/module (for clusters and summary modes). Default: 500.',
+        minimum: 1,
+      },
+    },
+    required: ['mode'],
+  },
+} as const;
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export interface AnalyzeArgs {
+  mode: 'cycles' | 'components' | 'clusters' | 'summary';
+  edge_kinds?: EdgeKind;
+  scope?: 'file' | 'symbol';
+  branch?: string;
+  max_lines?: number;
+}
+
+export type AnalyzeResult =
+  | { mode: 'cycles'; sccs: number[][] }
+  | { mode: 'components'; components: number[][] }
+  | { mode: 'clusters'; clusters: SymbolCluster[] }
+  | { mode: 'summary'; summary: CodebaseSummary };
+
+export function handler(db: Database.Database, args: AnalyzeArgs): AnalyzeResult {
+  const opts = {
+    edgeKinds: args.edge_kinds ?? 'both' as EdgeKind,
+    branch: args.branch,
+  };
+
+  switch (args.mode) {
+    case 'cycles':
+      return { mode: 'cycles', sccs: detectSymbolCycles(db, opts) };
+
+    case 'components':
+      return {
+        mode: 'components',
+        components: findConnectedComponents(db, {
+          ...opts,
+          scope: args.scope ?? 'symbol',
+        }),
+      };
+
+    case 'clusters':
+      return {
+        mode: 'clusters',
+        clusters: clusterSymbols(db, {
+          ...opts,
+          maxLinesPerCluster: args.max_lines,
+        }),
+      };
+
+    case 'summary':
+      return {
+        mode: 'summary',
+        summary: buildCodebaseSummary(db, {
+          ...opts,
+          maxLinesPerModule: args.max_lines,
+        }),
+      };
+  }
+}

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -69,6 +69,21 @@ describe('public API surface', () => {
     expect(publicApi.listResolvedEdges).toBeDefined();
   });
 
+  it('should export listTypeRefs for type-reference edges', () => {
+    expect(publicApi.listTypeRefs).toBeDefined();
+  });
+
+  it('should export listSymbolRelationships for inheritance/implements edges', () => {
+    expect(publicApi.listSymbolRelationships).toBeDefined();
+  });
+
+  it('should export graph analysis primitives', () => {
+    expect(publicApi.detectSymbolCycles).toBeDefined();
+    expect(publicApi.findConnectedComponents).toBeDefined();
+    expect(publicApi.clusterSymbols).toBeDefined();
+    expect(publicApi.buildCodebaseSummary).toBeDefined();
+  });
+
   it('should NOT export internal stage helpers', () => {
     expect((publicApi as any).processFile).toBeUndefined();
     expect((publicApi as any).enrichProjectRefs).toBeUndefined();

--- a/tests/indexer/graph-analysis.test.ts
+++ b/tests/indexer/graph-analysis.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectSymbolCycles,
+  findConnectedComponents,
+  clusterSymbols,
+  buildCodebaseSummary,
+} from '../../src/indexer/graph-analysis.js';
+import { openDb } from '../../src/indexer/db.js';
+import { resolveSymbolEdges } from '../../src/indexer/call-graph.js';
+import type { Database } from '../../src/indexer/db.js';
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function createDb(): Database.Database {
+  return openDb(':memory:');
+}
+
+function insertFile(db: Database.Database, path: string): number {
+  return Number(
+    db.prepare("INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, 'HEAD', 'typescript', 0, NULL, '')")
+      .run(path).lastInsertRowid,
+  );
+}
+
+function insertSymbol(
+  db: Database.Database,
+  fileId: number,
+  name: string,
+  kind = 'function',
+  startLine = 1,
+  endLine?: number,
+): number {
+  return Number(
+    db.prepare('INSERT INTO symbols (file_id, name, kind, start_line, end_line, signature) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(fileId, name, kind, startLine, endLine ?? startLine + 10, `${kind} ${name}`).lastInsertRowid,
+  );
+}
+
+function insertCallRef(
+  db: Database.Database,
+  callerId: number,
+  fileId: number,
+  calleeName: string,
+  callLine: number,
+): void {
+  db.prepare(
+    `INSERT INTO symbol_refs (caller_id, file_id, callee_name, call_line) VALUES (?, ?, ?, ?)`,
+  ).run(callerId, fileId, calleeName, callLine);
+}
+
+function insertFileImport(db: Database.Database, fileId: number, resolvedId: number): void {
+  db.prepare(
+    `INSERT INTO file_imports (file_id, raw_import, resolved_id) VALUES (?, 'import', ?)`,
+  ).run(fileId, resolvedId);
+}
+
+/**
+ * Helper: set up a resolved call edge directly.
+ * Sets callee_id and resolution_method to bypass resolution.
+ */
+function insertResolvedCallRef(
+  db: Database.Database,
+  callerId: number,
+  calleeId: number,
+  fileId: number,
+  callLine = 1,
+): void {
+  db.prepare(
+    `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+     VALUES (?, ?, ?, 'resolved', ?, 'name_unique')`,
+  ).run(callerId, fileId, calleeId, callLine);
+}
+
+// ─── detectSymbolCycles ───────────────────────────────────────────────────────
+
+describe('detectSymbolCycles', () => {
+  it('should find no cycles in a DAG', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'a');
+    const b = insertSymbol(db, f, 'b');
+    const c = insertSymbol(db, f, 'c');
+
+    // a → b → c (no cycle)
+    insertResolvedCallRef(db, a, b, f);
+    insertResolvedCallRef(db, b, c, f);
+
+    const sccs = detectSymbolCycles(db);
+    expect(sccs).toEqual([]);
+  });
+
+  it('should detect a simple mutual recursion cycle', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'funcA');
+    const b = insertSymbol(db, f, 'funcB');
+
+    // a → b → a (cycle)
+    insertResolvedCallRef(db, a, b, f);
+    insertResolvedCallRef(db, b, a, f);
+
+    const sccs = detectSymbolCycles(db);
+    expect(sccs).toHaveLength(1);
+    expect(sccs[0]).toHaveLength(2);
+    expect(new Set(sccs[0])).toEqual(new Set([a, b]));
+  });
+
+  it('should detect a self-referencing symbol', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'recursive');
+
+    insertResolvedCallRef(db, a, a, f);
+
+    const sccs = detectSymbolCycles(db);
+    expect(sccs).toHaveLength(1);
+    expect(sccs[0]).toEqual([a]);
+  });
+
+  it('should detect multiple separate SCCs', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'a');
+    const b = insertSymbol(db, f, 'b');
+    const c = insertSymbol(db, f, 'c');
+    const d = insertSymbol(db, f, 'd');
+
+    // Cycle 1: a ↔ b
+    insertResolvedCallRef(db, a, b, f);
+    insertResolvedCallRef(db, b, a, f);
+    // Cycle 2: c ↔ d
+    insertResolvedCallRef(db, c, d, f);
+    insertResolvedCallRef(db, d, c, f);
+
+    const sccs = detectSymbolCycles(db);
+    expect(sccs).toHaveLength(2);
+
+    const sets = sccs.map(scc => new Set(scc));
+    expect(sets).toContainEqual(new Set([a, b]));
+    expect(sets).toContainEqual(new Set([c, d]));
+  });
+
+  it('should respect edgeKinds=call (ignore type edges)', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'ClassA', 'class');
+    const b = insertSymbol(db, f, 'ClassB', 'class');
+
+    // Type-ref cycle only (not call)
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'ClassB', 'ClassB', 'parameter', 5, 'name_same_file')`,
+    ).run(f, a, b);
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'ClassA', 'ClassA', 'parameter', 15, 'name_same_file')`,
+    ).run(f, b, a);
+
+    // With call only → no cycles
+    const callOnly = detectSymbolCycles(db, { edgeKinds: 'call' });
+    expect(callOnly).toEqual([]);
+
+    // With type only → should find the cycle
+    const typeOnly = detectSymbolCycles(db, { edgeKinds: 'type' });
+    expect(typeOnly).toHaveLength(1);
+    expect(new Set(typeOnly[0])).toEqual(new Set([a, b]));
+
+    // With both → should also find it
+    const both = detectSymbolCycles(db, { edgeKinds: 'both' });
+    expect(both).toHaveLength(1);
+  });
+
+  it('should return empty for empty database', () => {
+    const db = createDb();
+    expect(detectSymbolCycles(db)).toEqual([]);
+  });
+});
+
+// ─── findConnectedComponents ──────────────────────────────────────────────────
+
+describe('findConnectedComponents', () => {
+  describe('symbol scope', () => {
+    it('should find a single component from connected symbols', () => {
+      const db = createDb();
+      const f = insertFile(db, 'src/a.ts');
+      const a = insertSymbol(db, f, 'a');
+      const b = insertSymbol(db, f, 'b');
+      const c = insertSymbol(db, f, 'c');
+
+      insertResolvedCallRef(db, a, b, f);
+      insertResolvedCallRef(db, b, c, f);
+
+      const components = findConnectedComponents(db, { scope: 'symbol' });
+      expect(components).toHaveLength(1);
+      expect(new Set(components[0])).toEqual(new Set([a, b, c]));
+    });
+
+    it('should find two separate components', () => {
+      const db = createDb();
+      const f1 = insertFile(db, 'src/a.ts');
+      const f2 = insertFile(db, 'src/b.ts');
+      const a = insertSymbol(db, f1, 'a');
+      const b = insertSymbol(db, f1, 'b');
+      const c = insertSymbol(db, f2, 'c');
+      const d = insertSymbol(db, f2, 'd');
+
+      insertResolvedCallRef(db, a, b, f1);
+      insertResolvedCallRef(db, c, d, f2);
+
+      const components = findConnectedComponents(db, { scope: 'symbol' });
+      expect(components).toHaveLength(2);
+
+      const sets = components.map(c => new Set(c));
+      expect(sets).toContainEqual(new Set([a, b]));
+      expect(sets).toContainEqual(new Set([c, d]));
+    });
+
+    it('should return empty for no edges', () => {
+      const db = createDb();
+      insertFile(db, 'src/a.ts');
+      expect(findConnectedComponents(db, { scope: 'symbol' })).toEqual([]);
+    });
+  });
+
+  describe('file scope', () => {
+    it('should find connected file components via imports', () => {
+      const db = createDb();
+      const f1 = insertFile(db, 'src/a.ts');
+      const f2 = insertFile(db, 'src/b.ts');
+      const f3 = insertFile(db, 'src/c.ts');
+
+      insertFileImport(db, f1, f2);
+      insertFileImport(db, f2, f3);
+
+      const components = findConnectedComponents(db, { scope: 'file' });
+      expect(components).toHaveLength(1);
+      expect(new Set(components[0])).toEqual(new Set([f1, f2, f3]));
+    });
+
+    it('should find two disconnected file components', () => {
+      const db = createDb();
+      const f1 = insertFile(db, 'src/a.ts');
+      const f2 = insertFile(db, 'src/b.ts');
+      const f3 = insertFile(db, 'src/c.ts');
+      const f4 = insertFile(db, 'src/d.ts');
+
+      insertFileImport(db, f1, f2);
+      insertFileImport(db, f3, f4);
+
+      const components = findConnectedComponents(db, { scope: 'file' });
+      expect(components).toHaveLength(2);
+    });
+  });
+});
+
+// ─── clusterSymbols ───────────────────────────────────────────────────────────
+
+describe('clusterSymbols', () => {
+  it('should return empty for an empty database', () => {
+    const db = createDb();
+    expect(clusterSymbols(db)).toEqual([]);
+  });
+
+  it('should cluster mutually recursive symbols together', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'funcA', 'function', 1, 20);
+    const b = insertSymbol(db, f, 'funcB', 'function', 21, 40);
+
+    insertResolvedCallRef(db, a, b, f);
+    insertResolvedCallRef(db, b, a, f);
+
+    const clusters = clusterSymbols(db);
+    expect(clusters.length).toBeGreaterThanOrEqual(1);
+
+    // a and b must be in the same cluster (SCC)
+    const clusterWithA = clusters.find(c => c.symbolIds.includes(a));
+    expect(clusterWithA).toBeDefined();
+    expect(clusterWithA!.symbolIds).toContain(b);
+  });
+
+  it('should merge same-file symbols when within line budget', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'helper', 'function', 1, 10);
+    const b = insertSymbol(db, f, 'main', 'function', 11, 20);
+
+    // No edges between them, but same file → should merge
+    const clusters = clusterSymbols(db, { maxLinesPerCluster: 100 });
+    expect(clusters.length).toBeGreaterThanOrEqual(1);
+
+    const clusterWithA = clusters.find(c => c.symbolIds.includes(a));
+    expect(clusterWithA).toBeDefined();
+    expect(clusterWithA!.symbolIds).toContain(b);
+  });
+
+  it('should not merge when exceeding max lines', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const a = insertSymbol(db, f1, 'bigFunc', 'function', 1, 50);
+    const b = insertSymbol(db, f2, 'otherBig', 'function', 1, 50);
+
+    insertResolvedCallRef(db, a, b, f1);
+
+    // maxLines = 60 — combining two 50-line symbols would exceed
+    const clusters = clusterSymbols(db, { maxLinesPerCluster: 60 });
+    const clusterA = clusters.find(c => c.symbolIds.includes(a));
+    const clusterB = clusters.find(c => c.symbolIds.includes(b));
+    expect(clusterA).toBeDefined();
+    expect(clusterB).toBeDefined();
+    expect(clusterA!.id).not.toBe(clusterB!.id);
+  });
+
+  it('should report internal and external edge counts', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const a = insertSymbol(db, f1, 'a', 'function', 1, 100);
+    const b = insertSymbol(db, f1, 'b', 'function', 101, 200);
+    const c = insertSymbol(db, f2, 'c', 'function', 1, 100);
+
+    // a → b (internal), a → c (external)
+    insertResolvedCallRef(db, a, b, f1);
+    insertResolvedCallRef(db, a, c, f1);
+
+    const clusters = clusterSymbols(db, { maxLinesPerCluster: 250 });
+    // a and b should be in same cluster (same file, fits in budget)
+    const clusterAB = clusters.find(c => c.symbolIds.includes(a));
+    expect(clusterAB).toBeDefined();
+    expect(clusterAB!.symbolIds).toContain(b);
+    expect(clusterAB!.internalEdges).toBeGreaterThanOrEqual(1);
+    expect(clusterAB!.externalEdges).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── buildCodebaseSummary ─────────────────────────────────────────────────────
+
+describe('buildCodebaseSummary', () => {
+  it('should return zero counts for an empty database', () => {
+    const db = createDb();
+    const summary = buildCodebaseSummary(db);
+    expect(summary.totalFiles).toBe(0);
+    expect(summary.totalSymbols).toBe(0);
+    expect(summary.totalEdges).toBe(0);
+    expect(summary.modules).toEqual([]);
+    expect(summary.connectedComponents).toEqual([]);
+    expect(summary.cyclicGroups).toEqual([]);
+  });
+
+  it('should produce a summary with modules for a simple codebase', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const a = insertSymbol(db, f1, 'funcA', 'function', 1, 20);
+    const b = insertSymbol(db, f2, 'funcB', 'function', 1, 20);
+
+    insertResolvedCallRef(db, a, b, f1);
+
+    const summary = buildCodebaseSummary(db);
+    expect(summary.totalFiles).toBe(2);
+    expect(summary.totalSymbols).toBe(2);
+    expect(summary.totalEdges).toBe(1);
+    expect(summary.modules.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should detect cyclic module groups', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const a = insertSymbol(db, f1, 'funcA', 'function', 1, 200);
+    const b = insertSymbol(db, f2, 'funcB', 'function', 1, 200);
+
+    // Force a → b and b → a (module-level cycle)
+    insertResolvedCallRef(db, a, b, f1);
+    insertResolvedCallRef(db, b, a, f2);
+
+    // max 250 lines per module — symbols are in separate files with 200 lines each
+    // so they shouldn't merge into one cluster
+    const summary = buildCodebaseSummary(db, { maxLinesPerModule: 250 });
+
+    // Should have at least 2 modules (one per file since they don't fit together)
+    if (summary.modules.length >= 2) {
+      // The two modules should be in the same connected component
+      expect(summary.connectedComponents.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('should report module dependencies', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const a = insertSymbol(db, f1, 'funcA', 'function', 1, 200);
+    const b = insertSymbol(db, f2, 'funcB', 'function', 1, 200);
+
+    insertResolvedCallRef(db, a, b, f1);
+
+    const summary = buildCodebaseSummary(db, { maxLinesPerModule: 250 });
+    // At least one module should have a dependency
+    const hasDeps = summary.modules.some(m => m.dependsOn.length > 0);
+    const hasRevDeps = summary.modules.some(m => m.dependedOnBy.length > 0);
+    if (summary.modules.length >= 2) {
+      expect(hasDeps).toBe(true);
+      expect(hasRevDeps).toBe(true);
+    }
+  });
+});
+
+// ─── methods filter (resolution confidence) ───────────────────────────────────
+
+describe('resolution method filtering', () => {
+  it('should only include specified resolution methods', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'a');
+    const b = insertSymbol(db, f, 'b');
+    const c = insertSymbol(db, f, 'c');
+
+    // a → b via lsp_definition
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'b', 1, 'lsp_definition')`,
+    ).run(a, f, b);
+
+    // b → c via name_unique
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'c', 1, 'name_unique')`,
+    ).run(b, f, c);
+
+    // a → c via self-loop with name_same_file
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'a', 1, 'name_same_file')`,
+    ).run(c, f, a);
+
+    // Filter to only lsp_definition → no cycle (only a→b)
+    const sccsLsp = detectSymbolCycles(db, { methods: ['lsp_definition'] });
+    expect(sccsLsp).toEqual([]);
+
+    // Filter to all three → should find cycle a→b→c→a
+    const sccsAll = detectSymbolCycles(db, {
+      methods: ['lsp_definition', 'name_unique', 'name_same_file'],
+    });
+    expect(sccsAll).toHaveLength(1);
+    expect(new Set(sccsAll[0])).toEqual(new Set([a, b, c]));
+  });
+});

--- a/tests/lore-server/db-edges.test.ts
+++ b/tests/lore-server/db-edges.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import { openDb } from '../../src/indexer/db.js';
+import {
+  listResolvedEdges,
+  listTypeRefs,
+  listSymbolRelationships,
+} from '../../src/lore-server/db.js';
+import type { Database } from '../../src/indexer/db.js';
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function createDb(): Database.Database {
+  return openDb(':memory:');
+}
+
+function insertFile(db: Database.Database, path: string): number {
+  return Number(
+    db.prepare("INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, 'HEAD', 'typescript', 0, NULL, '')")
+      .run(path).lastInsertRowid,
+  );
+}
+
+function insertSymbol(
+  db: Database.Database,
+  fileId: number,
+  name: string,
+  kind = 'function',
+  startLine = 1,
+  endLine?: number,
+): number {
+  return Number(
+    db.prepare('INSERT INTO symbols (file_id, name, kind, start_line, end_line, signature) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(fileId, name, kind, startLine, endLine ?? startLine + 10, `${kind} ${name}`).lastInsertRowid,
+  );
+}
+
+// ─── listResolvedEdges with methods filter ────────────────────────────────────
+
+describe('listResolvedEdges – methods filter', () => {
+  it('should filter edges by resolution method when methods option is set', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'caller');
+    const b = insertSymbol(db, f, 'callee1');
+    const c = insertSymbol(db, f, 'callee2');
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'callee1', 5, 'lsp_definition')`,
+    ).run(a, f, b);
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'callee2', 10, 'name_unique')`,
+    ).run(a, f, c);
+
+    // Without filter: both edges
+    const all = listResolvedEdges(db);
+    expect(all).toHaveLength(2);
+
+    // With lsp_definition only
+    const lspOnly = listResolvedEdges(db, { methods: ['lsp_definition'] });
+    expect(lspOnly).toHaveLength(1);
+    expect(lspOnly[0]!.callee_id).toBe(b);
+
+    // With name_unique only
+    const nameOnly = listResolvedEdges(db, { methods: ['name_unique'] });
+    expect(nameOnly).toHaveLength(1);
+    expect(nameOnly[0]!.callee_id).toBe(c);
+  });
+
+  it('should return all edges when methods is not set', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const a = insertSymbol(db, f, 'caller');
+    const b = insertSymbol(db, f, 'callee');
+
+    db.prepare(
+      `INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, resolution_method)
+       VALUES (?, ?, ?, 'callee', 5, 'lsp_definition')`,
+    ).run(a, f, b);
+
+    const edges = listResolvedEdges(db);
+    expect(edges).toHaveLength(1);
+  });
+});
+
+// ─── listTypeRefs ─────────────────────────────────────────────────────────────
+
+describe('listTypeRefs', () => {
+  it('should return type-ref edges with denormalized metadata', () => {
+    const db = createDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const sym = insertSymbol(db, f1, 'render', 'function');
+    const typeTarget = insertSymbol(db, f2, 'Widget', 'class');
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'Widget', 'Widget', 'parameter', 5, 'lsp_definition')`,
+    ).run(f1, sym, typeTarget);
+
+    const edges = listTypeRefs(db);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]!.symbol_id).toBe(sym);
+    expect(edges[0]!.type_id).toBe(typeTarget);
+    expect(edges[0]!.type_name).toBe('Widget');
+    expect(edges[0]!.ref_kind).toBe('parameter');
+    expect(edges[0]!.resolution_method).toBe('lsp_definition');
+    expect(edges[0]!.symbol_file_path).toBe('src/a.ts');
+    expect(edges[0]!.type_file_path).toBe('src/b.ts');
+  });
+
+  it('should filter by resolvedOnly', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const sym = insertSymbol(db, f, 'func');
+
+    // Resolved
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'Widget', 'Widget', 'parameter', 5, 'lsp_definition')`,
+    ).run(f, sym, sym);
+
+    // Unresolved
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, 'Unknown', 'Unknown', 'parameter', 10, 'unresolved')`,
+    ).run(f, sym);
+
+    const all = listTypeRefs(db);
+    expect(all).toHaveLength(2);
+
+    const resolved = listTypeRefs(db, { resolvedOnly: true });
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.type_id).toBe(sym);
+  });
+
+  it('should filter by methods', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const sym = insertSymbol(db, f, 'func');
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'A', 'A', 'parameter', 5, 'lsp_definition')`,
+    ).run(f, sym, sym);
+
+    db.prepare(
+      `INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, resolution_method)
+       VALUES (?, ?, ?, 'B', 'B', 'return', 10, 'name_same_file')`,
+    ).run(f, sym, sym);
+
+    const lspOnly = listTypeRefs(db, { methods: ['lsp_definition'] });
+    expect(lspOnly).toHaveLength(1);
+    expect(lspOnly[0]!.type_name).toBe('A');
+  });
+});
+
+// ─── listSymbolRelationships ──────────────────────────────────────────────────
+
+describe('listSymbolRelationships', () => {
+  it('should return symbol-relationship edges with denormalized metadata', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const parent = insertSymbol(db, f, 'BaseClass', 'class');
+    const child = insertSymbol(db, f, 'ChildClass', 'class');
+
+    db.prepare(
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, resolution_method)
+       VALUES (?, ?, ?, 'BaseClass', 'extends', 1, 'name_same_file')`,
+    ).run(f, child, parent);
+
+    const edges = listSymbolRelationships(db);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]!.source_symbol_id).toBe(child);
+    expect(edges[0]!.target_symbol_id).toBe(parent);
+    expect(edges[0]!.relationship_type).toBe('extends');
+    expect(edges[0]!.source_file_path).toBe('src/a.ts');
+  });
+
+  it('should filter by relationshipType', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const parent = insertSymbol(db, f, 'Base', 'class');
+    const iface = insertSymbol(db, f, 'IFace', 'interface');
+    const child = insertSymbol(db, f, 'Child', 'class');
+
+    db.prepare(
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, resolution_method)
+       VALUES (?, ?, ?, 'Base', 'extends', 1, 'name_same_file')`,
+    ).run(f, child, parent);
+
+    db.prepare(
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, resolution_method)
+       VALUES (?, ?, ?, 'IFace', 'implements', 2, 'name_same_file')`,
+    ).run(f, child, iface);
+
+    const extendsOnly = listSymbolRelationships(db, { relationshipType: 'extends' });
+    expect(extendsOnly).toHaveLength(1);
+
+    const implementsOnly = listSymbolRelationships(db, { relationshipType: 'implements' });
+    expect(implementsOnly).toHaveLength(1);
+  });
+
+  it('should filter by methods', () => {
+    const db = createDb();
+    const f = insertFile(db, 'src/a.ts');
+    const parent = insertSymbol(db, f, 'Base', 'class');
+    const child = insertSymbol(db, f, 'Child', 'class');
+
+    db.prepare(
+      `INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, resolution_method)
+       VALUES (?, ?, ?, 'Base', 'extends', 1, 'lsp_definition')`,
+    ).run(f, child, parent);
+
+    const noMatch = listSymbolRelationships(db, { methods: ['name_unique'] });
+    expect(noMatch).toHaveLength(0);
+
+    const match = listSymbolRelationships(db, { methods: ['lsp_definition'] });
+    expect(match).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add higher-level graph analysis primitives that operate on the symbol adjacency graph (`call_refs` + `type_refs`), filling gaps identified by downstream consumers (AAMF).

## New functions — `src/indexer/graph-analysis.ts`

| Function | Description |
|---|---|
| `detectSymbolCycles(db, opts)` | Tarjan's SCC on the **symbol** graph — finds mutual recursion and circular type dependencies |
| `findConnectedComponents(db, opts)` | Union-find connected components at `file` or `symbol` scope — identifies independent codebase regions |
| `clusterSymbols(db, opts)` | Bounded-size symbol clustering via SCC contraction → same-file merge → greedy edge-weight consolidation → affinity folding |
| `buildCodebaseSummary(db, opts)` | Condensed dependency overview with modules, SCCs, and connected components |

All functions accept an `edgeKinds` option (`'call'` | `'type'` | `'both'`) and a `methods` allowlist for resolution confidence filtering.

## New query functions — `src/lore-server/db.ts`

| Function | Description |
|---|---|
| `listTypeRefs(db, opts)` | Denormalized `type_refs` query with full source/target metadata |
| `listSymbolRelationships(db, opts)` | Denormalized `symbol_relationships` query (extends, implements) |

Also added a `methods?: string[]` allowlist filter to `listResolvedEdges()`, `listTypeRefs()`, and `listSymbolRelationships()` — consumers can now filter edges by resolution confidence without post-processing.

## Surface area

| Surface | How |
|---|---|
| **Node API** | All functions and types exported from `src/index.ts` |
| **CLI** | `lore analyze --db <path> --mode <cycles\|components\|clusters\|summary> [--edge-kinds <call\|type\|both>] [--branch <name>] [--max-lines <n>]` |
| **MCP** | `lore_analyze` tool with `mode`, `edge_kinds`, `scope`, `branch`, `max_lines` parameters |

## Tests

29 new tests across 3 files — all 1416 tests pass.