### PR TITLE
chore: release v0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ flowchart LR
         METRICS[lore_metrics]
         COVERAGE[lore_coverage]
         WRITEBACK[lore_writeback]
+        ANALYZE[lore_analyze]
     end
 
     subgraph MCP_CLIENTS[MCP Clients — Agents]
@@ -84,10 +85,10 @@ flowchart LR
     RESOLVE -.->|optional| EMBED
     EMBED -.-> DB
 
-    DB --- LOOKUP & SEARCH & DOCS_TOOL & ANNOT & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS & COVERAGE & WRITEBACK
+    DB --- LOOKUP & SEARCH & DOCS_TOOL & ANNOT & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS & COVERAGE & WRITEBACK & ANALYZE
     EMBED <-.->|semantic/fused| SEARCH
 
-    LOOKUP & SEARCH & DOCS_TOOL & ANNOT & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS & COVERAGE & WRITEBACK <--> MCP_CLIENTS
+    LOOKUP & SEARCH & DOCS_TOOL & ANNOT & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS & COVERAGE & WRITEBACK & ANALYZE <--> MCP_CLIENTS
 ```
 
 Lore sits between your codebase and any LLM-powered tool. A `LoreRuntime`
@@ -196,6 +197,7 @@ await builder.build();
 | `lore_metrics` | Aggregate index metrics plus coverage/staleness fields |
 | `lore_coverage` | Symbol-level coverage, uncovered lines, and staleness metadata |
 | `lore_writeback` | Persist agent-authored symbol summaries |
+| `lore_analyze` | Run graph analysis primitives: symbol-level cycle detection (SCC), connected components (file or symbol scope), bounded-size symbol clustering, and condensed codebase summary |
 
 ### lore_lookup query options
 
@@ -380,13 +382,19 @@ npx @jafreck/lore ingest-coverage --db ./lore.db --root ./my-project \
 
 Lore optionally generates dense vector embeddings for semantic search using
 `@huggingface/transformers` (Transformers.js), which runs ONNX models natively
-in Node.js — no Python or external processes required. Specify the model with
-`--embedding-model`:
+in Node.js — no Python or external processes required. The default model is
+`Qwen/Qwen3-Embedding-0.6B` (1024-dim); override with `--embedding-model`:
 
 ```bash
 npx @jafreck/lore index --root ./my-project --db ./lore.db \
   --embedding-model 'nomic-ai/nomic-embed-text-v1.5'
 ```
+
+Hardware acceleration is automatic: CoreML on Apple Silicon, WebGPU when
+available, CPU elsewhere. Override via the `LORE_EMBED_DEVICE` env var.
+Quantized ONNX dtype (fp32/fp16/q8/q4) is configurable with `LORE_EMBED_DTYPE`.
+In update/watch/poll mode, symbols and docs whose embedding text is unchanged
+(SHA-256 hash comparison) are skipped entirely for fast incremental re-embeds.
 
 At query time, `lore_search` in `semantic` or `fused` mode embeds the query
 and performs cosine similarity against stored vectors. If the model cannot
@@ -541,6 +549,14 @@ Start the MCP server over stdio.
 
 ```bash
 npx @jafreck/lore mcp --db <path> [--blocking-embedder]
+```
+
+### lore analyze
+
+Run graph analysis on an indexed knowledge base.
+
+```bash
+npx @jafreck/lore analyze --db <path> [--mode <cycles|components|clusters|summary>] [--edge-kinds <call|type|both>] [--branch <name>] [--max-lines <n>]
 ```
 
 ## Build from source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ LoreRuntime              ← lifecycle owner (DB, embedder, LSP, watcher/poller)
             ├─ TestMapStage           (inline)
             ├─ HistoryStage           (inline)
             └─ EmbeddingStage
+  └─ GraphAnalysis       ← SCC, connected components, clustering, summary
   └─ MCP Server
        └─ ToolRegistry   ← auto-registers tools from toolDef exports
 ```
@@ -92,6 +93,7 @@ flowchart LR
         METRICS[lore_metrics]
         LORE_COVERAGE[lore_coverage]
         WRITEBACK[lore_writeback]
+        ANALYZE[lore_analyze]
     end
 
     subgraph LLM_AGENTS[Agents]
@@ -129,9 +131,9 @@ flowchart LR
     EMBED -.->|optional| VEC
     GIT --> GITHIST --> HIST
 
-    FILES & SYM & IMP & EXT & REFS & TYPES & ANN & ROUTE_STORE & DOCS & NOTES & COV & VEC & HIST & META --- LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK
+    FILES & SYM & IMP & EXT & REFS & TYPES & ANN & ROUTE_STORE & DOCS & NOTES & COV & VEC & HIST & META --- LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK & ANALYZE
 
