### PR TITLE
feat(tools): add lore_structure structural anomaly detection tool (#193)

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -43,6 +43,8 @@ import * as snippet from './tools/snippet.js';
 import * as blame from './tools/blame.js';
 import * as metrics from './tools/metrics.js';
 import * as history from './tools/history.js';
+import * as trace from './tools/trace.js';
+import * as structure from './tools/structure.js';
 
 // ─── Server options ───────────────────────────────────────────────────────────
 
@@ -133,6 +135,8 @@ function buildToolModulesSync(): ToolModule[] {
     { def: blame.toolDef, handlerFactory: (deps) => (args) => blame.handler(deps.db, args) },
     { def: metrics.toolDef, handlerFactory: (deps) => (args) => metrics.handler(deps.db, args ?? {}) },
     { def: history.toolDef, handlerFactory: (deps) => (args) => history.handler(deps.db, args, deps.embedder) },
+    { def: trace.toolDef, handlerFactory: (deps) => (args) => trace.handler(deps.db, args) },
+    { def: structure.toolDef, handlerFactory: (deps) => (args) => structure.handler(deps.db, args) },
   ];
 }
 

--- a/src/server/tool-registry.ts
+++ b/src/server/tool-registry.ts
@@ -240,6 +240,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     metrics,
     history,
     trace,
+    structure,
   ] = await Promise.all([
     import('./tools/lookup.js'),
     import('./tools/graph.js'),
@@ -251,6 +252,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     import('./tools/metrics.js'),
     import('./tools/history.js'),
     import('./tools/trace.js'),
+    import('./tools/structure.js'),
   ]);
 
   return [
@@ -293,6 +295,10 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     {
       def: trace.toolDef,
       handlerFactory: (deps) => (args) => trace.handler(deps.db, args),
+    },
+    {
+      def: structure.toolDef,
+      handlerFactory: (deps) => (args) => structure.handler(deps.db, args),
     },
   ];
 }

