### PR TITLE
test(benchmark): add structured benchmark report output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 coverage/
 .scip-indexes/
 .benchmark/
+autoresearch/

--- a/tests/benchmark/copilot-agent.test.ts
+++ b/tests/benchmark/copilot-agent.test.ts
@@ -22,13 +22,14 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { join } from 'node:path';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { RepoManager } from './util/repo-manager.js';
 import { indexRepo } from './util/indexer.js';
 import { runCopilotAgent, type CopilotAgentOptions } from './util/copilot-agent.js';
-import { scoreRun, aggregateScores, formatReport, compareReports, formatToolFrequency, diagnoseExpectations, truncate, formatLoreToolArgs } from './util/scorer.js';
+import { scoreRun, aggregateScores, formatReport, compareReports, formatToolFrequency, diagnoseExpectations, truncate, formatLoreToolArgs, buildStructuredTaskResult, buildStructuredReport } from './util/scorer.js';
+import type { StructuredTaskResult } from './util/scorer.js';
 import { getTasksForRepo } from './util/tasks.js';
 import { PILOT_REPOS } from './util/repos.js';
 import type { RunScore, AgentTrace, BenchmarkTask } from './util/types.js';
@@ -180,6 +181,7 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
     // Collect scores for whichever tasks completed (report is always printed)
     const controlScores: RunScore[] = [];
     const loreScores: RunScore[] = [];