-    LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK <--> LLM_AGENTS
+    LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK & ANALYZE <--> LLM_AGENTS
 
     LLM_AGENTS <--- ENTRY
 ```
@@ -172,9 +174,10 @@ during the LSP enrichment stage.
 | `extractors/*` | Language-specific AST visitors for symbols, imports, call refs, type refs, annotations, and API routes; all 23 supported languages extract call references |
 | `resolver.ts` | Classifies each raw import as internal (resolved to a file ID) or external (third-party / stdlib) |
 | `call-graph.ts` | 3-tier symbol resolution with LSP-first ref resolution and name-based fallback; supports topo sort and cycle detection |
+| `graph-analysis.ts` | Higher-level graph primitives: Tarjan SCC on symbol adjacency, union-find connected components, SCC-contracted bounded clustering, and condensed codebase summary |
 | `docs.ts` | Discovers docs from default/configured globs, infers kind/title, chunks by heading hierarchy |
 | `coverage.ts` | Parses LCOV/Cobertura reports, normalizes per-file/per-line hit data, persists runs linked to commit SHA/source mtime |
-| `embedder.ts` | Optional — uses `@huggingface/transformers` (Transformers.js) to run ONNX embedding models natively in Node.js; async initialization so MCP starts immediately |
+| `embedder.ts` | Optional — uses `@huggingface/transformers` (Transformers.js) to run ONNX embedding models natively in Node.js; default model `Qwen/Qwen3-Embedding-0.6B`; supports CoreML/WebGPU hardware acceleration, quantized ONNX dtype (fp32/fp16/q8/q4), skip-unchanged hash-based re-embedding, and lazy on-demand initialization |
 | `process-tracker.ts` | Global registry of spawned child processes; `killAllTracked()` ensures cleanup on SIGINT/SIGTERM/exit |
 | `git-history.ts` | Ingests commits, per-file diffs, and branch/tag refs via `simple-git` |
 | `resolution-method.ts` | Authoritative taxonomy for `resolution_method` column values shared by writers and readers |
@@ -251,6 +254,7 @@ Key optimizations in the indexing pipeline (v0.3.0):
 | `lore_metrics` | Return aggregate index metrics plus global coverage totals and staleness metadata (`coverage_commit`, `current_commit`, `commits_behind`, `stale`) |
 | `lore_coverage` | Return symbol-level coverage, uncovered lines, and staleness metadata for the latest coverage run |
 | `lore_writeback` | Persist symbol summaries into `symbol_summaries` |
+| `lore_analyze` | Run graph analysis: symbol-level SCC (cycle detection), connected components (file or symbol scope), bounded-size symbol clustering, and condensed codebase summary with per-module stats |
 
 `lore_blame` response enrichment:
 - Supports legacy `line`/`start_line`/`end_line` requests and symbol-driven targeting (`symbol` + optional `path`/`branch`), returning `resolved_symbol` when symbol resolution is used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jafreck/lore",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@elm-tooling/tree-sitter-elm": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Language-aware codebase indexer — tree-sitter parsing, symbol extraction, call-graph construction, and optional embeddings for semantic search",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.3.5

**Version bump**: 0.3.4 → 0.3.5
**Compare range**: [`v0.3.4...release/v0.3.5`](https://github.com/jafreck/Lore/compare/v0.3.4...release/v0.3.5)

### Key changes since v0.3.4

#### Features
- **Graph analysis primitives** (#161) — New `graph-analysis.ts` module with four operations on the symbol adjacency graph:
  - `detectSymbolCycles` — Tarjan's SCC for mutual-recursion / cycle detection
  - `findConnectedComponents` — union-find at file or symbol scope
  - `clusterSymbols` — SCC-contracted, bounded-size coherent symbol clustering
  - `buildCodebaseSummary` — condensed dependency overview with per-module stats
- **New MCP tool `lore_analyze`** — exposes all four graph analysis modes through MCP
- **New CLI command `lore analyze`** — runs graph analysis from the command line
- **New public API exports** — `detectSymbolCycles`, `findConnectedComponents`, `clusterSymbols`, `buildCodebaseSummary`, and associated types
- **Server-side DB edge queries** — `listTypeRefs` and extended `listResolvedEdges` with `methods` filter in `lore-server/db.ts`

#### Performance
- **Embedding optimization** (#160):
  - CoreML auto-detection on Apple Silicon for hardware-accelerated ONNX inference
  - WebGPU device detection (future-proofing)
  - Default model changed to `Qwen/Qwen3-Embedding-0.6B` (1024-dim, stronger code/multilingual understanding)
  - Quantized ONNX dtype support (fp32/fp16/q8/q4) via `LORE_EMBED_DTYPE`
  - Skip-unchanged embeddings via SHA-256 hash comparison (biggest win for watch/poll on large repos)
  - `LazyEmbeddingProvider` for instant MCP startup with on-demand model loading
  - Token-aware batching and increased batch size (64 → 512)
  - Overlapped I/O: fires next `embed()` while writing current batch to SQLite

### Docs refreshed
- **README.md** — added `lore_analyze` to MCP tools table and Mermaid diagram; updated embeddings section with new default model, hardware acceleration, quantized dtype, and skip-unchanged behavior; added `lore analyze` CLI reference
- **docs/architecture.md** — added `lore_analyze` to MCP tools table and Mermaid diagram; added `graph-analysis.ts` to supporting modules table; updated `embedder.ts` description with new capabilities

### Validation
- Build: ✅ `tsc` clean
- Tests: ✅ 1416 passed, 2 skipped (LSP smoke)
- Version: ✅ `0.3.5` in both `package.json` and `package-lock.json`