### PR TITLE
fix(scip): make symbol_relationships.line nullable for missing definition locations

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS symbol_relationships (
   target_symbol_id   INTEGER REFERENCES symbols(id),
   target_symbol_name TEXT    NOT NULL,
   relationship_type  TEXT    NOT NULL,
-  line               INTEGER NOT NULL,
+  line               INTEGER,
   character          INTEGER,
   definition_uri     TEXT,
   definition_path    TEXT,

--- a/src/indexer/stages/scip-source.ts
+++ b/src/indexer/stages/scip-source.ts
@@ -544,7 +544,10 @@ export class ScipSourceStage implements PipelineStage {
 
             const targetName = extractNameFromScipSymbol(rel.symbol);
             const targetId = scipToLoreId.get(rel.symbol) ?? null;
-            // Find a definition location for the line/character
+            // Find a definition location for the line/character.
+            // Some SCIP indexers (e.g. scip-go) emit SymbolInformation with
+            // relationships for symbols whose definition is in another file or
+            // external package, so defLoc may be undefined.
             const defLoc = symbolDefinitions.get(symInfo.symbol);
 
             insertRelationship.run(

--- a/tests/scip/scip-source-stage.test.ts
+++ b/tests/scip/scip-source-stage.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for the SCIP source stage.
+ *
+ * Covers the full ScipSourceStage.execute path with a real SQLite DB
+ * to catch schema-level bugs like NOT NULL violations.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, afterEach } from 'vitest';
+import { create, toBinary } from '@bufbuild/protobuf';
+import {
+  IndexSchema,
+  DocumentSchema,
+  OccurrenceSchema,
+  SymbolInformationSchema,
+  RelationshipSchema,
+  SymbolRole,
+} from '../../src/scip/scip_pb.js';
+import { openDb } from '../../src/db/schema.js';
+import { ScipSourceStage } from '../../src/indexer/stages/scip-source.js';
+import type { PipelineContext } from '../../src/indexer/pipeline.js';
+import { initLogger, LogLevel } from '../../src/logger.js';
+import { resolveEffectiveScipSettings } from '../../src/scip/config.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+  tmpDirs.length = 0;
+});
+
+function buildScipIndexBytes(docs: Array<{
+  relativePath: string;
+  language: string;
+  occurrences: Array<{ range: number[]; symbol: string; symbolRoles: number }>;
+  symbols?: Array<{
+    symbol: string;
+    documentation?: string[];
+    displayName?: string;
+    relationships?: Array<{ symbol: string; isImplementation?: boolean; isTypeDefinition?: boolean; isDefinition?: boolean }>;
+  }>;
+}>): Uint8Array {
+  const index = create(IndexSchema, {
+    documents: docs.map(d => create(DocumentSchema, {
+      relativePath: d.relativePath,
+      language: d.language,
+      occurrences: d.occurrences.map(o => create(OccurrenceSchema, {
+        range: o.range,
+        symbol: o.symbol,
+        symbolRoles: o.symbolRoles,
+      })),
+      symbols: (d.symbols ?? []).map(s => create(SymbolInformationSchema, {
+        symbol: s.symbol,
+        documentation: s.documentation ?? [],
+        displayName: s.displayName ?? '',
+        relationships: (s.relationships ?? []).map(r => create(RelationshipSchema, {
+          symbol: r.symbol,
+          isImplementation: r.isImplementation ?? false,
+          isTypeDefinition: r.isTypeDefinition ?? false,
+          isDefinition: r.isDefinition ?? false,
+        })),
+      })),
+    })),
+  });
+  return toBinary(IndexSchema, index);
+}
+
+function makeContext(rootDir: string, dbPath: string): PipelineContext {
+  const db = openDb(dbPath);
+  return {
+    db,
+    dbPath,
+    walkerConfig: { rootDir },
+    branch: 'HEAD',
+    lsp: null,
+    scip: resolveEffectiveScipSettings({}, { enabled: true, indexDir: '.scip-indexes' }),
+    embedder: null,
+    log: initLogger({ level: LogLevel.SILENT }),
+    files: [],
+    indexDependencies: false,
+    history: false,
+    docsAutoNotes: false,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ScipSourceStage', () => {
+  it('inserts relationships when definition location is known', async () => {
+    const rootDir = makeTmpDir('lore-scip-rel-known-');
+    const indexDir = join(rootDir, '.scip-indexes');
+    mkdirSync(indexDir, { recursive: true });
+
+    // Symbol A defines at line 5; symbol B is related to A
+    const symA = 'go . example.com/pkg 1.0 `main`/Animal#';
+    const symB = 'go . example.com/pkg 1.0 `main`/Dog#';
+
+    const bytes = buildScipIndexBytes([{
+      relativePath: 'main.go',
+      language: 'Go',
+      occurrences: [
+        { range: [5, 0, 5, 6], symbol: symA, symbolRoles: SymbolRole.Definition },
+        { range: [10, 0, 10, 3], symbol: symB, symbolRoles: SymbolRole.Definition },
+      ],
+      symbols: [
+        { symbol: symA, displayName: 'Animal', documentation: ['type Animal struct'] },
+        {
+          symbol: symB,
+          displayName: 'Dog',
+          documentation: ['type Dog struct'],
+          relationships: [{ symbol: symA, isImplementation: true }],
+        },
+      ],
+    }]);
+    writeFileSync(join(indexDir, 'go.scip'), bytes);
+
+    // Create a source file so the walker picks it up
+    writeFileSync(join(rootDir, 'main.go'), 'package main\ntype Animal struct{}\ntype Dog struct{}');
+
+    const dbPath = join(rootDir, 'test.db');
+    const ctx = makeContext(rootDir, dbPath);
+
+    const stage = new ScipSourceStage();
+    await stage.execute(ctx, 'build');
+
+    const rels = ctx.db.prepare('SELECT * FROM symbol_relationships').all() as any[];
+    expect(rels.length).toBeGreaterThan(0);
+
+    const rel = rels[0];
+    expect(rel.relationship_type).toBe('implements');
+    expect(rel.target_symbol_name).toBe('Animal');
+    // Definition was found → line should be populated
+    expect(rel.line).toBe(10);
+
+    ctx.db.close();
+  });
+
+  it('inserts relationships with NULL line when definition location is unknown', async () => {
+    const rootDir = makeTmpDir('lore-scip-rel-null-line-');
+    const indexDir = join(rootDir, '.scip-indexes');
+    mkdirSync(indexDir, { recursive: true });
+
+    // symA: external type — no definition occurrence in our index
+    const symA = 'go . stdlib 1.0 `io`/Reader#';
+    // symB: local type that implements symA, BUT symB has no definition
+    // occurrence either (simulates a SymbolInformation-only entry).
+    const symB = 'go . example.com/pkg 1.0 `main`/MyReader#';
+
+    const bytes = buildScipIndexBytes([{
+      relativePath: 'main.go',
+      language: 'Go',
+      occurrences: [
+        // Only a reference to symB, not a definition — so symbolDefinitions
+        // won't have an entry and defLoc will be undefined.
+        { range: [20, 4, 20, 12], symbol: symB, symbolRoles: 0 },
+      ],
+      symbols: [
+        {
+          symbol: symB,
+          displayName: 'MyReader',
+          documentation: ['type MyReader struct'],
+          relationships: [{ symbol: symA, isImplementation: true }],
+        },
+      ],
+    }]);
+    writeFileSync(join(indexDir, 'go.scip'), bytes);
+
+    writeFileSync(join(rootDir, 'main.go'), 'package main\ntype MyReader struct{}');
+
+    const dbPath = join(rootDir, 'test.db');
+    const ctx = makeContext(rootDir, dbPath);
+
+    const stage = new ScipSourceStage();
+
+    // Before the fix this threw: SqliteError: NOT NULL constraint failed:
+    // symbol_relationships.line
+    await stage.execute(ctx, 'build');
+
+    const rels = ctx.db.prepare('SELECT * FROM symbol_relationships').all() as any[];
+    expect(rels.length).toBeGreaterThan(0);
+
+    const rel = rels[0];
+    expect(rel.target_symbol_name).toBe('Reader');
+    // No definition location → line should be NULL
+    expect(rel.line).toBeNull();
+
+    ctx.db.close();
+  });
+});