+    const structuredTasks: StructuredTaskResult[] = [];
 
     for (const task of COPILOT_TASKS) {
       for (let iter = 0; iter < ITERATIONS; iter++) {
@@ -193,6 +195,12 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
         }
         controlScores.push(cr.score);
         loreScores.push(lr.score);
+
+        const structuredTask = buildStructuredTaskResult(
+          task, cr.score, cr.trace, lr.score, lr.trace,
+          ITERATIONS > 1 ? iter + 1 : undefined,
+        );
+        structuredTasks.push(structuredTask);
 
         const iterLabel = ITERATIONS > 1 ? ` [iter ${iter + 1}]` : '';
         const tokenDelta = lr.score.tokensUsed - cr.score.tokensUsed;
@@ -234,6 +242,30 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
       console.log(formatReport(controlReport));
       console.log('\n' + formatReport(loreReport));
       console.log('\n' + compareReports(controlReport, loreReport));
+
+      const structuredReport = buildStructuredReport(
+        {
+          model: COPILOT_OPTIONS.model!,
+          repo: TARGET_REPO,
+          indexMode: INDEX_MODE,
+          embeddingModel: EMBEDDING_MODEL || 'none',
+          lsp: ENABLE_LSP,
+          tasks: COPILOT_TASKS.length,
+          iterations: ITERATIONS,
+          completedRuns: controlScores.length,
+          totalExpectedRuns,
+          timestamp: new Date().toISOString(),
+        },
+        structuredTasks,
+        controlReport,
+        loreReport,
+      );
+
+      const outDir = join(LORE_BUILD_ROOT, 'benchmark-results');
+      mkdirSync(outDir, { recursive: true });
+      const jsonPath = join(outDir, `${TARGET_REPO}.json`);
+      writeFileSync(jsonPath, JSON.stringify(structuredReport, null, 2) + '\n');
+      console.log(`\nStructured report written to: ${jsonPath}`);
 
       // Assertions come AFTER the report is printed
       expect(controlReport.totalRuns).toBe(totalExpectedRuns);

--- a/tests/benchmark/util/scorer.ts
+++ b/tests/benchmark/util/scorer.ts
@@ -558,6 +558,171 @@ export function truncate(s: string, maxLen = 200): string {
   return s.slice(0, maxLen) + '…';
 }
 
+export interface StructuredTaskResult {
+  taskId: string;
+  family: string;
+  iteration?: number;
+  control: {
+    score: RunScore;
+    tools: string;
+    loreToolArgs?: string;
+    answer: string;
+    missedParts: string[];
+    missedAnswerLines: string[];
+  };
+  lore: {
+    score: RunScore;
+    tools: string;
+    loreToolArgs: string;
+    answer: string;
+    missedParts: string[];
+    missedAnswerLines: string[];
+  };
+  delta: {
+    correctness: number;
+    tokens: number;
+    tokensPct: number | null;
+    wallTimeMs: number;
+    wallTimePct: number | null;
+  };
+  warnings: string[];
+}
+
+export interface StructuredBenchmarkReport {
+  metadata: {
+    model: string;
+    repo: string;
+    indexMode: string;
+    embeddingModel: string;
+    lsp: boolean;
+    tasks: number;
+    iterations: number;
+    completedRuns: number;
+    totalExpectedRuns: number;
+    timestamp: string;
+  };
+  tasks: StructuredTaskResult[];
+  aggregate: {
+    control: AggregateReport;
+    lore: AggregateReport;
+    comparison: {
+      successRateDelta: number;
+      correctnessDelta: number;
+      firstPassAccuracyDelta: number;
+      answerCoverageDelta: number;
+      toolCallsDelta: number;
+      tokensDelta: number;
+      tokensPct: number | null;
+      wallTimeDelta: number;
+      wallTimePct: number | null;
+    };
+    significance?: {
+      t: number;
+      df: number;
+      p: number;
+      significant: boolean;
+    };
+  };
+}
+
+export function buildStructuredTaskResult(
+  task: BenchmarkTask,
+  controlScore: RunScore,
+  controlTrace: AgentTrace,
+  loreScore: RunScore,
+  loreTrace: AgentTrace,
+  iteration?: number,
+): StructuredTaskResult {
+  const controlDiag = diagnoseExpectations(task, controlTrace);
+  const loreDiag = diagnoseExpectations(task, loreTrace);
+
+  const tokenDelta = loreScore.tokensUsed - controlScore.tokensUsed;
+  const tokensPct = controlScore.tokensUsed ? (tokenDelta / controlScore.tokensUsed) * 100 : null;
+  const wallDelta = loreScore.wallTimeMs - controlScore.wallTimeMs;
+  const wallPct = controlScore.wallTimeMs ? (wallDelta / controlScore.wallTimeMs) * 100 : null;
+  const warnings: string[] = [];
+  if (loreScore.correctness < controlScore.correctness) {
+    warnings.push(`lore worse on correctness — missed: [${loreDiag.correctnessDetail.missed.join(', ')}]`);
+  }
+  if (loreScore.tokensUsed > controlScore.tokensUsed * 1.5) {
+    warnings.push('lore 50%+ more tokens');
+  }
+  if (loreScore.wallTimeMs > controlScore.wallTimeMs * 1.5) {
+    warnings.push('lore 50%+ slower');
+  }
+
+  return {
+    taskId: task.id,
+    family: task.family,
+    ...(iteration !== undefined ? { iteration } : {}),
+    control: {
+      score: controlScore,
+      tools: formatToolFrequency(controlTrace.toolCalls),
+      answer: truncate(controlTrace.finalAnswer.replace(/\n/g, ' '), 300),
+      missedParts: controlDiag.missed,
+      missedAnswerLines: controlDiag.correctnessDetail.missed,
+    },
+    lore: {
+      score: loreScore,
+      tools: formatToolFrequency(loreTrace.toolCalls),
+      loreToolArgs: formatLoreToolArgs(loreTrace.toolCalls),
+      answer: truncate(loreTrace.finalAnswer.replace(/\n/g, ' '), 300),
+      missedParts: loreDiag.missed,
+      missedAnswerLines: loreDiag.correctnessDetail.missed,
+    },
+    delta: {
+      correctness: loreScore.correctness - controlScore.correctness,
+      tokens: tokenDelta,
+      tokensPct,
+      wallTimeMs: wallDelta,
+      wallTimePct: wallPct,
+    },
+    warnings,
+  };
+}
+
+export function buildStructuredReport(
+  metadata: StructuredBenchmarkReport['metadata'],
+  taskResults: StructuredTaskResult[],
+  controlReport: AggregateReport,
+  loreReport: AggregateReport,
+): StructuredBenchmarkReport {
+  const tokenDelta = loreReport.meanTokens - controlReport.meanTokens;
+  const wallDelta = loreReport.meanWallTimeMs - controlReport.meanWallTimeMs;
+
+  const comparison: StructuredBenchmarkReport['aggregate']['comparison'] = {
+    successRateDelta: loreReport.successRate - controlReport.successRate,
+    correctnessDelta: loreReport.meanCorrectness - controlReport.meanCorrectness,
+    firstPassAccuracyDelta: loreReport.firstPassAccuracyRate - controlReport.firstPassAccuracyRate,
+    answerCoverageDelta: loreReport.meanAnswerCoverage - controlReport.meanAnswerCoverage,
+    toolCallsDelta: loreReport.meanToolCalls - controlReport.meanToolCalls,
+    tokensDelta: tokenDelta,
+    tokensPct: controlReport.meanTokens ? (tokenDelta / controlReport.meanTokens) * 100 : null,
+    wallTimeDelta: wallDelta,
+    wallTimePct: controlReport.meanWallTimeMs ? (wallDelta / controlReport.meanWallTimeMs) * 100 : null,
+  };
+
+  let significance: StructuredBenchmarkReport['aggregate']['significance'];
+  if (controlReport.totalRuns > 1 && loreReport.totalRuns > 1) {
+    const tResult = welchTTest(
+      controlReport.meanCorrectness, controlReport.stdCorrectness, controlReport.totalRuns,
+      loreReport.meanCorrectness, loreReport.stdCorrectness, loreReport.totalRuns,
+    );
+    significance = { ...tResult, significant: tResult.p < 0.05 };
+  }
+
+  return {
+    metadata,
+    tasks: taskResults,
+    aggregate: {
+      control: controlReport,
+      lore: loreReport,
+      comparison,
+      ...(significance ? { significance } : {}),
+    },
+  };
+}
+
 /**
  * Format a compact summary of Lore tool calls with their key arguments.
  * e.g. "lore_graph(kind=call, depth=1, target_id=42), lore_lookup(kind=symbol, query=openDb)"


### PR DESCRIPTION
## Summary

Adds structured JSON benchmark report output for the Copilot benchmark harness and ignores the local `autoresearch/` directory.

## Changes

- write a structured JSON report to `benchmark-results/<repo>.json` from `tests/benchmark/copilot-agent.test.ts`
- add `StructuredTaskResult` and `StructuredBenchmarkReport` helpers in `tests/benchmark/util/scorer.ts`
- include per-task deltas, warnings, aggregate comparison, and optional significance data in the structured output
- ignore `autoresearch/` in `.gitignore`

## Validation

- `npx vitest run tests/benchmark/copilot-agent.test.ts`
  - file loaded successfully
  - all tests remained skipped as expected without `BENCHMARK_COPILOT=1`

## Scope

This PR is intentionally limited to:

- `.gitignore`
- `tests/benchmark/copilot-agent.test.ts`
- `tests/benchmark/util/scorer.ts`