### PR TITLE
feat(tools): add lore_dependents tool for unified reverse-dependency queries

### DIFF
--- a/src/server/tool-registry.ts
+++ b/src/server/tool-registry.ts
@@ -243,6 +243,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     diff,
     cohesion,
     structure,
+    dependents,
   ] = await Promise.all([
     import('./tools/lookup.js'),
     import('./tools/graph.js'),
@@ -257,6 +258,7 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     import('./tools/diff.js'),
     import('./tools/cohesion.js'),
     import('./tools/structure.js'),
+    import('./tools/dependents.js'),
   ]);
 
   return [
@@ -311,6 +313,10 @@ export async function buildToolModules(): Promise<ToolModule[]> {
     {
       def: structure.toolDef,
       handlerFactory: (deps) => (args) => structure.handler(deps.db, args),
+    },
+    {
+      def: dependents.toolDef,
+      handlerFactory: (deps) => (args) => dependents.handler(deps.db, args),
     },
   ];
 }

--- a/src/server/tools/dependents.ts
+++ b/src/server/tools/dependents.ts
@@ -1,0 +1,617 @@
+/**
+ * @module lore-server/tools/dependents
+ *
+ * MCP tool: unified reverse-dependency / blast-radius queries.
+ *
+ * Given a symbol name or file path, returns all dependents across edge types
+ * (callers, importers, subclasses, type references) in a single call.
+ * This is a higher-level abstraction over `lore_graph` that resolves names
+ * internally and aggregates across edge kinds.
+ */
+
+import type { Database } from '../../db/read-only.js';
+import {
+  getSymbolsByName,
+  getFileByPath,
+  getSymbolById,
+  getFileById,
+} from '../../db/read-only.js';
+
+// ─── Tool definition ──────────────────────────────────────────────────────────
+
+export const toolDef = {
+  name: 'lore_dependents',
+  description:
+    'Find everything affected by changing a symbol or file — unified blast-radius / reverse-dependency query. ' +
+    'Takes a name or path (not a numeric ID) and returns callers, importers, subclasses, and type references in one call. ' +
+    'For kind="symbol", resolves the query to a symbol and returns callers, subclasses, and type-referencers. ' +
+    'For kind="file", resolves the query to a file and returns files that import it plus symbols in other files that call into its symbols. ' +
+    'Set depth > 1 for transitive closure (up to 5 hops). Set compact=true to reduce token count.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Symbol name, class name, or file path to find dependents of.',
+      },
+      kind: {
+        type: 'string',
+        enum: ['symbol', 'file'],
+        description:
+          '"symbol" resolves query as a symbol name; "file" resolves query as a file path.',
+      },
+      depth: {
+        type: 'number',
+        description:
+          'Transitive hops (default 1, max 5). depth=1 returns direct dependents only. ' +
+          'depth=N follows dependents N hops deep.',
+        minimum: 1,
+        maximum: 5,
+      },
+      branch: {
+        type: 'string',
+        description: 'Optional branch name to filter results.',
+      },
+      compact: {
+        type: 'boolean',
+        description:
+          'If true, omit provenance fields (line, character, resolution details) to reduce token count. Default false.',
+      },
+    },
+    required: ['query', 'kind'],
+  },
+} as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DependentsArgs {
+  query: string;
+  kind: 'symbol' | 'file';
+  depth?: number;
+  branch?: string;
+  compact?: boolean;
+}
+
+export interface DependentTarget {
+  id: number;
+  name: string;
+  kind: string;
+  file?: string;
+}
+
+interface CallerEntry {
+  caller_id: number;
+  caller_name: string;
+  caller_kind: string;
+  caller_file: string;
+  line?: number;
+  character?: number | null;
+  resolution_method?: string;
+}
+
+interface CompactCallerEntry {
+  caller_id: number;
+  caller_name: string;
+  caller_kind: string;
+  caller_file: string;
+}
+
+interface ImporterEntry {
+  file_id: number;
+  file_path: string;
+  raw_import: string;
+}
+
+interface CompactImporterEntry {
+  file_id: number;
+  file_path: string;
+}
+
+interface SubclassEntry {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  relationship_type: string;
+  line?: number;
+  character?: number | null;
+  resolution_method?: string;
+}
+
+interface CompactSubclassEntry {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  relationship_type: string;
+}
+
+interface TypeRefEntry {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  ref_kind: string;
+  line?: number;
+  character?: number | null;
+  resolution_method?: string;
+}
+
+interface CompactTypeRefEntry {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  ref_kind: string;
+}
+
+export interface DependentsResult {
+  target: DependentTarget;
+  dependents: {
+    callers: CallerEntry[] | CompactCallerEntry[];
+    importers: ImporterEntry[] | CompactImporterEntry[];
+    subclasses: SubclassEntry[] | CompactSubclassEntry[];
+    type_references: TypeRefEntry[] | CompactTypeRefEntry[];
+  };
+  depth_used: number;
+  total_count: number;
+}
+
+export interface DependentsErrorResult {
+  error: string;
+  candidates?: Array<{ id: number; name: string; kind: string; file: string }>;
+}
+
+// ─── Raw SQL row shapes ──────────────────────────────────────────────────────
+
+interface RawCallerRow {
+  caller_id: number;
+  caller_name: string;
+  caller_kind: string;
+  caller_file: string;
+  line: number;
+  character: number | null;
+  resolution_method: string;
+}
+
+interface RawImporterRow {
+  file_id: number;
+  file_path: string;
+  raw_import: string;
+}
+
+interface RawSubclassRow {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  relationship_type: string;
+  line: number | null;
+  character: number | null;
+  resolution_method: string;
+}
+
+interface RawTypeRefRow {
+  symbol_id: number;
+  symbol_name: string;
+  symbol_kind: string;
+  file: string;
+  ref_kind: string;
+  line: number;
+  character: number | null;
+  resolution_method: string;
+}
+
+// ─── Query helpers ────────────────────────────────────────────────────────────
+
+function queryCallers(
+  db: Database.Database,
+  symbolIds: number[],
+  branch: string | undefined,
+  limit: number,
+): RawCallerRow[] {
+  if (symbolIds.length === 0) return [];
+  const placeholders = symbolIds.map(() => '?').join(', ');
+  const conditions = [`sr.callee_id IN (${placeholders})`];
+  const params: Array<string | number> = [...symbolIds];
+  if (branch !== undefined) {
+    conditions.push('f.branch = ?');
+    params.push(branch);
+  }
+  params.push(limit);
+
+  return db
+    .prepare(
+      `SELECT sr.caller_id,
+              s.name AS caller_name,
+              s.kind AS caller_kind,
+              f.path AS caller_file,
+              sr.call_line + 1 AS line,
+              CASE WHEN sr.call_character IS NULL THEN NULL ELSE sr.call_character + 1 END AS character,
+              sr.resolution_method
+         FROM symbol_refs sr
+         JOIN symbols s ON s.id = sr.caller_id
+         JOIN files f ON f.id = s.file_id
+        WHERE ${conditions.join(' AND ')}
+        LIMIT ?`,
+    )
+    .all(...params) as RawCallerRow[];
+}
+
+function queryImporters(
+  db: Database.Database,
+  fileIds: number[],
+  branch: string | undefined,
+  limit: number,
+): RawImporterRow[] {
+  if (fileIds.length === 0) return [];
+  const placeholders = fileIds.map(() => '?').join(', ');
+  const conditions = [`fi.resolved_id IN (${placeholders})`];
+  const params: Array<string | number> = [...fileIds];
+  if (branch !== undefined) {
+    conditions.push('f.branch = ?');
+    params.push(branch);
+  }
+  params.push(limit);
+
+  return db
+    .prepare(
+      `SELECT fi.file_id,
+              f.path AS file_path,
+              fi.raw_import
+         FROM file_imports fi
+         JOIN files f ON f.id = fi.file_id
+        WHERE ${conditions.join(' AND ')}
+        LIMIT ?`,
+    )
+    .all(...params) as RawImporterRow[];
+}
+
+function querySubclasses(
+  db: Database.Database,
+  symbolIds: number[],
+  branch: string | undefined,
+  limit: number,
+): RawSubclassRow[] {
+  if (symbolIds.length === 0) return [];
+  const placeholders = symbolIds.map(() => '?').join(', ');
+  const conditions = [
+    `rel.target_symbol_id IN (${placeholders})`,
+    "rel.relationship_type IN ('extends', 'implements')",
+  ];
+  const params: Array<string | number> = [...symbolIds];
+  if (branch !== undefined) {
+    conditions.push('f.branch = ?');
+    params.push(branch);
+  }
+  params.push(limit);
+
+  return db
+    .prepare(
+      `SELECT rel.source_symbol_id AS symbol_id,
+              s.name AS symbol_name,
+              s.kind AS symbol_kind,
+              f.path AS file,
+              rel.relationship_type,
+              CASE WHEN rel.line IS NULL THEN NULL ELSE rel.line + 1 END AS line,
+              CASE WHEN rel.character IS NULL THEN NULL ELSE rel.character + 1 END AS character,
+              rel.resolution_method
+         FROM symbol_relationships rel
+         JOIN symbols s ON s.id = rel.source_symbol_id
+         JOIN files f ON f.id = s.file_id
+        WHERE ${conditions.join(' AND ')}
+        LIMIT ?`,
+    )
+    .all(...params) as RawSubclassRow[];
+}
+
+function queryTypeReferences(
+  db: Database.Database,
+  symbolIds: number[],
+  branch: string | undefined,
+  limit: number,
+): RawTypeRefRow[] {
+  if (symbolIds.length === 0) return [];
+  const placeholders = symbolIds.map(() => '?').join(', ');
+  const conditions = [`tr.type_id IN (${placeholders})`];
+  const params: Array<string | number> = [...symbolIds];
+  if (branch !== undefined) {
+    conditions.push('f.branch = ?');
+    params.push(branch);
+  }
+  params.push(limit);
+
+  return db
+    .prepare(
+      `SELECT tr.symbol_id,
+              COALESCE(s.name, '') AS symbol_name,
+              COALESCE(s.kind, '') AS symbol_kind,
+              f.path AS file,
+              tr.ref_kind,
+              tr.ref_line + 1 AS line,
+              CASE WHEN tr.ref_character IS NULL THEN NULL ELSE tr.ref_character + 1 END AS character,
+              tr.resolution_method
+         FROM type_refs tr
+         JOIN files f ON f.id = tr.file_id
+         LEFT JOIN symbols s ON s.id = tr.symbol_id
+        WHERE ${conditions.join(' AND ')}
+        LIMIT ?`,
+    )
+    .all(...params) as RawTypeRefRow[];
+}
+
+/** For kind="file", find all symbols defined in the given file(s) so we can query their callers. */
+function getSymbolIdsInFiles(
+  db: Database.Database,
+  fileIds: number[],
+  branch: string | undefined,
+): number[] {
+  if (fileIds.length === 0) return [];
+  const placeholders = fileIds.map(() => '?').join(', ');
+  const conditions = [`s.file_id IN (${placeholders})`];
+  const params: Array<string | number> = [...fileIds];
+  if (branch !== undefined) {
+    conditions.push('f.branch = ?');
+    params.push(branch);
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT s.id
+         FROM symbols s
+         JOIN files f ON f.id = s.file_id
+        WHERE ${conditions.join(' AND ')}`,
+    )
+    .all(...params) as Array<{ id: number }>;
+
+  return rows.map((r) => r.id);
+}
+
+// ─── Compact helpers ──────────────────────────────────────────────────────────
+
+function compactCaller(row: RawCallerRow): CompactCallerEntry {
+  return {
+    caller_id: row.caller_id,
+    caller_name: row.caller_name,
+    caller_kind: row.caller_kind,
+    caller_file: row.caller_file,
+  };
+}
+
+function compactImporter(row: RawImporterRow): CompactImporterEntry {
+  return {
+    file_id: row.file_id,
+    file_path: row.file_path,
+  };
+}
+
+function compactSubclass(row: RawSubclassRow): CompactSubclassEntry {
+  return {
+    symbol_id: row.symbol_id,
+    symbol_name: row.symbol_name,
+    symbol_kind: row.symbol_kind,
+    file: row.file,
+    relationship_type: row.relationship_type,
+  };
+}
+
+function compactTypeRef(row: RawTypeRefRow): CompactTypeRefEntry {
+  return {
+    symbol_id: row.symbol_id,
+    symbol_name: row.symbol_name,
+    symbol_kind: row.symbol_kind,
+    file: row.file,
+    ref_kind: row.ref_kind,
+  };
+}
+
+// ─── Multi-hop expansion ──────────────────────────────────────────────────────
+
+function expandCallers(
+  db: Database.Database,
+  seedIds: number[],
+  branch: string | undefined,
+  depth: number,
+  limit: number,
+): RawCallerRow[] {
+  const all: RawCallerRow[] = [];
+  const seen = new Set<number>();
+  let frontier = seedIds;
+
+  for (let hop = 0; hop < depth && frontier.length > 0 && all.length < limit; hop++) {
+    const remaining = limit - all.length;
+    const rows = queryCallers(db, frontier, branch, remaining);
+    const nextFrontier: number[] = [];
+    for (const row of rows) {
+      if (seen.has(row.caller_id)) continue;
+      seen.add(row.caller_id);
+      all.push(row);
+      nextFrontier.push(row.caller_id);
+    }
+    frontier = nextFrontier;
+  }
+  return all;
+}
+
+function expandImporters(
+  db: Database.Database,
+  seedIds: number[],
+  branch: string | undefined,
+  depth: number,
+  limit: number,
+): RawImporterRow[] {
+  const all: RawImporterRow[] = [];
+  const seen = new Set<number>();
+  let frontier = seedIds;
+
+  for (let hop = 0; hop < depth && frontier.length > 0 && all.length < limit; hop++) {
+    const remaining = limit - all.length;
+    const rows = queryImporters(db, frontier, branch, remaining);
+    const nextFrontier: number[] = [];
+    for (const row of rows) {
+      if (seen.has(row.file_id)) continue;
+      seen.add(row.file_id);
+      all.push(row);
+      nextFrontier.push(row.file_id);
+    }
+    frontier = nextFrontier;
+  }
+  return all;
+}
+
+function expandSubclasses(
+  db: Database.Database,
+  seedIds: number[],
+  branch: string | undefined,
+  depth: number,
+  limit: number,
+): RawSubclassRow[] {
+  const all: RawSubclassRow[] = [];
+  const seen = new Set<number>();
+  let frontier = seedIds;
+
+  for (let hop = 0; hop < depth && frontier.length > 0 && all.length < limit; hop++) {
+    const remaining = limit - all.length;
+    const rows = querySubclasses(db, frontier, branch, remaining);
+    const nextFrontier: number[] = [];
+    for (const row of rows) {
+      if (seen.has(row.symbol_id)) continue;
+      seen.add(row.symbol_id);
+      all.push(row);
+      nextFrontier.push(row.symbol_id);
+    }
+    frontier = nextFrontier;
+  }
+  return all;
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 200;
+
+/** Unified reverse-dependency / blast-radius query. */
+export function handler(
+  db: Database.Database,
+  args: DependentsArgs,
+): DependentsResult | DependentsErrorResult {
+  const depth = Math.max(1, Math.min(args.depth ?? 1, 5));
+  const compact = args.compact ?? false;
+  const limit = DEFAULT_LIMIT;
+
+  if (args.kind === 'file') {
+    return handleFileDependents(db, args, depth, compact, limit);
+  }
+  return handleSymbolDependents(db, args, depth, compact, limit);
+}
+
+function handleFileDependents(
+  db: Database.Database,
+  args: DependentsArgs,
+  depth: number,
+  compact: boolean,
+  limit: number,
+): DependentsResult | DependentsErrorResult {
+  const file = getFileByPath(db, args.query, args.branch);
+  if (!file) {
+    return { error: `No file found matching path "${args.query}"` };
+  }
+
+  const target: DependentTarget = {
+    id: file.id,
+    name: file.path,
+    kind: 'file',
+    file: file.path,
+  };
+
+  // Get importers of this file
+  const importerRows = expandImporters(db, [file.id], args.branch, depth, limit);
+
+  // Get symbols defined in this file, then find callers from other files
+  const symbolIds = getSymbolIdsInFiles(db, [file.id], args.branch);
+  const callerRows = expandCallers(db, symbolIds, args.branch, depth, limit)
+    // Exclude callers that are within the same file
+    .filter((row) => row.caller_file !== file.path);
+
+  // For files, subclasses and type_references target symbols within the file
+  const subclassRows = expandSubclasses(db, symbolIds, args.branch, depth, limit);
+  const typeRefRows = queryTypeReferences(db, symbolIds, args.branch, limit);
+
+  return buildResult(target, callerRows, importerRows, subclassRows, typeRefRows, compact, depth);
+}
+
+function handleSymbolDependents(
+  db: Database.Database,
+  args: DependentsArgs,
+  depth: number,
+  compact: boolean,
+  limit: number,
+): DependentsResult | DependentsErrorResult {
+  const symbols = getSymbolsByName(db, args.query, {
+    branch: args.branch,
+    matchMode: 'exact',
+  });
+
+  if (symbols.length === 0) {
+    return { error: `No symbol found matching name "${args.query}"` };
+  }
+
+  // If multiple matches, use the first but if many are ambiguous, report
+  if (symbols.length > 5) {
+    return {
+      error: `Ambiguous: ${symbols.length} symbols match "${args.query}". Narrow your query with a more specific name.`,
+      candidates: symbols.slice(0, 10).map((s) => {
+        const file = getFileById(db, s.file_id, args.branch);
+        return { id: s.id, name: s.name, kind: s.kind, file: file?.path ?? '' };
+      }),
+    };
+  }
+
+  // Use the best match (first result). If there are a few, aggregate across all.
+  const symbolIds = symbols.map((s) => s.id);
+  const primarySymbol = symbols[0]!;
+  const primaryFile = getFileById(db, primarySymbol.file_id, args.branch);
+
+  const target: DependentTarget = {
+    id: primarySymbol.id,
+    name: primarySymbol.name,
+    kind: primarySymbol.kind,
+    file: primaryFile?.path,
+  };
+
+  const callerRows = expandCallers(db, symbolIds, args.branch, depth, limit);
+  const subclassRows = expandSubclasses(db, symbolIds, args.branch, depth, limit);
+  const typeRefRows = queryTypeReferences(db, symbolIds, args.branch, limit);
+
+  // For symbols, importers are files that import the file containing this symbol
+  const fileIds = [...new Set(symbols.map((s) => s.file_id))];
+  const importerRows = expandImporters(db, fileIds, args.branch, depth, limit);
+
+  return buildResult(target, callerRows, importerRows, subclassRows, typeRefRows, compact, depth);
+}
+
+function buildResult(
+  target: DependentTarget,
+  callerRows: RawCallerRow[],
+  importerRows: RawImporterRow[],
+  subclassRows: RawSubclassRow[],
+  typeRefRows: RawTypeRefRow[],
+  compact: boolean,
+  depth: number,
+): DependentsResult {
+  const callers = compact ? callerRows.map(compactCaller) : callerRows;
+  const importers = compact ? importerRows.map(compactImporter) : importerRows;
+  const subclasses = compact ? subclassRows.map(compactSubclass) : subclassRows;
+  const typeRefs = compact ? typeRefRows.map(compactTypeRef) : typeRefRows;
+
+  return {
+    target,
+    dependents: {
+      callers,
+      importers,
+      subclasses,
+      type_references: typeRefs,
+    },
+    depth_used: depth,
+    total_count: callers.length + importers.length + subclasses.length + typeRefs.length,
+  };
+}

--- a/tests/server/tools/dependents.test.ts
+++ b/tests/server/tools/dependents.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  handler,
+  toolDef,
+  type DependentsArgs,
+  type DependentsResult,
+  type DependentsErrorResult,
+} from '../../../src/server/tools/dependents.js';
+import { openDb } from '../../../src/db/schema.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTestDb(): Database.Database {
+  return openDb(':memory:');
+}
+
+function insertFile(db: Database.Database, path: string, branch = 'main'): number {
+  const result = db
+    .prepare("INSERT INTO files (path, branch, language, size_bytes, last_hash, source) VALUES (?, ?, 'typescript', 0, NULL, '')")
+    .run(path, branch);
+  return result.lastInsertRowid as number;
+}
+
+function insertSymbol(db: Database.Database, fileId: number, name: string, kind = 'function'): number {
+  const result = db
+    .prepare('INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, ?, ?, 1, 10)')
+    .run(fileId, name, kind);
+  return result.lastInsertRowid as number;
+}
+
+function insertCallEdge(
+  db: Database.Database,
+  callerId: number,
+  calleeId: number | null,
+  calleeName: string,
+  line = 0,
+): void {
+  db.prepare(
+    "INSERT INTO symbol_refs (caller_id, callee_id, callee_name, call_line, resolution_method) VALUES (?, ?, ?, ?, 'resolved')",
+  ).run(callerId, calleeId, calleeName, line);
+}
+
+function insertImportEdge(db: Database.Database, fileId: number, rawImport: string, resolvedId: number | null): void {
+  db.prepare('INSERT INTO file_imports (file_id, raw_import, resolved_id) VALUES (?, ?, ?)').run(
+    fileId,
+    rawImport,
+    resolvedId,
+  );
+}
+
+function insertInheritanceEdge(
+  db: Database.Database,
+  fileId: number,
+  sourceSymbolId: number,
+  targetSymbolId: number | null,
+  targetSymbolName: string,
+  type: 'extends' | 'implements' = 'extends',
+): void {
+  db.prepare(
+    'INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line) VALUES (?, ?, ?, ?, ?, 1)',
+  ).run(fileId, sourceSymbolId, targetSymbolId, targetSymbolName, type);
+}
+
+function insertTypeRef(
+  db: Database.Database,
+  fileId: number,
+  symbolId: number | null,
+  typeId: number | null,
+  typeName: string,
+): void {
+  db.prepare(
+    "INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line) VALUES (?, ?, ?, ?, ?, 'type_annotation', 1)",
+  ).run(fileId, symbolId, typeId, typeName, typeName);
+}
+
+function isSuccess(result: DependentsResult | DependentsErrorResult): result is DependentsResult {
+  return !('error' in result);
+}
+
+function isError(result: DependentsResult | DependentsErrorResult): result is DependentsErrorResult {
+  return 'error' in result;
+}
+
+// ─── toolDef ──────────────────────────────────────────────────────────────────
+
+describe('lore_dependents toolDef', () => {
+  it('should have correct name and required fields', () => {
+    expect(toolDef.name).toBe('lore_dependents');
+    expect(toolDef.inputSchema.required).toEqual(['query', 'kind']);
+  });
+
+  it('should expose kind enum with symbol and file', () => {
+    expect(toolDef.inputSchema.properties.kind.enum).toEqual(['symbol', 'file']);
+  });
+
+  it('should expose depth with min/max constraints', () => {
+    expect(toolDef.inputSchema.properties.depth.minimum).toBe(1);
+    expect(toolDef.inputSchema.properties.depth.maximum).toBe(5);
+  });
+});
+
+// ─── Symbol dependents ───────────────────────────────────────────────────────
+
+describe('dependents handler – kind=symbol', () => {
+  let db: Database.Database;
+  let targetSymbolId: number;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Set up: src/db.ts has openDb; src/main.ts has runApp which calls openDb
+    const dbFileId = insertFile(db, 'src/db.ts');
+    const mainFileId = insertFile(db, 'src/main.ts');
+    const utilFileId = insertFile(db, 'src/util.ts');
+
+    targetSymbolId = insertSymbol(db, dbFileId, 'openDb');
+    const runAppId = insertSymbol(db, mainFileId, 'runApp');
+    const helperSymId = insertSymbol(db, utilFileId, 'helper');
+
+    // runApp calls openDb
+    insertCallEdge(db, runAppId, targetSymbolId, 'openDb', 5);
+    // helper calls openDb
+    insertCallEdge(db, helperSymId, targetSymbolId, 'openDb', 3);
+
+    // main.ts imports db.ts
+    insertImportEdge(db, mainFileId, './db', dbFileId);
+    // util.ts imports db.ts
+    insertImportEdge(db, utilFileId, './db', dbFileId);
+  });
+
+  it('should return callers of a symbol', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.target.name).toBe('openDb');
+    expect(result.target.kind).toBe('function');
+    expect(result.dependents.callers.length).toBe(2);
+  });
+
+  it('should return importers of the file containing the symbol', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.importers.length).toBe(2);
+  });
+
+  it('should set total_count accurately', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    const total =
+      result.dependents.callers.length +
+      result.dependents.importers.length +
+      result.dependents.subclasses.length +
+      result.dependents.type_references.length;
+    expect(result.total_count).toBe(total);
+  });
+
+  it('should return error when symbol not found', () => {
+    const result = handler(db, { query: 'nonExistent', kind: 'symbol' });
+    expect(isError(result)).toBe(true);
+    if (!isError(result)) return;
+    expect(result.error).toContain('No symbol found');
+  });
+
+  it('should omit provenance fields in compact mode', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol', compact: true });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    expect(caller).not.toHaveProperty('line');
+    expect(caller).not.toHaveProperty('character');
+    expect(caller).not.toHaveProperty('resolution_method');
+    // But name/id fields are preserved
+    expect(caller).toHaveProperty('caller_id');
+    expect(caller).toHaveProperty('caller_name');
+  });
+
+  it('should include provenance fields when compact is false', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol', compact: false });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    expect(caller).toHaveProperty('line');
+    expect(caller).toHaveProperty('resolution_method');
+  });
+
+  it('should set depth_used in response', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol', depth: 3 });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+    expect(result.depth_used).toBe(3);
+  });
+
+  it('should clamp depth to max 5', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol', depth: 10 });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+    expect(result.depth_used).toBe(5);
+  });
+});
+
+// ─── Symbol: subclasses & type references ────────────────────────────────────
+
+describe('dependents handler – symbol subclasses and type refs', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const baseFileId = insertFile(db, 'src/base.ts');
+    const childFileId = insertFile(db, 'src/child.ts');
+    const consumerFileId = insertFile(db, 'src/consumer.ts');
+
+    const baseClassId = insertSymbol(db, baseFileId, 'BaseService', 'class');
+    const childClassId = insertSymbol(db, childFileId, 'ChildService', 'class');
+    const consumerId = insertSymbol(db, consumerFileId, 'consume', 'function');
+
+    // ChildService extends BaseService
+    insertInheritanceEdge(db, childFileId, childClassId, baseClassId, 'BaseService');
+
+    // consume references BaseService as a type
+    insertTypeRef(db, consumerFileId, consumerId, baseClassId, 'BaseService');
+  });
+
+  it('should return subclasses of a class', () => {
+    const result = handler(db, { query: 'BaseService', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.subclasses.length).toBe(1);
+    const sub = result.dependents.subclasses[0] as Record<string, unknown>;
+    expect(sub.symbol_name).toBe('ChildService');
+    expect(sub.relationship_type).toBe('extends');
+  });
+
+  it('should return type references to a symbol', () => {
+    const result = handler(db, { query: 'BaseService', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.type_references.length).toBe(1);
+    const ref = result.dependents.type_references[0] as Record<string, unknown>;
+    expect(ref.symbol_name).toBe('consume');
+  });
+});
+
+// ─── File dependents ─────────────────────────────────────────────────────────
+
+describe('dependents handler – kind=file', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const targetFileId = insertFile(db, 'src/db.ts');
+    const importerFileId = insertFile(db, 'src/main.ts');
+    const anotherFileId = insertFile(db, 'src/util.ts');
+
+    // src/main.ts imports src/db.ts
+    insertImportEdge(db, importerFileId, './db', targetFileId);
+    // src/util.ts imports src/db.ts
+    insertImportEdge(db, anotherFileId, './db', targetFileId);
+
+    // Symbol in db.ts called by symbol in util.ts
+    const openDbId = insertSymbol(db, targetFileId, 'openDb');
+    const helperSymId = insertSymbol(db, anotherFileId, 'helper');
+    insertCallEdge(db, helperSymId, openDbId, 'openDb', 2);
+  });
+
+  it('should return files that import this file', () => {
+    const result = handler(db, { query: 'src/db.ts', kind: 'file' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.target.kind).toBe('file');
+    expect(result.target.name).toBe('src/db.ts');
+    expect(result.dependents.importers.length).toBe(2);
+  });
+
+  it('should return callers from other files that call symbols in this file', () => {
+    const result = handler(db, { query: 'src/db.ts', kind: 'file' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    // Only the cross-file caller (helper from util.ts), not intra-file calls
+    expect(result.dependents.callers.length).toBe(1);
+    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    expect(caller.caller_name).toBe('helper');
+    expect(caller.caller_file).toBe('src/util.ts');
+  });
+
+  it('should return error when file not found', () => {
+    const result = handler(db, { query: 'src/nonexistent.ts', kind: 'file' });
+    expect(isError(result)).toBe(true);
+    if (!isError(result)) return;
+    expect(result.error).toContain('No file found');
+  });
+
+  it('should compute total_count correctly for file dependents', () => {
+    const result = handler(db, { query: 'src/db.ts', kind: 'file' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.total_count).toBe(
+      result.dependents.callers.length +
+      result.dependents.importers.length +
+      result.dependents.subclasses.length +
+      result.dependents.type_references.length,
+    );
+  });
+
+  it('should support compact mode for file dependents', () => {
+    const result = handler(db, { query: 'src/db.ts', kind: 'file', compact: true });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    const importer = result.dependents.importers[0] as Record<string, unknown>;
+    expect(importer).toHaveProperty('file_id');
+    expect(importer).toHaveProperty('file_path');
+    expect(importer).not.toHaveProperty('raw_import');
+  });
+});
+
+// ─── Transitive (multi-hop) dependents ────────────────────────────────────────
+
+describe('dependents handler – transitive closure', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Chain: A calls B calls C — querying C with depth=2 should reach A
+    const fileId = insertFile(db, 'src/chain.ts');
+    const symA = insertSymbol(db, fileId, 'funcA');
+    const symB = insertSymbol(db, fileId, 'funcB');
+    const symC = insertSymbol(db, fileId, 'funcC');
+    insertCallEdge(db, symA, symB, 'funcB');
+    insertCallEdge(db, symB, symC, 'funcC');
+  });
+
+  it('depth=1 should return only direct callers', () => {
+    const result = handler(db, { query: 'funcC', kind: 'symbol', depth: 1 });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.callers.length).toBe(1);
+    expect((result.dependents.callers[0] as Record<string, unknown>).caller_name).toBe('funcB');
+  });
+
+  it('depth=2 should return transitive callers', () => {
+    const result = handler(db, { query: 'funcC', kind: 'symbol', depth: 2 });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.callers.length).toBe(2);
+    const callerNames = result.dependents.callers.map(
+      (c) => (c as Record<string, unknown>).caller_name,
+    );
+    expect(callerNames).toContain('funcA');
+    expect(callerNames).toContain('funcB');
+  });
+});
+
+// ─── Transitive importer expansion ───────────────────────────────────────────
+
+describe('dependents handler – transitive import chain', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Chain: file3 imports file2 imports file1
+    const file1Id = insertFile(db, 'src/lib.ts');
+    const file2Id = insertFile(db, 'src/mid.ts');
+    const file3Id = insertFile(db, 'src/app.ts');
+    insertImportEdge(db, file2Id, './lib', file1Id);
+    insertImportEdge(db, file3Id, './mid', file2Id);
+  });
+
+  it('depth=2 file query should return transitive importers', () => {
+    const result = handler(db, { query: 'src/lib.ts', kind: 'file', depth: 2 });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.importers.length).toBe(2);
+    const paths = result.dependents.importers.map((i) => (i as Record<string, unknown>).file_path);
+    expect(paths).toContain('src/mid.ts');
+    expect(paths).toContain('src/app.ts');
+  });
+});
+
+// ─── Branch filtering ─────────────────────────────────────────────────────────
+
+describe('dependents handler – branch filtering', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const mainFileId = insertFile(db, 'src/db.ts', 'main');
+    const featFileId = insertFile(db, 'src/main.ts', 'main');
+    const devFileId = insertFile(db, 'src/main.ts', 'dev');
+
+    const targetSym = insertSymbol(db, mainFileId, 'openDb');
+    const mainCaller = insertSymbol(db, featFileId, 'mainCaller');
+    const devCaller = insertSymbol(db, devFileId, 'devCaller');
+
+    insertCallEdge(db, mainCaller, targetSym, 'openDb');
+    insertCallEdge(db, devCaller, targetSym, 'openDb');
+  });
+
+  it('should filter callers by branch', () => {
+    const result = handler(db, { query: 'openDb', kind: 'symbol', branch: 'main' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.callers.length).toBe(1);
+    expect((result.dependents.callers[0] as Record<string, unknown>).caller_name).toBe('mainCaller');
+  });
+});
+
+// ─── Ambiguous symbol ─────────────────────────────────────────────────────────
+
+describe('dependents handler – ambiguous symbol', () => {
+  it('should return disambiguation error when too many matches', () => {
+    const db = createTestDb();
+    // Insert many symbols with the same name in different files
+    for (let i = 0; i < 7; i++) {
+      const fid = insertFile(db, `src/mod${i}.ts`);
+      insertSymbol(db, fid, 'init');
+    }
+
+    const result = handler(db, { query: 'init', kind: 'symbol' });
+    expect(isError(result)).toBe(true);
+    if (!isError(result)) return;
+    expect(result.error).toContain('Ambiguous');
+    expect(result.candidates).toBeDefined();
+    expect(result.candidates!.length).toBeGreaterThan(0);
+  });
+
+  it('should aggregate across a few matching symbols (≤5)', () => {
+    const db = createTestDb();
+    const f1 = insertFile(db, 'src/a.ts');
+    const f2 = insertFile(db, 'src/b.ts');
+    const s1 = insertSymbol(db, f1, 'run');
+    const s2 = insertSymbol(db, f2, 'run');
+
+    // One caller each
+    const caller1 = insertSymbol(db, f1, 'callerA');
+    const caller2 = insertSymbol(db, f2, 'callerB');
+    insertCallEdge(db, caller1, s1, 'run');
+    insertCallEdge(db, caller2, s2, 'run');
+
+    const result = handler(db, { query: 'run', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    // Both callers aggregated
+    expect(result.dependents.callers.length).toBe(2);
+  });
+});
+
+// ─── Empty dependents ─────────────────────────────────────────────────────────
+
+describe('dependents handler – empty dependents', () => {
+  it('should return all-empty arrays when a symbol has no dependents', () => {
+    const db = createTestDb();
+    const fid = insertFile(db, 'src/lonely.ts');
+    insertSymbol(db, fid, 'isolated');
+
+    const result = handler(db, { query: 'isolated', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.callers).toEqual([]);
+    expect(result.dependents.importers).toEqual([]);
+    expect(result.dependents.subclasses).toEqual([]);
+    expect(result.dependents.type_references).toEqual([]);
+    expect(result.total_count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #178 — adds a new `lore_dependents` MCP tool that answers "what is affected if I change X?" in a single call.

## Changes

### New: `src/server/tools/dependents.ts`
- **Name-based input**: takes a symbol name or file path (not numeric IDs), resolves internally
- **Cross-kind aggregation**: returns `callers`, `importers`, `subclasses`, and `type_references` in one response
- **Transitive closure**: `depth` param (1–5) follows dependents N hops deep via frontier expansion
- **Compact mode**: `compact: true` strips provenance fields (line, character, resolution_method) to reduce tokens
- **Branch filtering**: optional `branch` param filters all queries
- **Disambiguation**: ≤5 symbol matches aggregates results; >5 returns error with candidates

### Modified: `src/server/tool-registry.ts`
- Registered `lore_dependents` in `buildToolModules()`

### New: `tests/server/tools/dependents.test.ts`
- 25 tests covering: toolDef shape- 25 tests covering: toolDef shape- 25 tests covering: toolDef shape--fi- 25 tests covering: toolDef shape- 25 tests covering: toolDef shape- 25 tests covering: toolDef shape--fi- 25 tests covele
- 25 testlor- 25 testlor- 25 testlor- 25 testlor- 25: - 25 testlor- 25 testlor- 25 testlor- 25 testlor- 25: - 25 testlor- 25 testlor- 25 testlor- 25d"- 25 testlor- 25 testlor- 25 testlor- 25 testlor- 25: - 25 testlor- 25 testlor- 25 testlor- 25 testlor- 25: - 25  - 25 testlor- 25 testlor- 25 testlor- 25 testlor- 25: - 25 testlor- 25 testlor- 25 testlor- 25 testl}
```

Closes #178