### PR TITLE
chore: release v0.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ flowchart LR
         GRAPH[lore_graph]
         ROUTES[lore_routes]
         NOTES[lore_notes_read/write]
-        ARCH[lore_architecture]
         TESTMAP[lore_test_map]
         SNIPPET[lore_snippet]
         BLAME[lore_blame]
@@ -89,10 +88,10 @@ flowchart LR
     RESOLVE -.->|optional| EMBED
     EMBED -.-> DB
 
-    DB --- LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS
+    DB --- LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS
     EMBED <-.->|semantic/fused| SEARCH
 
-    LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES & ARCH & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS <--> MCP_CLIENTS
+    LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES & TESTMAP & SNIPPET & BLAME & HISTORY & METRICS <--> MCP_CLIENTS
 ```
 
 Lore sits between your codebase and any LLM-powered tool. A `LoreRuntime`
@@ -193,7 +192,6 @@ await builder.build();
 | `lore_routes` | Query extracted API routes/endpoints with optional method, path prefix, and framework filters |
 | `lore_notes_write` | Upsert agent-authored notes by key and scope, with optional source hash for staleness tracking |
 | `lore_notes_read` | Read notes by exact key or key prefix with scope-aware staleness metadata |
-| `lore_architecture` | Build a component-level architecture view with edges, entry/leaf nodes, and external dependency usage |
 | `lore_graph` | Query call/import/inheritance/type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries; call edges include `callee_coverage_percent` |
 | `lore_snippet` | Return snippets from indexed source snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata (name, kind, start/end lines) when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,6 @@ flowchart LR
         GRAPH[lore_graph]
         ROUTES[lore_routes]
         NOTES_TOOL[lore_notes_read/write]
-        ARCHITECTURE[lore_architecture]
         SNIPPET[lore_snippet]
         TESTMAP[lore_test_map]
         BLAME[lore_blame]
@@ -136,9 +135,9 @@ flowchart LR
     EMBED -.->|optional| VEC
     GIT --> GITHIST --> HIST
 
-    FILES & SYM & IMP & EXT & REFS & TYPES & ANN & ROUTE_STORE & DOCS & NOTES & COV & VEC & HIST & META --- LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK & ANALYZE
+    FILES & SYM & IMP & EXT & REFS & TYPES & ANN & ROUTE_STORE & DOCS & NOTES & COV & VEC & HIST & META --- LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES_TOOL & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS
 
-    LOOKUP & SEARCH & DOCS_TOOL & ANNOTATIONS & GRAPH & ROUTES & NOTES_TOOL & ARCHITECTURE & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS & LORE_COVERAGE & WRITEBACK & ANALYZE <--> LLM_AGENTS
+    LOOKUP & SEARCH & DOCS_TOOL & GRAPH & ROUTES & NOTES_TOOL & SNIPPET & TESTMAP & BLAME & HISTORY & METRICS <--> LLM_AGENTS
 
     LLM_AGENTS <--- ENTRY
 ```
@@ -257,7 +256,6 @@ Key optimizations in the indexing pipeline (v0.3.0):
 | `lore_docs` | List indexed docs, fetch full docs with optional sections, or search indexed sections |
 | `lore_routes` | Query extracted API routes/endpoints with optional method, path prefix, and framework filters |
 | `lore_notes_read` / `lore_notes_write` | Persist notes and read note freshness metadata (`source_hash_mismatch`, `doc_missing`, etc.) |
-| `lore_architecture` | Build a component-level architecture view with edges, entry/leaf nodes, and external dependency usage |
 | `lore_graph` | Query call, import, inheritance, or type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries (`call` edges include `callee_coverage_percent`) |
 | `lore_snippet` | Return snippets from indexed DB-backed file snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jafreck/lore",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Language-aware codebase indexer — tree-sitter parsing, symbol extraction, call-graph construction, and optional embeddings for semantic search",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.3.7

**Version bump:** 0.3.6 → 0.3.7
**Compare range:** [`v0.3.6...release/v0.3.7`](https://github.com/jafreck/Lore/compare/v0.3.6...release/v0.3.7)

### Key changes since v0.3.6

**Features**
- Overhauled copilot benchmark suite with indexing performance improvements (#181)

**Fixes**
- Improved scorer arrow-line matching, resolved dynamic imports, and added full prompts to benchmark results (#183)

**Refactors**
- Removed low-value MCP tools: `lore_annotations`, `lore_coverage`, `lore_writeback`, `lore_analyze`, `lore_architecture` (#186)

**Docs**
- Updated README mermaid diagram layout and fixed benchmark-results formatting (#185)
- Removed stale tool references (`lore_architecture`, `lore_annotations`, `lore_coverage`, `lore_writeback`, `lore_analyze`) from README.md and docs/architecture.md mermaid diagrams and tool tables

### Docs refresh
- [README.md](README.md): removed `lore_architecture` from mermaid diagram and tool table
- [docs/architecture.md](docs/architecture.md): removed `lore_architecture`, `lore_annotations`, `lore_coverage`, `lore_writeback`, `lore_analyze` from mermaid diagram and tool table

### Validation
- ✅ Build passes (`tsc`)
- ✅ 1641 tests passed, 0 failed