### PR TITLE
chore: release v0.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ await builder.build();
 | `lore_lookup` | Find symbols by name or files by path, including external dependency API symbols and LSP-resolved metadata when available |
 | `lore_search` | Structural BM25, semantic vector, or fused RRF search across symbols and doc sections |
 | `lore_docs` | List, fetch, or search indexed documentation with branch, kind, and path filters |
-| `lore_dependents` | Find everything affected by changing a symbol or file — callers, importers, subclasses, and type references in one call |
+| `lore_dependents` | Find everything affected by changing a symbol or file — callers, importers, subclasses, and type references with automatic transitive traversal (up to 5 hops) in one call |
 | `lore_trace` | Trace an execution path from an entry point and return an ordered call sequence with source code for each step |
 | `lore_diff` | Compare exported symbols between two indexed branches; returns added, removed, and changed symbols |
 | `lore_cohesion` | Rank directories by module cohesion (ratio of internal to external symbol references) |
 | `lore_structure` | Detect structural anomalies — import cycles (Tarjan SCC), layering violations (Kahn toposort), and outlier couplings |
-| `lore_graph` | Query call/import/inheritance/type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries; call edges include `callee_coverage_percent` |
+| `lore_graph` | Query call/import/inheritance/type-dependency edges with automatic transitive traversal (up to 5 hops); supports `source_id` for outbound and `target_id` for inbound/reverse queries; materializes virtual dispatch edges for polymorphic call resolution; call edges include `callee_coverage_percent` |
 | `lore_snippet` | Return snippets from indexed source snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata (name, kind, start/end lines) when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |
 | `lore_blame` | Query blame, line-range history, or ownership aggregates with optional symbol targeting, commit-context enrichment, and risk signals |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,11 +249,11 @@ Key optimizations in the indexing pipeline (v0.3.0):
 | `lore_lookup` | Find symbols by name or files by path (optional branch filter), including external API symbol matches from `external_symbols` and persisted LSP-enrichment metadata when available |
 | `lore_search` | Structural BM25, semantic vector, or fused RRF search; semantic/fused modes can return docs section hits and structural results are augmented by external symbol-name matches from `external_symbols`; returns persisted LSP-enrichment metadata fields when available |
 | `lore_docs` | List indexed docs, fetch full docs with optional sections, or search indexed sections |
-| `lore_graph` | Query call, import, inheritance, or type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries (`call` edges include `callee_coverage_percent`) |
+| `lore_graph` | Query call, import, inheritance, or type-dependency edges with automatic transitive traversal (up to 5 hops); supports `source_id` for outbound and `target_id` for inbound/reverse queries; materializes virtual dispatch edges (`call` edges include `callee_coverage_percent`) |
 | `lore_trace` | Trace execution paths between two symbols through the call graph |
 | `lore_diff` | Diff exported API surfaces between branches |
 | `lore_cohesion` | Compute module cohesion metrics for a file or directory |
-| `lore_dependents` | Unified reverse-dependency / blast-radius query across callers, importers, subclasses, and type refs |
+| `lore_dependents` | Unified reverse-dependency / blast-radius query with automatic transitive traversal (up to 5 hops) across callers, importers, subclasses, and type refs |
 | `lore_snippet` | Return snippets from indexed DB-backed file snapshots by file path + line range or by symbol name; path/symbol resolution is branch-aware and responses include containing-symbol context metadata when available |
 | `lore_test_map` | Return mapped test files (with confidence) for a given source file path |
 | `lore_blame` | Query blame (`mode: "blame"`), line-range evolution (`mode: "history"`), or ownership aggregates (`mode: "ownership"`), including symbol-targeted range resolution |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jafreck/lore",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jafreck/lore",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Language-aware codebase indexer — tree-sitter parsing, symbol extraction, call-graph construction, and optional embeddings for semantic search",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.3.9

**Patch bump**: `0.3.8` → `0.3.9`
**Compare**: [`v0.3.8...release/v0.3.9`](https://github.com/jafreck/Lore/compare/v0.3.8...release/v0.3.9)

### Key Changes

#### Features
- **Virtual dispatch materialization** — `lore_graph` now materializes virtual dispatch edges, enabling polymorphic call resolution through the call graph (#221)
- **Automatic transitive traversal** — both `lore_graph` and `lore_dependents` now automatically follow edges up to 5 hops; the user-facing `depth` and `limit` parameters have been removed in favor of sensible internal defaults (#221)
- **Truncation flag** — `lore_graph` and `lore_dependents` results now include a `truncated` field when results hit the internal limit

#### Fixes
- **Virtual dispatch follow-up** — corrected edge cases in SCIP virtual dispatch resolution (#222)
- **Tree-sitter `end_line`** — fixed end-line calculation in tree-sitter source indexing (#219)

#### Benchmarks & Tests
- Expanded Postgres benchmark question set with corrected expected answers (#217, #218)
- Call-graph focused benchmark suite (#219)
- Structured benchmark report output (#223)
- Renamed Gson benchmark to Jackson-databind

### Docs Refreshed
- **README.md** — updated `lore_graph` and `lore_dependents` tool descriptions to reflect automatic transitive traversal and virtual dispatch
- **docs/architecture.md** — matching tool description updates

### Validation
- Build: ✅ passed
- Tests: 1860 passed, 1 pre-existing env-dependent failure (SCIP Java registry check), 83 skipped