### PR DESCRIPTION
## Problem

SCIP indexers (e.g. `scip-go`) can emit `SymbolInformation` with `relationships` for symbols whose definition occurrence is in another file or external package. When the definition isn't in the index, `symbolDefinitions.get()` returns `undefined` and the insert passes `NULL` for the `line` column — violating the `NOT NULL` constraint on `symbol_relationships.line`.

This causes a crash when indexing Go repos (and potentially other languages) with SCIP:
```
SqliteError: NOT NULL constraint failed: symbol_relationships.line
 ❯ src/indexer/stages/scip-source.ts:550:32
```

## Root Cause

The `symbol_relationships.line` column was declared `INTEGER NOT NULL` in the schema, but the SCIP source stage legitimately needs to insert relationships where no definition location is known — the definition may be in a different file or an external dependency not present in the SCIP index.

## Fix

- **Schema**: Changed `line INTEGER NOT NULL` → `line INTEGER` in the `symbol_relationships` table DDL. Downstream enrichment stages already filter with `WHERE sr.line IS NOT NULL`, so this is safe.
- **SCIP source stage**: Kept `defLoc?.line ?? null` (the original intent was correct; the schema was wrong). Added a clarifying comment.

## Why Tests Didn't Catch This

The only SCIP tests covered helper functions (name extraction, end-line estimation). There was no integration test that ran `ScipSourceStage.execute()` against a real SQLite DB with relationship data containing missing definition locations.

## New Test Coverage

Added `tests/scip/scip-source-stage.test.ts` with two integration test cases:
1. **Known definition location** — relationship inserted with populated `line`
2. **Unknown definition location** — relationship inserted with `NULL` line (the crash case)