### PR TITLE
fix(scip): correct virtual dispatch edge metadata and call-site dedup

### DIFF
--- a/src/indexer/stages/scip-indexer.ts
+++ b/src/indexer/stages/scip-indexer.ts
@@ -898,7 +898,7 @@ export class ScipIndexerStage implements PipelineStage {
     // `symbol_refs` rows with `call_kind = 'virtual_dispatch'` so that
     // both `lore_graph` and `lore_dependents` surface these edges.
     const virtualDispatchEdges = materializeVirtualDispatch(
-      db, scipToLoreId, symbolInfoMap, layer, generation, log,
+      db, scipToLoreId, symbolInfoMap, symbolDefinitions, layer, generation, log,
     );
 
     // Communicate coverage to downstream stages
@@ -1353,6 +1353,7 @@ function materializeVirtualDispatch(
   db: Database.Database,
   scipToLoreId: Map<string, number>,
   symbolInfoMap: Map<string, import('../../scip/scip_pb.js').SymbolInformation>,
+  symbolDefinitions: Map<string, { filePath: string; line: number; character: number }>,
   layer: string,
   generation: number,
   log: ReturnType<typeof getLogger>,
@@ -1393,6 +1394,16 @@ function materializeVirtualDispatch(
             definition_uri, definition_path, definition_line, definition_character
        FROM symbol_refs
       WHERE callee_id = ?`,
+  );
+
+  const findExistingCallSite = db.prepare(
+    `SELECT 1
+       FROM symbol_refs
+      WHERE caller_id = ?
+        AND callee_id = ?
+        AND call_line = ?
+        AND call_character IS ?
+      LIMIT 1`,
   );
 
   const insertVDispatch = db.prepare(
@@ -1440,14 +1451,19 @@ function materializeVirtualDispatch(
         }>;
 
         for (const caller of callers) {
-          // Don't insert if this caller → concrete edge already exists
-          const existing = db.prepare(
-            'SELECT 1 FROM symbol_refs WHERE caller_id = ? AND callee_id = ? LIMIT 1',
-          ).get(caller.caller_id, concreteMethodId);
+          // Don't insert if the exact call site already resolves to this concrete callee.
+          const existing = findExistingCallSite.get(
+            caller.caller_id,
+            concreteMethodId,
+            caller.call_line,
+            caller.call_character,
+          );
           if (existing) continue;
 
           // Use the concrete method's name and definition info
           const concreteName = extractNameFromScipSymbol(concreteScip);
+          const concreteDef = symbolDefinitions.get(concreteScip);
+          const concreteDefUri = concreteDef ? pathToFileURL(concreteDef.filePath).toString() : null;
 
           try {
             insertVDispatch.run(
@@ -1461,10 +1477,10 @@ function materializeVirtualDispatch(
               'scip_definition',
               caller.resolved_type_signature,
               caller.resolved_return_type,
-              caller.definition_uri,
-              caller.definition_path,
-              caller.definition_line,
-              caller.definition_character,
+              concreteDefUri,
+              concreteDef?.filePath ?? null,
+              concreteDef?.line ?? null,
+              concreteDef?.character ?? null,
               layer, generation,
             );
             edgesInserted++;

--- a/tests/indexer/scip-virtual-dispatch.test.ts
+++ b/tests/indexer/scip-virtual-dispatch.test.ts
@@ -328,11 +328,20 @@ describe('ScipIndexerStage virtual dispatch materialization', () => {
 
     // KEY ASSERTION: there should be a virtual_dispatch edge RunBuild → myBuilder.Build
     const virtualEdge = db.prepare(
-      "SELECT call_kind, resolution_method FROM symbol_refs WHERE caller_id = ? AND callee_id = ?",
-    ).get(runBuildId, concreteBuildId) as { call_kind: string; resolution_method: string } | undefined;
+      "SELECT call_kind, resolution_method, definition_path, definition_line, definition_character FROM symbol_refs WHERE caller_id = ? AND callee_id = ?",
+    ).get(runBuildId, concreteBuildId) as {
+      call_kind: string;
+      resolution_method: string;
+      definition_path: string | null;
+      definition_line: number | null;
+      definition_character: number | null;
+    } | undefined;
     expect(virtualEdge).toBeDefined();
     expect(virtualEdge!.call_kind).toBe('virtual_dispatch');
     expect(virtualEdge!.resolution_method).toBe('scip_definition');
+    expect(virtualEdge!.definition_path).toMatch(/impl\.go$/);
+    expect(virtualEdge!.definition_line).toBe(4);
+    expect(virtualEdge!.definition_character).toBe(22);
 
     // Verify: querying callers of myBuilder.Build should now return RunBuild
     const callers = db.prepare(
@@ -350,7 +359,7 @@ describe('ScipIndexerStage virtual dispatch materialization', () => {
     db.close();
   });
 
-  it('does not duplicate edges that already exist', async () => {
+  it('preserves distinct direct and virtual call sites to the same concrete method', async () => {
     const rootDir = makeTmpDir('lore-scip-vdispatch-nodup-');
     const indexDir = join(rootDir, '.scip-indexes');
     mkdirSync(indexDir, { recursive: true });
@@ -430,17 +439,18 @@ describe('ScipIndexerStage virtual dispatch materialization', () => {
       "SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id WHERE s.name = 'Do' AND f.path LIKE '%main.go' AND s.start_line = 4",
     ).get() as { id: number })?.id;
 
-    // There should be exactly 1 edge to Impl.Do:
-    // The direct edge (from y.Do() call) already exists, so the virtual_dispatch
-    // edge should NOT be duplicated — the dedup check prevents it.
+    // There should be 2 edges to Impl.Do:
+    // - a virtual_dispatch edge for x.Do() via the interface call site
+    // - a direct edge for y.Do() at its distinct concrete call site
     const edges = db.prepare(
-      "SELECT caller_id, call_kind FROM symbol_refs WHERE callee_id = ?",
-    ).all(implDoId) as Array<{ caller_id: number; call_kind: string }>;
+      "SELECT caller_id, call_kind, call_line FROM symbol_refs WHERE callee_id = ? ORDER BY call_line",
+    ).all(implDoId) as Array<{ caller_id: number; call_kind: string; call_line: number }>;
 
-    // Only the direct edge exists — virtual_dispatch was skipped because
-    // caller→callee already had an edge
-    expect(edges.length).toBe(1);
-    expect(edges[0]!.call_kind).toBe('direct');
+    expect(edges.length).toBe(2);
+    expect(edges).toEqual([
+      { caller_id: edges[0]!.caller_id, call_kind: 'virtual_dispatch', call_line: 7 },
+      { caller_id: edges[1]!.caller_id, call_kind: 'direct', call_line: 9 },
+    ]);
 
     db.close();
   });


### PR DESCRIPTION
## Summary

Follow-up to #221. PR #221 merged the virtual dispatch materialization work from #220, but it carried through two correctness bugs in the new `virtual_dispatch` edges.

This PR fixes both issues on top of current `main`.

## Problems fixed

### 1. Wrong callee definition metadata on virtual dispatch edges

The inserted `symbol_refs` rows for `call_kind = 'virtual_dispatch'` were copying `definition_uri`, `definition_path`, `definition_line`, and `definition_character` from the interface method edge being materialized.

That meant downstream tools could report an edge to the concrete implementation while still pointing users at the interface definition location.

### 2. Overly broad dedup removed distinct call sites

The original dedup logic skipped insertion whenever a `caller_id -> callee_id` edge already existed, regardless of `call_line` and `call_character`.

Because `symbol_refs` is a call-site table, this incorrectly collapsed distinct calls in the same caller when one call was a direct concrete call and another was a virtual dispatch call on a different line.

## Fix

- Pass `symbolDefinitions` into `materializeVirtualDispatch()`
- Populate virtual dispatch edges with the concrete method's definition metadata
- Deduplicate only exact duplicate call sites using `caller_id`, `callee_id`, `call_line`, and `call_character`
- Extend the regression tests to assert both behaviors

## Testing

- `npx vitest run tests/indexer/scip-virtual-dispatch.test.ts`

## Context

- #220 was accidentally closed
- #221 merged the broader call-graph improvements into `main`
- This PR is the minimal follow-up needed to fully correct the virtual dispatch implementation that landed in #221