### PR TITLE
feat(tools): add lore_trace execution path tracing tool

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jacobfreck/Source/Lore/node_modules

--- a/src/server/tool-registry.ts
+++ b/src/server/tool-registry.ts
@@ -239,6 +239,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     blame,
     metrics,
     history,
+    trace,
   ] = await Promise.all([
     import('./tools/lookup.js'),
     import('./tools/graph.js'),
@@ -249,6 +250,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     import('./tools/blame.js'),
     import('./tools/metrics.js'),
     import('./tools/history.js'),
+    import('./tools/trace.js'),
   ]);
 
   return [
@@ -287,6 +289,10 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     {
       def: history.toolDef,
       handlerFactory: (deps) => (args) => history.handler(deps.db, args, deps.embedder),
+    },
+    {
+      def: trace.toolDef,
+      handlerFactory: (deps) => (args) => trace.handler(deps.db, args),
     },
   ];
 }

--- a/src/server/tools/trace.ts
+++ b/src/server/tools/trace.ts
@@ -1,0 +1,461 @@
+/**
+ * @module lore-server/tools/trace
+ *
+ * MCP tool: trace an execution path from an entry point and return an ordered
+ * call sequence with source code inlined — a self-contained reasoning bundle
+ * for LLM agents.
+ *
+ * Entry modes:
+ *   1. Symbol ID:   `from=symbolId`
+ *   2. Symbol name: `from_name="handleCreateUser"`
+ *   3. Point-to-point: `from` + `to` (BFS shortest path)
+ */
+
+import type { Database } from '../../db/read-only.js';
+import { getSymbolsByName, getCoveragePercentBySymbolIds } from '../../db/read-only.js';
+
+// ─── Tool definition ──────────────────────────────────────────────────────────
+
+export const toolDef = {
+  name: 'lore_trace',
+  description:
+    'Trace an execution path from an entry point (symbol or symbol name) and ' +
+    'return an ordered call sequence with source code for each step. Designed for ' +
+    'reasoning about data flow, config propagation, and side effects.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      from: {
+        type: 'number',
+        description: 'Symbol ID to start the trace from (forward trace).',
+      },
+      from_name: {
+        type: 'string',
+        description:
+          'Symbol name to start the trace from (resolved via lore_lookup). Use when you don\'t have the ID.',
+      },
+      to: {
+        type: 'number',
+        description:
+          'Optional target symbol ID. When provided, returns the shortest call path from `from` to `to` instead of a full forward trace.',
+      },
+      to_name: {
+        type: 'string',
+        description: 'Optional target symbol name. Resolved via lore_lookup.',
+      },
+      depth: {
+        type: 'number',
+        description: 'Max call depth to trace (default 5, max 10).',
+        minimum: 1,
+        maximum: 10,
+      },
+      max_source_lines: {
+        type: 'number',
+        description:
+          'Max source lines per step (default 50). Larger functions are truncated with a comment indicating remaining lines.',
+      },
+      branch: {
+        type: 'string',
+        description: 'Optional branch name to filter symbols.',
+      },
+    },
+  },
+} as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface TraceArgs {
+  from?: number;
+  from_name?: string;
+  to?: number;
+  to_name?: string;
+  depth?: number;
+  max_source_lines?: number;
+  branch?: string;
+}
+
+export interface TraceStep {
+  depth: number;
+  symbol_id: number;
+  name: string;
+  kind: string;
+  file_path: string;
+  start_line: number;
+  end_line: number;
+  signature?: string;
+  source: string;
+  call_line?: number;
+  resolution_method?: string;
+  cyclomatic?: number;
+  coverage_percent?: number;
+}
+
+export interface TraceResult {
+  entry: string;
+  steps: TraceStep[];
+  truncated: boolean;
+  total_nodes: number;
+}
+
+// ─── Internal DB row types ────────────────────────────────────────────────────
+
+interface SymbolWithSource {
+  id: number;
+  name: string;
+  kind: string;
+  file_path: string;
+  start_line: number;
+  end_line: number;
+  signature: string | null;
+  source: string;
+  cyclomatic: number | null;
+}
+
+interface CalleeEdge {
+  callee_id: number;
+  callee_name: string;
+  call_line: number;
+  resolution_method: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Resolve a symbol name to a single symbol ID, throwing if ambiguous or missing. */
+function resolveSymbolName(db: Database.Database, name: string, branch?: string): number {
+  const rows = getSymbolsByName(db, name, branch);
+  if (rows.length === 0) {
+    throw new Error(`Symbol not found: "${name}"`);
+  }
+  if (rows.length > 1) {
+    const locations = rows
+      .slice(0, 5)
+      .map((r) => `  id=${r.id} kind=${r.kind}`)
+      .join('\n');
+    throw new Error(
+      `Ambiguous symbol name "${name}" (${rows.length} matches). Provide \`from\`/\`to\` with a specific symbol ID instead.\n${locations}`,
+    );
+  }
+  return rows[0]!.id;
+}
+
+/** Check whether a table exists in the database. */
+function hasTable(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1",
+    )
+    .get(name) as { present: number } | undefined;
+  return row?.present === 1;
+}
+
+/** Fetch full symbol info with source for a batch of symbol IDs. */
+function getSymbolsWithSource(
+  db: Database.Database,
+  symbolIds: number[],
+): Map<number, SymbolWithSource> {
+  if (symbolIds.length === 0) return new Map();
+
+  const hasMetrics = hasTable(db, 'symbol_metrics');
+  const placeholders = symbolIds.map(() => '?').join(', ');
+  const sql = `
+    SELECT s.id, s.name, s.kind, f.path AS file_path,
+           s.start_line, s.end_line, s.signature, f.source
+           ${hasMetrics ? ', sm.cyclomatic' : ''}
+      FROM symbols s
+      JOIN files f ON f.id = s.file_id
+      ${hasMetrics ? 'LEFT JOIN symbol_metrics sm ON sm.symbol_id = s.id' : ''}
+     WHERE s.id IN (${placeholders})`;
+
+  const rows = db.prepare(sql).all(...symbolIds) as Array<{
+    id: number;
+    name: string;
+    kind: string;
+    file_path: string;
+    start_line: number;
+    end_line: number;
+    signature: string | null;
+    source: string;
+    cyclomatic: number | null;
+  }>;
+
+  const map = new Map<number, SymbolWithSource>();
+  for (const row of rows) {
+    map.set(row.id, {
+      ...row,
+      cyclomatic: hasMetrics ? row.cyclomatic : null,
+    });
+  }
+  return map;
+}
+
+/** Get outbound call edges for a symbol. */
+function getCallees(db: Database.Database, callerId: number): CalleeEdge[] {
+  return db
+    .prepare(
+      `SELECT callee_id, callee_name, call_line, resolution_method
+         FROM symbol_refs
+        WHERE caller_id = ? AND callee_id IS NOT NULL
+        ORDER BY call_line ASC`,
+    )
+    .all(callerId) as CalleeEdge[];
+}
+
+/** Extract source lines for a symbol, applying truncation. */
+function extractSource(sym: SymbolWithSource, maxLines: number): string {
+  const allLines = sym.source.split('\n');
+  const start = Math.max(0, sym.start_line - 1);
+  const end = Math.min(allLines.length, sym.end_line);
+  const lines = allLines.slice(start, end);
+
+  if (lines.length <= maxLines) {
+    return lines.join('\n');
+  }
+
+  const truncated = lines.slice(0, maxLines);
+  const remaining = lines.length - maxLines;
+  truncated.push(`// ... (${remaining} more lines)`);
+  return truncated.join('\n');
+}
+
+/**
+ * Build a TraceStep from a symbol, with optional caller context.
+ */
+function buildStep(
+  sym: SymbolWithSource,
+  depthLevel: number,
+  maxLines: number,
+  callLine?: number,
+  resolutionMethod?: string,
+  coveragePercent?: number | null,
+): TraceStep {
+  const step: TraceStep = {
+    depth: depthLevel,
+    symbol_id: sym.id,
+    name: sym.name,
+    kind: sym.kind,
+    file_path: sym.file_path,
+    start_line: sym.start_line,
+    end_line: sym.end_line,
+    source: extractSource(sym, maxLines),
+  };
+  if (sym.signature) step.signature = sym.signature;
+  if (callLine !== undefined) step.call_line = callLine;
+  if (resolutionMethod !== undefined) step.resolution_method = resolutionMethod;
+  if (sym.cyclomatic !== null && sym.cyclomatic !== undefined) step.cyclomatic = sym.cyclomatic;
+  if (coveragePercent !== undefined && coveragePercent !== null) step.coverage_percent = coveragePercent;
+  return step;
+}
+
+// ─── DFS forward trace ───────────────────────────────────────────────────────
+
+function forwardTrace(
+  db: Database.Database,
+  entryId: number,
+  maxDepth: number,
+  maxLines: number,
+  branch?: string,
+): { steps: TraceStep[]; truncated: boolean; visitedIds: Set<number> } {
+  const steps: TraceStep[] = [];
+  const visited = new Set<number>();
+  let truncated = false;
+
+  // Collect all symbol IDs we'll visit via iterative DFS planning pass
+  // then batch-fetch source and coverage.
+
+  interface DfsFrame {
+    symbolId: number;
+    depthLevel: number;
+    callLine?: number;
+    resolutionMethod?: string;
+  }
+
+  // First pass: plan the traversal to discover all needed symbol IDs.
+  const planned: DfsFrame[] = [];
+  const planStack: DfsFrame[] = [{ symbolId: entryId, depthLevel: 0 }];
+  const planVisited = new Set<number>();
+
+  while (planStack.length > 0) {
+    const frame = planStack.pop()!;
+    if (planVisited.has(frame.symbolId)) continue;
+    planVisited.add(frame.symbolId);
+    planned.push(frame);
+
+    if (frame.depthLevel < maxDepth) {
+      const edges = getCallees(db, frame.symbolId);
+      // Push in reverse order so first callee is processed first (stack is LIFO)
+      for (let i = edges.length - 1; i >= 0; i--) {
+        const edge = edges[i]!;
+        if (!planVisited.has(edge.callee_id)) {
+          planStack.push({
+            symbolId: edge.callee_id,
+            depthLevel: frame.depthLevel + 1,
+            callLine: edge.call_line + 1, // 0-indexed → 1-indexed
+            resolutionMethod: edge.resolution_method,
+          });
+        }
+      }
+    } else if (frame.depthLevel === maxDepth) {
+      // Check if there are further edges we're cutting off
+      const edges = getCallees(db, frame.symbolId);
+      if (edges.length > 0) truncated = true;
+    }
+  }
+
+  // Batch-fetch all symbols with source
+  const allIds = planned.map((f) => f.symbolId);
+  const symbolMap = getSymbolsWithSource(db, allIds);
+  const coverageMap = getCoveragePercentBySymbolIds(db, allIds, branch);
+
+  // Second pass: replay the planned traversal in order, building steps.
+  // Re-run the DFS to ensure correct pre-order.
+  const dfsStack: DfsFrame[] = [{ symbolId: entryId, depthLevel: 0 }];
+
+  while (dfsStack.length > 0) {
+    const frame = dfsStack.pop()!;
+    if (visited.has(frame.symbolId)) continue;
+    visited.add(frame.symbolId);
+
+    const sym = symbolMap.get(frame.symbolId);
+    if (!sym) continue;
+
+    const coverage = coverageMap.get(frame.symbolId) ?? null;
+    steps.push(
+      buildStep(sym, frame.depthLevel, maxLines, frame.callLine, frame.resolutionMethod, coverage),
+    );
+
+    if (frame.depthLevel < maxDepth) {
+      const edges = getCallees(db, frame.symbolId);
+      for (let i = edges.length - 1; i >= 0; i--) {
+        const edge = edges[i]!;
+        if (!visited.has(edge.callee_id)) {
+          dfsStack.push({
+            symbolId: edge.callee_id,
+            depthLevel: frame.depthLevel + 1,
+            callLine: edge.call_line + 1,
+            resolutionMethod: edge.resolution_method,
+          });
+        }
+      }
+    }
+  }
+
+  return { steps, truncated, visitedIds: visited };
+}
+
+// ─── BFS point-to-point ──────────────────────────────────────────────────────
+
+function pointToPointTrace(
+  db: Database.Database,
+  fromId: number,
+  toId: number,
+  maxDepth: number,
+  maxLines: number,
+  branch?: string,
+): { steps: TraceStep[]; truncated: boolean; visitedIds: Set<number> } {
+  // BFS to find shortest path from → to
+  const parentMap = new Map<number, { parentId: number; callLine: number; resolutionMethod: string }>();
+  const visited = new Set<number>();
+  const queue: Array<{ id: number; depth: number }> = [{ id: fromId, depth: 0 }];
+  visited.add(fromId);
+  let found = false;
+
+  while (queue.length > 0) {
+    const { id, depth } = queue.shift()!;
+    if (id === toId) {
+      found = true;
+      break;
+    }
+    if (depth >= maxDepth) continue;
+
+    const edges = getCallees(db, id);
+    for (const edge of edges) {
+      if (!visited.has(edge.callee_id)) {
+        visited.add(edge.callee_id);
+        parentMap.set(edge.callee_id, {
+          parentId: id,
+          callLine: edge.call_line + 1,
+          resolutionMethod: edge.resolution_method,
+        });
+        queue.push({ id: edge.callee_id, depth: depth + 1 });
+      }
+    }
+  }
+
+  if (!found) {
+    throw new Error(
+      `No call path found from symbol ${fromId} to symbol ${toId} within depth ${maxDepth}.`,
+    );
+  }
+
+  // Reconstruct path from `to` back to `from`
+  const path: Array<{ id: number; callLine?: number; resolutionMethod?: string }> = [];
+  let current = toId;
+  while (current !== fromId) {
+    const parent = parentMap.get(current)!;
+    path.push({ id: current, callLine: parent.callLine, resolutionMethod: parent.resolutionMethod });
+    current = parent.parentId;
+  }
+  path.push({ id: fromId });
+  path.reverse();
+
+  // Batch-fetch symbols and coverage
+  const pathIds = path.map((p) => p.id);
+  const symbolMap = getSymbolsWithSource(db, pathIds);
+  const coverageMap = getCoveragePercentBySymbolIds(db, pathIds, branch);
+
+  const steps: TraceStep[] = [];
+  for (let i = 0; i < path.length; i++) {
+    const node = path[i]!;
+    const sym = symbolMap.get(node.id);
+    if (!sym) continue;
+    const coverage = coverageMap.get(node.id) ?? null;
+    steps.push(buildStep(sym, i, maxLines, node.callLine, node.resolutionMethod, coverage));
+  }
+
+  return { steps, truncated: false, visitedIds: new Set(pathIds) };
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export function handler(db: Database.Database, args: TraceArgs): TraceResult {
+  const maxDepth = Math.max(1, Math.min(args.depth ?? 5, 10));
+  const maxLines = args.max_source_lines ?? 50;
+
+  // Resolve entry point
+  let fromId: number | undefined = args.from;
+  if (fromId === undefined && args.from_name !== undefined) {
+    fromId = resolveSymbolName(db, args.from_name, args.branch);
+  }
+  if (fromId === undefined) {
+    throw new Error('Provide `from` (symbol ID) or `from_name` (symbol name) to start the trace.');
+  }
+
+  // Resolve optional target
+  let toId: number | undefined = args.to;
+  if (toId === undefined && args.to_name !== undefined) {
+    toId = resolveSymbolName(db, args.to_name, args.branch);
+  }
+
+  // Fetch entry symbol name for the result description
+  const entrySymbols = getSymbolsWithSource(db, [fromId]);
+  const entrySym = entrySymbols.get(fromId);
+  if (!entrySym) {
+    throw new Error(`Entry symbol not found: id=${fromId}`);
+  }
+  const entryDesc = toId !== undefined
+    ? `${entrySym.name} → symbol ${toId}`
+    : entrySym.name;
+
+  // Dispatch to the appropriate trace strategy
+  const { steps, truncated, visitedIds } =
+    toId !== undefined
+      ? pointToPointTrace(db, fromId, toId, maxDepth, maxLines, args.branch)
+      : forwardTrace(db, fromId, maxDepth, maxLines, args.branch);
+
+  return {
+    entry: entryDesc,
+    steps,
+    truncated,
+    total_nodes: visitedIds.size,
+  };
+}

--- a/tests/server/tools/trace.test.ts
+++ b/tests/server/tools/trace.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { handler, toolDef, type TraceArgs, type TraceResult } from '../../../src/server/tools/trace.js';
+import { openDb } from '../../../src/db/schema.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTestDb(): Database.Database {
+  const db = openDb(':memory:');
+  return db;
+}
+
+function insertFile(db: Database.Database, path: string, branch: string, source: string): number {
+  const result = db
+    .prepare('INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, ?, ?, 0, NULL, ?)')
+    .run(path, branch, 'typescript', source);
+  return result.lastInsertRowid as number;
+}
+
+function insertSymbol(
+  db: Database.Database,
+  fileId: number,
+  name: string,
+  kind: string,
+  startLine: number,
+  endLine: number,
+  signature?: string,
+): number {
+  const result = db
+    .prepare(
+      'INSERT INTO symbols (file_id, name, kind, start_line, end_line, signature) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+    .run(fileId, name, kind, startLine, endLine, signature ?? null);
+  return result.lastInsertRowid as number;
+}
+
+function insertCallEdge(
+  db: Database.Database,
+  callerId: number,
+  calleeId: number,
+  calleeName: string,
+  callLine: number,
+  resolutionMethod = 'tree-sitter',
+): void {
+  db.prepare(
+    'INSERT INTO symbol_refs (caller_id, callee_id, callee_name, call_line, resolution_method) VALUES (?, ?, ?, ?, ?)',
+  ).run(callerId, calleeId, calleeName, callLine, resolutionMethod);
+}
+
+function insertCoverage(db: Database.Database, filePath: string, lines: Array<[number, number]>): void {
+  const runId = db
+    .prepare(
+      'INSERT INTO coverage_runs (commit_sha, source_path, format, ingested_at) VALUES (?, ?, ?, ?)',
+    )
+    .run('abc123', 'coverage/lcov.info', 'lcov', 100).lastInsertRowid as number;
+  db.prepare('INSERT INTO coverage_files (run_id, file_path, lines_found, lines_hit) VALUES (?, ?, ?, ?)').run(
+    runId,
+    filePath,
+    lines.length,
+    lines.filter(([, hit]) => hit > 0).length,
+  );
+  for (const [lineNum, hitCount] of lines) {
+    db.prepare('INSERT INTO coverage_lines (run_id, file_path, line_number, hit_count) VALUES (?, ?, ?, ?)').run(
+      runId,
+      filePath,
+      lineNum,
+      hitCount,
+    );
+  }
+}
+
+// ─── Source fixtures ──────────────────────────────────────────────────────────
+
+const MAIN_SOURCE = [
+  'import { helper } from "./helper";',
+  '',
+  'function main() {',
+  '  const result = helper();',
+  '  console.log(result);',
+  '}',
+].join('\n');
+
+const HELPER_SOURCE = [
+  'import { util } from "./util";',
+  '',
+  'export function helper() {',
+  '  return util("hello");',
+  '}',
+].join('\n');
+
+const UTIL_SOURCE = [
+  'export function util(msg: string) {',
+  '  return msg.toUpperCase();',
+  '}',
+].join('\n');
+
+// ─── toolDef ──────────────────────────────────────────────────────────────────
+
+describe('lore_trace toolDef', () => {
+  it('exposes the correct tool name', () => {
+    expect(toolDef.name).toBe('lore_trace');
+  });
+
+  it('defines from, from_name, to, to_name, depth, max_source_lines, branch', () => {
+    const props = toolDef.inputSchema.properties;
+    expect(props.from.type).toBe('number');
+    expect(props.from_name.type).toBe('string');
+    expect(props.to.type).toBe('number');
+    expect(props.to_name.type).toBe('string');
+    expect(props.depth.type).toBe('number');
+    expect(props.depth.minimum).toBe(1);
+    expect(props.depth.maximum).toBe(10);
+    expect(props.max_source_lines.type).toBe('number');
+    expect(props.branch.type).toBe('string');
+  });
+});
+
+// ─── Forward trace (DFS) ─────────────────────────────────────────────────────
+
+describe('trace handler – forward trace', () => {
+  let db: Database.Database;
+  let mainId: number;
+  let helperId: number;
+  let utilId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const mainFileId = insertFile(db, 'src/main.ts', 'main', MAIN_SOURCE);
+    const helperFileId = insertFile(db, 'src/helper.ts', 'main', HELPER_SOURCE);
+    const utilFileId = insertFile(db, 'src/util.ts', 'main', UTIL_SOURCE);
+
+    mainId = insertSymbol(db, mainFileId, 'main', 'function', 3, 6, '(): void');
+    helperId = insertSymbol(db, helperFileId, 'helper', 'function', 3, 5, '(): string');
+    utilId = insertSymbol(db, utilFileId, 'util', 'function', 1, 3, '(msg: string): string');
+
+    // main → helper (line 3, 0-indexed)
+    insertCallEdge(db, mainId, helperId, 'helper', 3);
+    // helper → util (line 3, 0-indexed)
+    insertCallEdge(db, helperId, utilId, 'util', 3);
+  });
+
+  it('traces a simple call chain with source inlined', () => {
+    const result = handler(db, { from: mainId });
+
+    expect(result.entry).toBe('main');
+    expect(result.steps).toHaveLength(3);
+    expect(result.truncated).toBe(false);
+    expect(result.total_nodes).toBe(3);
+
+    // Entry step
+    expect(result.steps[0]!.depth).toBe(0);
+    expect(result.steps[0]!.name).toBe('main');
+    expect(result.steps[0]!.kind).toBe('function');
+    expect(result.steps[0]!.file_path).toBe('src/main.ts');
+    expect(result.steps[0]!.source).toContain('function main()');
+
+    // First callee
+    expect(result.steps[1]!.depth).toBe(1);
+    expect(result.steps[1]!.name).toBe('helper');
+    expect(result.steps[1]!.call_line).toBe(4); // 0-based 3 → 1-based 4
+    expect(result.steps[1]!.resolution_method).toBe('tree-sitter');
+    expect(result.steps[1]!.source).toContain('export function helper()');
+
+    // Deepest callee
+    expect(result.steps[2]!.depth).toBe(2);
+    expect(result.steps[2]!.name).toBe('util');
+    expect(result.steps[2]!.source).toContain('export function util');
+  });
+
+  it('respects depth limit', () => {
+    const result = handler(db, { from: mainId, depth: 1 });
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]!.name).toBe('main');
+    expect(result.steps[1]!.name).toBe('helper');
+    expect(result.truncated).toBe(true); // helper has further edges
+  });
+
+  it('resolves from_name to symbol ID', () => {
+    const result = handler(db, { from_name: 'main' });
+
+    expect(result.entry).toBe('main');
+    expect(result.steps[0]!.symbol_id).toBe(mainId);
+  });
+
+  it('includes signature when present', () => {
+    const result = handler(db, { from: mainId });
+
+    expect(result.steps[0]!.signature).toBe('(): void');
+    expect(result.steps[1]!.signature).toBe('(): string');
+  });
+
+  it('truncates source when max_source_lines is exceeded', () => {
+    const result = handler(db, { from: mainId, max_source_lines: 2 });
+
+    // main has 4 lines (3-6), should be truncated
+    const mainSource = result.steps[0]!.source;
+    expect(mainSource).toContain('// ... (2 more lines)');
+  });
+
+  it('handles cycle without infinite loop', () => {
+    // Create a cycle: util → main
+    insertCallEdge(db, utilId, mainId, 'main', 1);
+
+    const result = handler(db, { from: mainId });
+
+    // main visited once, helper once, util once — cycle back to main is skipped
+    expect(result.steps).toHaveLength(3);
+    const names = result.steps.map((s) => s.name);
+    expect(names).toEqual(['main', 'helper', 'util']);
+  });
+});
+
+// ─── Point-to-point trace (BFS) ──────────────────────────────────────────────
+
+describe('trace handler – point-to-point', () => {
+  let db: Database.Database;
+  let mainId: number;
+  let helperId: number;
+  let utilId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const mainFileId = insertFile(db, 'src/main.ts', 'main', MAIN_SOURCE);
+    const helperFileId = insertFile(db, 'src/helper.ts', 'main', HELPER_SOURCE);
+    const utilFileId = insertFile(db, 'src/util.ts', 'main', UTIL_SOURCE);
+
+    mainId = insertSymbol(db, mainFileId, 'main', 'function', 3, 6, '(): void');
+    helperId = insertSymbol(db, helperFileId, 'helper', 'function', 3, 5, '(): string');
+    utilId = insertSymbol(db, utilFileId, 'util', 'function', 1, 3, '(msg: string): string');
+
+    insertCallEdge(db, mainId, helperId, 'helper', 3);
+    insertCallEdge(db, helperId, utilId, 'util', 3);
+  });
+
+  it('finds shortest path between two symbols', () => {
+    const result = handler(db, { from: mainId, to: utilId });
+
+    expect(result.entry).toBe(`main → symbol ${utilId}`);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps[0]!.name).toBe('main');
+    expect(result.steps[1]!.name).toBe('helper');
+    expect(result.steps[2]!.name).toBe('util');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('finds direct path when adjacent', () => {
+    const result = handler(db, { from: mainId, to: helperId });
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]!.name).toBe('main');
+    expect(result.steps[1]!.name).toBe('helper');
+  });
+
+  it('resolves to_name for point-to-point', () => {
+    const result = handler(db, { from: mainId, to_name: 'util' });
+
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps[2]!.name).toBe('util');
+  });
+
+  it('throws when no path exists', () => {
+    // util has no outgoing edges to main
+    expect(() => handler(db, { from: utilId, to: mainId })).toThrow(
+      /No call path found/,
+    );
+  });
+
+  it('throws when path exceeds depth', () => {
+    // main → helper → util is 2 hops, depth=1 should fail
+    expect(() => handler(db, { from: mainId, to: utilId, depth: 1 })).toThrow(
+      /No call path found/,
+    );
+  });
+});
+
+// ─── Error handling ───────────────────────────────────────────────────────────
+
+describe('trace handler – errors', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('throws when neither from nor from_name is provided', () => {
+    expect(() => handler(db, {})).toThrow(/Provide `from`/);
+  });
+
+  it('throws when from_name matches no symbols', () => {
+    expect(() => handler(db, { from_name: 'nonexistent' })).toThrow(
+      /Symbol not found/,
+    );
+  });
+
+  it('throws when from_name is ambiguous', () => {
+    const fId = insertFile(db, 'src/a.ts', 'main', 'function foo() {}');
+    insertSymbol(db, fId, 'foo', 'function', 1, 1);
+    const fId2 = insertFile(db, 'src/b.ts', 'main', 'function foo() {}');
+    insertSymbol(db, fId2, 'foo', 'function', 1, 1);
+
+    expect(() => handler(db, { from_name: 'foo' })).toThrow(/Ambiguous/);
+  });
+
+  it('throws when from symbol ID does not exist', () => {
+    expect(() => handler(db, { from: 99999 })).toThrow(/Entry symbol not found/);
+  });
+});
+
+// ─── Coverage enrichment ──────────────────────────────────────────────────────
+
+describe('trace handler – coverage enrichment', () => {
+  it('includes coverage_percent when coverage data is available', () => {
+    const db = createTestDb();
+    const fileId = insertFile(db, 'src/main.ts', 'main', MAIN_SOURCE);
+    const mainId = insertSymbol(db, fileId, 'main', 'function', 3, 6);
+    insertCoverage(db, 'src/main.ts', [
+      [3, 1],
+      [4, 1],
+      [5, 0],
+      [6, 1],
+    ]);
+
+    const result = handler(db, { from: mainId });
+
+    expect(result.steps[0]!.coverage_percent).toBeDefined();
+    expect(typeof result.steps[0]!.coverage_percent).toBe('number');
+  });
+});
+
+// ─── Metrics enrichment ──────────────────────────────────────────────────────
+
+describe('trace handler – metrics enrichment', () => {
+  it('includes cyclomatic complexity from symbol_metrics', () => {
+    const db = createTestDb();
+    const fileId = insertFile(db, 'src/main.ts', 'main', MAIN_SOURCE);
+    const mainId = insertSymbol(db, fileId, 'main', 'function', 3, 6);
+    db.prepare('INSERT INTO symbol_metrics (symbol_id, line_count, param_count, cyclomatic, max_nesting) VALUES (?, ?, ?, ?, ?)').run(
+      mainId,
+      4,
+      0,
+      3,
+      1,
+    );
+
+    const result = handler(db, { from: mainId });
+
+    expect(result.steps[0]!.cyclomatic).toBe(3);
+  });
+});
+
+// ─── Pre-order DFS ordering ──────────────────────────────────────────────────
+
+describe('trace handler – DFS ordering', () => {
+  it('returns steps in pre-order DFS (callees before siblings)', () => {
+    const db = createTestDb();
+    const source = 'function a() {}\nfunction b() {}\nfunction c() {}\nfunction d() {}';
+    const fileId = insertFile(db, 'src/main.ts', 'main', source);
+
+    const a = insertSymbol(db, fileId, 'a', 'function', 1, 1);
+    const b = insertSymbol(db, fileId, 'b', 'function', 2, 2);
+    const c = insertSymbol(db, fileId, 'c', 'function', 3, 3);
+    const d = insertSymbol(db, fileId, 'd', 'function', 4, 4);
+
+    // a calls b and c; b calls d
+    insertCallEdge(db, a, b, 'b', 0);
+    insertCallEdge(db, a, c, 'c', 0);
+    insertCallEdge(db, b, d, 'd', 1);
+
+    const result = handler(db, { from: a });
+
+    // Pre-order DFS: a → b → d → c
+    const names = result.steps.map((s) => s.name);
+    expect(names).toEqual(['a', 'b', 'd', 'c']);
+    expect(result.steps[0]!.depth).toBe(0);
+    expect(result.steps[1]!.depth).toBe(1);
+    expect(result.steps[2]!.depth).toBe(2);
+    expect(result.steps[3]!.depth).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #197

Add a `lore_trace` MCP tool that walks an execution path from an entry point and returns an ordered call sequence with source code inlined — a self-contained reasoning bundle for LLM agents.

## Entry modes

1. **Symbol ID**: `from=symbolId` — forward DFS trace
2. **Symbol name**: `from_name="handleCreateUser"` — resolved via `getSymbolsByName()`
3. **Point-to-point**: `from` + `to` — BFS shortest call path between two symbols

## Features

- Pre-order DFS traversal matching natural execution reading order
- Configurable depth (1–10, default 5)
- Source truncation via `max_source_lines` (default 50)
- Cyclomatic complexity enrichment from `symbol_metrics`
- Coverage percent enrichment from `coverage_lines`
- Cycle detection (visited symbols skipped)

## Files changed

- **New**: `src/server/tools/trace.ts` — tool de- **New**: `src/server/tools/trace.ts` — too-registry.ts` — register new tool module
- **New**: `tests/server/tools/trac- **New**: `te 20 tes- **New**:ting

All 278 server tests pass (including 20 new trace tests).