--- a/src/server/tools/structure.ts
+++ b/src/server/tools/structure.ts
@@ -1,0 +1,418 @@
+/**
+ * @module lore-server/tools/structure
+ *
+ * MCP tool: detect structural anomalies in the codebase at the directory level.
+ *
+ * Analyses:
+ *   - **cycles**: Directory-level import cycles via Tarjan's SCC.
+ *   - **layers**: Topological layering violations via Kahn's algorithm.
+ *   - **outliers**: Anomalous cross-directory couplings by edge-count statistics.
+ */
+
+import type { Database } from '../../db/read-only.js';
+
+// ─── Tool definition ──────────────────────────────────────────────────────────
+
+export const toolDef = {
+  name: 'lore_structure',
+  description:
+    'Detect structural anomalies in the codebase at the directory level. ' +
+    'Aggregates file-level imports into directory-level edges and runs: ' +
+    "(A) Tarjan's SCC for import cycle detection, " +
+    "(B) Kahn's topological sort for layering violation detection, " +
+    '(C) outlier detection for anomalous cross-directory couplings. ' +
+    'Set `analysis` to "cycles", "layers", "outliers", or "all" (default). ' +
+    'Use `depth` to control directory aggregation depth (default 2). ' +
+    'Use `branch` to filter by source branch.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      analysis: {
+        type: 'string',
+        enum: ['cycles', 'layers', 'outliers', 'all'] as const,
+        description:
+          'Which analysis to run. "cycles" detects directory-level import cycles, ' +
+          '"layers" detects topological layering violations, ' +
+          '"outliers" detects anomalous cross-directory couplings, ' +
+          '"all" runs all three. Default: "all".',
+      },
+      depth: {
+        type: 'number',
+        description:
+          'Directory aggregation depth. Controls how many path segments from the repo root ' +
+          'are used to group files into directories (e.g., depth=2 maps src/server/tools/graph.ts ' +
+          'to src/server). Default: 2.',
+        minimum: 1,
+        maximum: 10,
+      },
+      branch: {
+        type: 'string',
+        description: 'Optional branch name to filter file_imports by source file branch.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results per analysis (default 20).',
+        minimum: 1,
+        maximum: 500,
+      },
+    },
+    required: [] as readonly string[],
+  },
+} as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type AnalysisMode = 'cycles' | 'layers' | 'outliers' | 'all';
+
+export interface StructureArgs {
+  analysis?: AnalysisMode;
+  depth?: number;
+  branch?: string;
+  limit?: number;
+}
+
+export interface StructureCycle {
+  directories: string[];
+  edge_count: number;
+}
+
+export interface LayerViolation {
+  from_dir: string;
+  to_dir: string;
+  from_rank: number;
+  to_rank: number;
+  edge_count: number;
+  sample_files: string[];
+}
+
+export interface OutlierEdge {
+  from_dir: string;
+  to_dir: string;
+  edge_count: number;
+  reverse_edge_count: number;
+  sample_files: string[];
+}
+
+export interface StructureResult {
+  cycles?: StructureCycle[];
+  layer_violations?: LayerViolation[];
+  outliers?: OutlierEdge[];
+}
+
+// ─── Directory graph construction ─────────────────────────────────────────────
+
+interface DirEdge {
+  from_dir: string;
+  to_dir: string;
+  count: number;
+  sample_files: string[];
+}
+
+interface DirGraph {
+  /** All unique directory nodes. */
+  directories: Set<string>;
+  /** Adjacency: from_dir → to_dir → DirEdge */
+  adjacency: Map<string, Map<string, DirEdge>>;
+}
+
+/**
+ * Truncate a file path to the given depth of directory segments.
+ * E.g., depth=2: "src/server/tools/graph.ts" → "src/server"
+ */
+function dirPrefix(filePath: string, depth: number): string {
+  const segments = filePath.split('/');
+  // Take min(depth, segments.length - 1) to exclude the filename
+  const dirSegments = segments.slice(0, Math.min(depth, segments.length - 1));
+  return dirSegments.length > 0 ? dirSegments.join('/') : '.';
+}
+
+/**
+ * Build a directory-level graph by aggregating file_imports edges.
+ * Each file is mapped to its directory prefix at the given depth,
+ * and edges between distinct directories are deduplicated with counts.
+ */
+function buildDirGraph(db: Database.Database, depth: number, branch?: string): DirGraph {
+  const conditions: string[] = ['fi.resolved_id IS NOT NULL'];
+  const params: Array<string | number> = [];
+
+  if (branch !== undefined) {
+    conditions.push('f_src.branch = ?');
+    params.push(branch);
+  }
+
+  const whereClause = conditions.join(' AND ');
+
+  const rows = db.prepare(
+    `SELECT f_src.path AS src_path, f_dst.path AS dst_path
+       FROM file_imports fi
+       JOIN files f_src ON f_src.id = fi.file_id
+       JOIN files f_dst ON f_dst.id = fi.resolved_id
+      WHERE ${whereClause}`,
+  ).all(...params) as Array<{ src_path: string; dst_path: string }>;
+
+  const directories = new Set<string>();
+  const adjacency = new Map<string, Map<string, DirEdge>>();
+
+  for (const { src_path, dst_path } of rows) {
+    const srcDir = dirPrefix(src_path, depth);
+    const dstDir = dirPrefix(dst_path, depth);
+
+    directories.add(srcDir);
+    directories.add(dstDir);
+
+    // Skip self-loops at the directory level
+    if (srcDir === dstDir) continue;
+
+    let targets = adjacency.get(srcDir);
+    if (!targets) {
+      targets = new Map();
+      adjacency.set(srcDir, targets);
+    }
+
+    let edge = targets.get(dstDir);
+    if (!edge) {
+      edge = { from_dir: srcDir, to_dir: dstDir, count: 0, sample_files: [] };
+      targets.set(dstDir, edge);
+    }
+
+    edge.count++;
+    if (edge.sample_files.length < 3) {
+      const sample = `${src_path} → ${dst_path}`;
+      if (!edge.sample_files.includes(sample)) {
+        edge.sample_files.push(sample);
+      }
+    }
+  }
+
+  return { directories, adjacency };
+}
+
+// ─── Analysis A: Tarjan's SCC for directory-level cycles ──────────────────────
+
+function detectDirCycles(graph: DirGraph, limit: number): StructureCycle[] {
+  let index = 0;
+  const indices = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Map<string, boolean>();
+  const stack: string[] = [];
+  const sccs: string[][] = [];
+
+  function strongConnect(v: string): void {
+    indices.set(v, index);
+    lowlink.set(v, index);
+    index++;
+    stack.push(v);
+    onStack.set(v, true);
+
+    const targets = graph.adjacency.get(v);
+    if (targets) {
+      for (const w of targets.keys()) {
+        if (!indices.has(w)) {
+          strongConnect(w);
+          lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+        } else if (onStack.get(w)) {
+          lowlink.set(v, Math.min(lowlink.get(v)!, indices.get(w)!));
+        }
+      }
+    }
+
+    if (lowlink.get(v) === indices.get(v)) {
+      const scc: string[] = [];
+      let w: string;
+      do {
+        w = stack.pop()!;
+        onStack.set(w, false);
+        scc.push(w);
+      } while (w !== v);
+
+      if (scc.length > 1) {
+        sccs.push(scc);
+      } else {
+        // Single-node SCC: only a cycle if there's a self-loop
+        const selfTargets = graph.adjacency.get(scc[0]!);
+        if (selfTargets?.has(scc[0]!)) {
+          sccs.push(scc);
+        }
+      }
+    }
+  }
+
+  for (const dir of graph.directories) {
+    if (!indices.has(dir)) {
+      strongConnect(dir);
+    }
+  }
+
+  // Convert SCCs to StructureCycle with edge counts
+  const cycles: StructureCycle[] = sccs
+    .map((scc) => {
+      const sccSet = new Set(scc);
+      let edgeCount = 0;
+      for (const dir of scc) {
+        const targets = graph.adjacency.get(dir);
+        if (targets) {
+          for (const [target, edge] of targets) {
+            if (sccSet.has(target)) {
+              edgeCount += edge.count;
+            }
+          }
+        }
+      }
+      return { directories: scc.sort(), edge_count: edgeCount };
+    })
+    .sort((a, b) => b.edge_count - a.edge_count)
+    .slice(0, limit);
+
+  return cycles;
+}
+
+// ─── Analysis B: DFS-based layering violations ───────────────────────────────
+
+function detectLayerViolations(graph: DirGraph, limit: number): LayerViolation[] {
+  // Assign layers using DFS finish time.  Nodes that finish earlier are more
+  // foundational (deeper in the dependency chain).  Back-edges — edges from a
+  // node to an ancestor still on the DFS stack — represent layering violations
+  // where a downstream directory imports an upstream one.
+
+  const visited = new Set<string>();
+  const onStack = new Set<string>();
+  const finishRank = new Map<string, number>();
+  const violations: LayerViolation[] = [];
+  let finishTimer = 0;
+
+  // Compute traditional in-degree (how many dirs import this one) so we can
+  // seed the DFS from source nodes (entry points imported by nobody).
+  const inDeg = new Map<string, number>();
+  for (const dir of graph.directories) inDeg.set(dir, 0);
+  for (const targets of graph.adjacency.values()) {
+    for (const dst of targets.keys()) {
+      inDeg.set(dst, (inDeg.get(dst) ?? 0) + 1);
+    }
+  }
+
+  // Sort so source nodes (low in-degree) are visited first for determinism.
+  const sorted = [...graph.directories].sort(
+    (a, b) => (inDeg.get(a) ?? 0) - (inDeg.get(b) ?? 0) || a.localeCompare(b),
+  );
+
+  function dfs(v: string): void {
+    visited.add(v);
+    onStack.add(v);
+
+    const targets = graph.adjacency.get(v);
+    if (targets) {
+      for (const [w, edge] of targets) {
+        if (!visited.has(w)) {
+          dfs(w);
+        } else if (onStack.has(w)) {
+          // Back-edge: v → w where w is an ancestor on the current path.
+          violations.push({
+            from_dir: v,
+            to_dir: w,
+            from_rank: -1, // patched after DFS completes
+            to_rank: -1,
+            edge_count: edge.count,
+            sample_files: edge.sample_files,
+          });
+        }
+      }
+    }
+
+    onStack.delete(v);
+    finishRank.set(v, finishTimer++);
+  }
+
+  for (const dir of sorted) {
+    if (!visited.has(dir)) {
+      dfs(dir);
+    }
+  }
+
+  // Patch ranks using finish times (lower = more foundational).
+  for (const v of violations) {
+    v.from_rank = finishRank.get(v.from_dir) ?? -1;
+    v.to_rank = finishRank.get(v.to_dir) ?? -1;
+  }
+
+  return violations
+    .sort((a, b) => b.edge_count - a.edge_count)
+    .slice(0, limit);
+}
+
+// ─── Analysis C: Outlier detection ────────────────────────────────────────────
+
+function detectOutliers(graph: DirGraph, limit: number): OutlierEdge[] {
+  // Collect all directed edges with their counts
+  const allEdges: DirEdge[] = [];
+  for (const targets of graph.adjacency.values()) {
+    for (const edge of targets.values()) {
+      allEdges.push(edge);
+    }
+  }
+
+  if (allEdges.length === 0) return [];
+
+  // Compute mean edge count
+  const totalCount = allEdges.reduce((sum, e) => sum + e.count, 0);
+  const mean = totalCount / allEdges.length;
+
+  // Compute standard deviation
+  const variance = allEdges.reduce((sum, e) => sum + (e.count - mean) ** 2, 0) / allEdges.length;
+  const stddev = Math.sqrt(variance);
+
+  // Outliers are edges with unusually low edge counts.
+  // Threshold: count < mean - 1*stddev, but at least count == 1 to be meaningful.
+  // If stddev is 0 (all edges same count), no outliers.
+  const threshold = stddev > 0 ? Math.max(1, mean - stddev) : 0;
+
+  if (threshold === 0) return [];
+
+  const outliers: OutlierEdge[] = [];
+
+  for (const edge of allEdges) {
+    if (edge.count >= threshold) continue;
+
+    // Look up reverse edge count
+    const reverseTargets = graph.adjacency.get(edge.to_dir);
+    const reverseEdge = reverseTargets?.get(edge.from_dir);
+    const reverseCount = reverseEdge?.count ?? 0;
+
+    outliers.push({
+      from_dir: edge.from_dir,
+      to_dir: edge.to_dir,
+      edge_count: edge.count,
+      reverse_edge_count: reverseCount,
+      sample_files: edge.sample_files,
+    });
+  }
+
+  return outliers
+    .sort((a, b) => a.edge_count - b.edge_count)
+    .slice(0, limit);
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+/** Analyse directory-level structural anomalies in the codebase. */
+export function handler(db: Database.Database, args: StructureArgs): StructureResult {
+  const analysis = args.analysis ?? 'all';
+  const depth = Math.max(1, Math.min(args.depth ?? 2, 10));
+  const limit = Math.max(1, Math.min(args.limit ?? 20, 500));
+
+  const graph = buildDirGraph(db, depth, args.branch);
+  const result: StructureResult = {};
+
+  if (analysis === 'cycles' || analysis === 'all') {
+    result.cycles = detectDirCycles(graph, limit);
+  }
+
+  if (analysis === 'layers' || analysis === 'all') {
+    result.layer_violations = detectLayerViolations(graph, limit);
+  }
+
+  if (analysis === 'outliers' || analysis === 'all') {
+    result.outliers = detectOutliers(graph, limit);
+  }
+
+  return result;
+}

--- a/tests/server/server.test.ts
+++ b/tests/server/server.test.ts
@@ -67,7 +67,7 @@ describe('createLoreMcpServer', () => {
     createLoreMcpServer(db, '/tmp/test.db');
 
     const toolNames = mockTool.mock.calls.map((call) => call[0]);
-
+    expect(toolNames).toContain('lore_structure');
   });
 
   it('should register newly exposed tools with expected schema fields', () => {

--- a/tests/server/tool-registry.test.ts
+++ b/tests/server/tool-registry.test.ts
@@ -297,7 +297,7 @@ describe('tool-registry', () => {
   describe('buildToolModules', () => {
     it('should return an array of tool modules with expected tool names', async () => {
       const modules = await buildToolModules();
-      expect(modules.length).toBeGreaterThanOrEqual(9);
+      expect(modules.length).toBeGreaterThanOrEqual(11);
       const names = modules.map(m => m.def.name);
       expect(names).toContain('lore_lookup');
       expect(names).toContain('lore_graph');
@@ -307,6 +307,8 @@ describe('tool-registry', () => {
       expect(names).toContain('lore_blame');
       expect(names).toContain('lore_metrics');
       expect(names).toContain('lore_history');
+      expect(names).toContain('lore_trace');
+      expect(names).toContain('lore_structure');
     });
 
     it('should return modules with callable handlerFactory', async () => {

--- a/tests/server/tools/structure.test.ts
+++ b/tests/server/tools/structure.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  handler,
+  toolDef,
+  type StructureArgs,
+  type StructureResult,
+} from '../../../src/server/tools/structure.js';
+import { openDb } from '../../../src/db/schema.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTestDb(): Database.Database {
+  return openDb(':memory:');
+}
+
+function insertFile(db: Database.Database, path: string, branch: string): number {
+  const result = db
+    .prepare(
+      "INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, ?, ?, 0, NULL, '')",
+    )
+    .run(path, branch, 'typescript');
+  return result.lastInsertRowid as number;
+}
+
+function insertImportEdge(
+  db: Database.Database,
+  fileId: number,
+  rawImport: string,
+  resolvedId: number | null,
+): void {
+  db.prepare(
+    'INSERT INTO file_imports (file_id, raw_import, resolved_id) VALUES (?, ?, ?)',
+  ).run(fileId, rawImport, resolvedId);
+}
+
+// ─── toolDef ──────────────────────────────────────────────────────────────────
+
+describe('lore_structure toolDef', () => {
+  it('should have the correct tool name', () => {
+    expect(toolDef.name).toBe('lore_structure');
+  });
+
+  it('should expose analysis enum with cycles, layers, outliers, and all', () => {
+    expect(toolDef.inputSchema.properties.analysis.enum).toEqual([
+      'cycles',
+      'layers',
+      'outliers',
+      'all',
+    ]);
+  });
+
+  it('should expose depth, branch, and limit parameters', () => {
+    expect(toolDef.inputSchema.properties.depth.type).toBe('number');
+    expect(toolDef.inputSchema.properties.branch.type).toBe('string');
+    expect(toolDef.inputSchema.properties.limit.type).toBe('number');
+  });
+
+  it('should have no required parameters', () => {
+    expect(toolDef.inputSchema.required).toEqual([]);
+  });
+});
+
+// ─── Empty database ───────────────────────────────────────────────────────────
+
+describe('structure handler – empty database', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should return empty arrays for all analyses on empty DB', () => {
+    const result = handler(db, { analysis: 'all' });
+    expect(result.cycles).toEqual([]);
+    expect(result.layer_violations).toEqual([]);
+    expect(result.outliers).toEqual([]);
+  });
+
+  it('should return empty cycles on empty DB', () => {
+    const result = handler(db, { analysis: 'cycles' });
+    expect(result.cycles).toEqual([]);
+    expect(result.layer_violations).toBeUndefined();
+    expect(result.outliers).toBeUndefined();
+  });
+
+  it('should return empty layers on empty DB', () => {
+    const result = handler(db, { analysis: 'layers' });
+    expect(result.layer_violations).toEqual([]);
+    expect(result.cycles).toBeUndefined();
+    expect(result.outliers).toBeUndefined();
+  });
+
+  it('should return empty outliers on empty DB', () => {
+    const result = handler(db, { analysis: 'outliers' });
+    expect(result.outliers).toEqual([]);
+    expect(result.cycles).toBeUndefined();
+    expect(result.layer_violations).toBeUndefined();
+  });
+});
+
+// ─── Cycles analysis ──────────────────────────────────────────────────────────
+
+describe('structure handler – cycles analysis', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should detect a directory-level import cycle', () => {
+    // src/a/foo.ts → src/b/bar.ts → src/a/baz.ts (cycle: src/a ↔ src/b)
+    const fileA1 = insertFile(db, 'src/a/foo.ts', 'main');
+    const fileB1 = insertFile(db, 'src/b/bar.ts', 'main');
+    const fileA2 = insertFile(db, 'src/a/baz.ts', 'main');
+
+    insertImportEdge(db, fileA1, './bar', fileB1); // src/a → src/b
+    insertImportEdge(db, fileB1, './baz', fileA2); // src/b → src/a
+
+    const result = handler(db, { analysis: 'cycles', depth: 2 });
+    expect(result.cycles).toBeDefined();
+    expect(result.cycles!.length).toBe(1);
+    expect(result.cycles![0]!.directories).toContain('src/a');
+    expect(result.cycles![0]!.directories).toContain('src/b');
+    expect(result.cycles![0]!.edge_count).toBe(2);
+  });
+
+  it('should not report non-cyclic imports as cycles', () => {
+    // A → B → C (no cycle)
+    const fileA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fileB = insertFile(db, 'src/b/bar.ts', 'main');
+    const fileC = insertFile(db, 'src/c/baz.ts', 'main');
+
+    insertImportEdge(db, fileA, './bar', fileB);
+    insertImportEdge(db, fileB, './baz', fileC);
+
+    const result = handler(db, { analysis: 'cycles', depth: 2 });
+    expect(result.cycles).toEqual([]);
+  });
+
+  it('should detect multiple cycles', () => {
+    // Cycle 1: src/a ↔ src/b
+    const fA1 = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB1 = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA1, './bar', fB1);
+    insertImportEdge(db, fB1, './foo', fA1);
+
+    // Cycle 2: src/c ↔ src/d
+    const fC1 = insertFile(db, 'src/c/one.ts', 'main');
+    const fD1 = insertFile(db, 'src/d/two.ts', 'main');
+    insertImportEdge(db, fC1, './two', fD1);
+    insertImportEdge(db, fD1, './one', fC1);
+
+    const result = handler(db, { analysis: 'cycles', depth: 2 });
+    expect(result.cycles!.length).toBe(2);
+  });
+
+  it('should skip self-edges within the same directory', () => {
+    // Both files in src/a → self-loop at directory level, not a cycle
+    const fA1 = insertFile(db, 'src/a/foo.ts', 'main');
+    const fA2 = insertFile(db, 'src/a/bar.ts', 'main');
+    insertImportEdge(db, fA1, './bar', fA2);
+
+    const result = handler(db, { analysis: 'cycles', depth: 2 });
+    expect(result.cycles).toEqual([]);
+  });
+});
+
+// ─── Layers analysis ─────────────────────────────────────────────────────────
+
+describe('structure handler – layers analysis', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should return empty violations for a well-ordered dependency chain', () => {
+    // Chain: src/app → src/lib → src/core
+    // Kahn's topo order: core(0), lib(1), app(2)
+    // All edges naturally satisfy dstRank < srcRank, so no violations.
+    const fCore = insertFile(db, 'src/core/core.ts', 'main');
+    const fLib = insertFile(db, 'src/lib/lib.ts', 'main');
+    const fApp = insertFile(db, 'src/app/app.ts', 'main');
+
+    insertImportEdge(db, fApp, '../lib/lib', fLib);
+    insertImportEdge(db, fLib, '../core/core', fCore);
+
+    const result = handler(db, { analysis: 'layers', depth: 2 });
+    expect(result.layer_violations).toBeDefined();
+    expect(result.layer_violations).toEqual([]);
+  });
+
+  it('should return empty violations for a diamond DAG', () => {
+    // Diamond: lib → app, lib → utils, app → core, utils → core
+    const fCore = insertFile(db, 'src/core/core.ts', 'main');
+    const fApp = insertFile(db, 'src/app/app.ts', 'main');
+    const fUtils = insertFile(db, 'src/utils/utils.ts', 'main');
+    const fLib = insertFile(db, 'src/lib/lib.ts', 'main');
+
+    insertImportEdge(db, fLib, '../app/app', fApp);
+    insertImportEdge(db, fLib, '../utils/utils', fUtils);
+    insertImportEdge(db, fApp, '../core/core', fCore);
+    insertImportEdge(db, fUtils, '../core/core', fCore);
+
+    const result = handler(db, { analysis: 'layers', depth: 2 });
+    expect(result.layer_violations).toEqual([]);
+  });
+
+  it('should detect a back-edge as a layer violation in a cycle', () => {
+    // Cycle: src/a → src/b → src/a. The DFS back-edge is a layer violation.
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', fB);
+    insertImportEdge(db, fB, './foo', fA);
+
+    const result = handler(db, { analysis: 'layers', depth: 2 });
+    expect(result.layer_violations).toBeDefined();
+    expect(result.layer_violations!.length).toBe(1);
+
+    const v = result.layer_violations![0]!;
+    // The back-edge creates a violation where from_rank < to_rank
+    expect(v.from_rank).toBeLessThan(v.to_rank);
+    expect(v.edge_count).toBe(1);
+  });
+
+  it('should detect a violation in a larger cycle', () => {
+    // Chain with back-edge: lib → app → core → utils → app
+    // DFS finds utils → app as the back-edge violation.
+    const fCore = insertFile(db, 'src/core/core.ts', 'main');
+    const fApp = insertFile(db, 'src/app/app.ts', 'main');
+    const fLib = insertFile(db, 'src/lib/lib.ts', 'main');
+    const fUtils = insertFile(db, 'src/utils/utils.ts', 'main');
+
+    insertImportEdge(db, fLib, '../app/app', fApp);
+    insertImportEdge(db, fApp, '../core/core', fCore);
+    insertImportEdge(db, fCore, '../utils/utils', fUtils);
+    insertImportEdge(db, fUtils, '../app/app', fApp);
+
+    const result = handler(db, { analysis: 'layers', depth: 2 });
+    expect(result.layer_violations).toBeDefined();
+    expect(result.layer_violations!.length).toBeGreaterThan(0);
+
+    const violation = result.layer_violations!.find(
+      (v) => v.from_dir === 'src/utils' && v.to_dir === 'src/app',
+    );
+    expect(violation).toBeDefined();
+    expect(violation!.edge_count).toBe(1);
+    expect(violation!.from_rank).toBeLessThan(violation!.to_rank);
+  });
+
+  it('should not flag non-cyclic edges alongside cycle violations', () => {
+    // Cycle: src/a ↔ src/b, plus non-cyclic: src/c → src/d
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', fB);
+    insertImportEdge(db, fB, './foo', fA);
+
+    const fC = insertFile(db, 'src/c/baz.ts', 'main');
+    const fD = insertFile(db, 'src/d/qux.ts', 'main');
+    insertImportEdge(db, fC, '../d/qux', fD);
+
+    const result = handler(db, { analysis: 'layers', depth: 2 });
+    // Only the back-edge from the cycle should be a violation
+    expect(result.layer_violations!.length).toBe(1);
+    // The non-cyclic edge src/c → src/d should NOT be a violation
+    const nonCyclicViolation = result.layer_violations!.find(
+      (v) => v.from_dir === 'src/c' || v.to_dir === 'src/d',
+    );
+    expect(nonCyclicViolation).toBeUndefined();
+  });
+
+  it('should return layer_violations as an array when analysis is layers', () => {
+    const result = handler(db, { analysis: 'layers' });
+    expect(Array.isArray(result.layer_violations)).toBe(true);
+    expect(result.cycles).toBeUndefined();
+    expect(result.outliers).toBeUndefined();
+  });
+});
+
+// ─── Outliers analysis ────────────────────────────────────────────────────────
+
+describe('structure handler – outliers analysis', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should detect anomalous low-count edges amid higher-count connections', () => {
+    // Create several high-count edges and one low-count edge
+    // High-count: src/a → src/b with many file imports
+    const filesA: number[] = [];
+    const filesB: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      filesA.push(insertFile(db, `src/a/file${i}.ts`, 'main'));
+      filesB.push(insertFile(db, `src/b/file${i}.ts`, 'main'));
+    }
+
+    // 10 edges from src/a → src/b
+    for (let i = 0; i < 10; i++) {
+      insertImportEdge(db, filesA[i]!, `../b/file${i}`, filesB[i]!);
+    }
+
+    // 10 edges from src/b → src/a (high-count reverse)
+    for (let i = 0; i < 10; i++) {
+      insertImportEdge(db, filesB[i]!, `../a/file${i}`, filesA[i]!);
+    }
+
+    // Add a third dir with high-count connections
+    const filesC: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      filesC.push(insertFile(db, `src/c/file${i}.ts`, 'main'));
+    }
+    for (let i = 0; i < 10; i++) {
+      insertImportEdge(db, filesA[i]!, `../c/file${i}`, filesC[i]!);
+    }
+
+    // Low-count outlier: src/c → src/b with just 1 edge
+    insertImportEdge(db, filesC[0]!, '../b/file0', filesB[0]!);
+
+    const result = handler(db, { analysis: 'outliers', depth: 2 });
+    expect(result.outliers).toBeDefined();
+
+    if (result.outliers!.length > 0) {
+      // The low-count edge src/c → src/b should be among outliers
+      const outlier = result.outliers!.find(
+        (o) => o.from_dir === 'src/c' && o.to_dir === 'src/b',
+      );
+      expect(outlier).toBeDefined();
+      expect(outlier!.edge_count).toBe(1);
+    }
+  });
+
+  it('should return empty outliers when all edges have the same count', () => {
+    // 3 dirs each with exactly 1 edge between them → stddev = 0 → no outliers
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    const fC = insertFile(db, 'src/c/baz.ts', 'main');
+
+    insertImportEdge(db, fA, './bar', fB);
+    insertImportEdge(db, fB, './baz', fC);
+    insertImportEdge(db, fC, './foo', fA);
+
+    const result = handler(db, { analysis: 'outliers', depth: 2 });
+    expect(result.outliers).toEqual([]);
+  });
+
+  it('should include reverse_edge_count and sample_files in outlier results', () => {
+    // Set up data where an outlier exists and check its shape
+    const filesA: number[] = [];
+    const filesB: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      filesA.push(insertFile(db, `src/a/f${i}.ts`, 'main'));
+      filesB.push(insertFile(db, `src/b/f${i}.ts`, 'main'));
+    }
+    for (let i = 0; i < 8; i++) {
+      insertImportEdge(db, filesA[i]!, `../b/f${i}`, filesB[i]!);
+    }
+    // High count from B → A
+    for (let i = 0; i < 8; i++) {
+      insertImportEdge(db, filesB[i]!, `../a/f${i}`, filesA[i]!);
+    }
+
+    // Third dir with low-count edge
+    const fC = insertFile(db, 'src/c/only.ts', 'main');
+    insertImportEdge(db, fC, '../a/f0', filesA[0]!);
+
+    const result = handler(db, { analysis: 'outliers', depth: 2 });
+    if (result.outliers!.length > 0) {
+      const outlier = result.outliers![0]!;
+      expect(outlier).toHaveProperty('from_dir');
+      expect(outlier).toHaveProperty('to_dir');
+      expect(outlier).toHaveProperty('edge_count');
+      expect(outlier).toHaveProperty('reverse_edge_count');
+      expect(outlier).toHaveProperty('sample_files');
+      expect(Array.isArray(outlier.sample_files)).toBe(true);
+      expect(outlier.sample_files.length).toBeLessThanOrEqual(3);
+    }
+  });
+});
+
+// ─── 'all' mode ───────────────────────────────────────────────────────────────
+
+describe('structure handler – all mode', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should return all three fields when analysis is "all"', () => {
+    const result = handler(db, { analysis: 'all' });
+    expect(result).toHaveProperty('cycles');
+    expect(result).toHaveProperty('layer_violations');
+    expect(result).toHaveProperty('outliers');
+  });
+
+  it('should default to "all" when no analysis is specified', () => {
+    const result = handler(db, {});
+    expect(result).toHaveProperty('cycles');
+    expect(result).toHaveProperty('layer_violations');
+    expect(result).toHaveProperty('outliers');
+  });
+});
+
+// ─── Depth parameter ──────────────────────────────────────────────────────────
+
+describe('structure handler – depth parameter', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should aggregate directories at the requested depth', () => {
+    // With depth=1, src/a/b and src/a/c both map to "src"
+    const fAB = insertFile(db, 'src/a/b/foo.ts', 'main');
+    const fAC = insertFile(db, 'src/a/c/bar.ts', 'main');
+    insertImportEdge(db, fAB, '../c/bar', fAC);
+
+    // At depth=1, both are "src" → self-loop, excluded
+    const resultDepth1 = handler(db, { analysis: 'cycles', depth: 1 });
+    expect(resultDepth1.cycles).toEqual([]);
+
+    // At depth=3, they become src/a/b and src/a/c → cross-directory edge but no cycle
+    const resultDepth3 = handler(db, { analysis: 'cycles', depth: 3 });
+    expect(resultDepth3.cycles).toEqual([]);
+  });
+
+  it('should clamp depth to valid range', () => {
+    // depth=0 should be clamped to 1, depth=100 to 10
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', fB);
+
+    // Should not throw with extreme values
+    expect(() => handler(db, { analysis: 'cycles', depth: 0 })).not.toThrow();
+    expect(() => handler(db, { analysis: 'cycles', depth: 100 })).not.toThrow();
+  });
+});
+
+// ─── Branch filtering ─────────────────────────────────────────────────────────
+
+describe('structure handler – branch filtering', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should scope results to the specified branch', () => {
+    // Create a cycle on branch "main"
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', fB);
+    insertImportEdge(db, fB, './foo', fA);
+
+    // Create files on branch "feature" with no cycle
+    const fC = insertFile(db, 'src/c/baz.ts', 'feature');
+    const fD = insertFile(db, 'src/d/qux.ts', 'feature');
+    insertImportEdge(db, fC, './qux', fD);
+
+    // With branch="main", should find the cycle
+    const mainResult = handler(db, { analysis: 'cycles', branch: 'main', depth: 2 });
+    expect(mainResult.cycles!.length).toBe(1);
+
+    // With branch="feature", should find no cycle
+    const featureResult = handler(db, { analysis: 'cycles', branch: 'feature', depth: 2 });
+    expect(featureResult.cycles).toEqual([]);
+  });
+
+  it('should return empty results for non-existent branch', () => {
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    const fB = insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', fB);
+
+    const result = handler(db, { analysis: 'all', branch: 'nonexistent' });
+    expect(result.cycles).toEqual([]);
+    expect(result.layer_violations).toEqual([]);
+    expect(result.outliers).toEqual([]);
+  });
+});
+
+// ─── Limit parameter ─────────────────────────────────────────────────────────
+
+describe('structure handler – limit parameter', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should cap cycle results to the specified limit', () => {
+    // Create 3 independent cycles
+    for (let i = 0; i < 3; i++) {
+      const fX = insertFile(db, `src/x${i}/a.ts`, 'main');
+      const fY = insertFile(db, `src/y${i}/b.ts`, 'main');
+      insertImportEdge(db, fX, `../y${i}/b`, fY);
+      insertImportEdge(db, fY, `../x${i}/a`, fX);
+    }
+
+    const result = handler(db, { analysis: 'cycles', depth: 2, limit: 2 });
+    expect(result.cycles!.length).toBeLessThanOrEqual(2);
+  });
+
+  it('should clamp limit to valid range', () => {
+    expect(() => handler(db, { analysis: 'all', limit: 0 })).not.toThrow();
+    expect(() => handler(db, { analysis: 'all', limit: 9999 })).not.toThrow();
+  });
+});
+
+// ─── Unresolved imports ───────────────────────────────────────────────────────
+
+describe('structure handler – unresolved imports', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should ignore imports with null resolved_id', () => {
+    const fA = insertFile(db, 'src/a/foo.ts', 'main');
+    insertFile(db, 'src/b/bar.ts', 'main');
+    insertImportEdge(db, fA, './bar', null); // unresolved
+
+    const result = handler(db, { analysis: 'all', depth: 2 });
+    expect(result.cycles).toEqual([]);
+    expect(result.layer_violations).toEqual([]);
+    expect(result.outliers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a `lore_structure` tool that detects structural anomalies in the codebase: directory-level import cycles, inferred topological layering violations, and outlier cross-directory dependencies.

## Changes

- **New tool**: `src/server/tools/structure.ts` — `lore_structure` tool definition + handler (418 lines)
- **Registration**: Added to tool registry and server
- **Tests**: Comprehensive test suite in `tests/server/tools/structure.test.ts` (532 lines)

Three analyses selectable individually or together:
- **Cycles**: Tarjan'\''s SCC on directory-level import graph
- **Layers**: Topological ordering to detect inferred layer violations
- **Outliers**: Statistical edge-count analysis for suspicious couplings

No new tables needed — pure query + in-memory graph algorithms over existing `file_imports` data.

> **Note**: Integration tests had regressions during the cadre run — this PR may need test fixes before merge.

Closes #193