### PR TITLE
chore(server): register cohesion + dependents tools, drop benchmark 14.1

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -48,6 +48,8 @@ import * as history from './tools/history.js';
 import * as diff from './tools/diff.js';
 import * as trace from './tools/trace.js';
 import * as structure from './tools/structure.js';
+import * as cohesion from './tools/cohesion.js';
+import * as dependents from './tools/dependents.js';
 
 // ─── Server options ───────────────────────────────────────────────────────────
 
@@ -141,6 +143,8 @@ function buildToolModulesSync(): ToolModule[] {
     { def: diff.toolDef, handlerFactory: (deps) => (args) => diff.handler(deps.db, args) },
     { def: trace.toolDef, handlerFactory: (deps) => (args) => trace.handler(deps.db, args) },
     { def: structure.toolDef, handlerFactory: (deps) => (args) => structure.handler(deps.db, args) },
+    { def: cohesion.toolDef, handlerFactory: (deps) => (args) => cohesion.handler(deps.db, args ?? {}) },
+    { def: dependents.toolDef, handlerFactory: (deps) => (args) => dependents.handler(deps.db, args) },
   ];
 }
 

--- a/tests/benchmark/util/questions.ts
+++ b/tests/benchmark/util/questions.ts
@@ -354,23 +354,6 @@ export const QUESTION_CATALOG: QuestionTemplate[] = [
       'Answer with ONLY a newline-separated list of violations in the format "from_dir → to_dir", ' +
       'or "None" if no violations are detected.',
   },
-
-  // ── Category 14: Module Cohesion ────────────────────────────────────────
-  {
-    questionId: '14.1',
-    category: 'Architecture',
-    family: 'explanation',
-    description: 'Module cohesion ranking (worst-bounded first)',
-    loreTools: ['lore_cohesion(depth=2)'],
-    loreAdvantage: 'Computes internal/external edge ratio per directory from resolved symbol_refs; no text search can measure coupling.',
-    promptTemplate:
-      'Which directories in this codebase have the lowest cohesion ' +
-      '(highest ratio of external coupling to internal coupling)? ' +
-      'Use pre-indexed module cohesion metrics if available. ' +
-      'Answer with ONLY a numbered list of the 3 least cohesive directories, ' +
-      'each with their cohesion score. Example format:\n' +
-      '1. src/server — cohesion: 0.32\n2. src/utils — cohesion: 0.45\n3. src/api — cohesion: 0.51',
-  },
 ];
 
 // ─── Lookup helpers ─────────────────────────────────────────────────────────

--- a/tests/benchmark/util/tasks.ts
+++ b/tests/benchmark/util/tasks.ts
@@ -52,7 +52,6 @@ const LORE_SELF_ANSWERS: RepoAnswers = {
     '3.5': { symbol: '', file: '', expectedAnswer: 'tree-sitter → src/parsing\nbetter-sqlite3 → src/db\nsqlite-vec → src/db', expectedAnswerParts: ['tree-sitter', 'src/parsing', 'better-sqlite3', 'src/db'], expectedSymbols: [] },
     '9.1': { symbol: '', file: '', expectedAnswer: 'Added: None\nRemoved: None\nChanged: None', expectedAnswerParts: ['Added', 'Removed', 'Changed'], expectedSymbols: [] },
     '12.1': { symbol: '', file: '', expectedAnswer: 'None', expectedAnswerParts: ['none'], expectedSymbols: [] },
-    '14.1': { symbol: '', file: '', expectedAnswer: 'src/server\nsrc/discovery\nsrc/indexer', expectedAnswerParts: ['src/server', 'src/discovery'], expectedSymbols: [] },
   },
 };
 


### PR DESCRIPTION
- Register `lore_cohesion` and `lore_dependents` in `buildToolModulesSync()` so all 14 tool modules are exposed via the MCP server.
- Remove benchmark question 14.1 (module cohesion ranking) — trivially answerable with a bash one-liner, does not demonstrate Lore's value on complex structural queries.