### PR TITLE
fix(resolution): add name_single_file tier for Java method overloads

### DIFF
--- a/src/resolution/call-graph.ts
+++ b/src/resolution/call-graph.ts
@@ -394,7 +394,18 @@ function resolveByNameFallback(
       continue;
     }
 
-    // Non-unique cross-file: leave as unresolved (option B)
+    // Tier 3: all candidates (after excluding macro/constant/enum_member) live
+    // in the same target file — e.g. Java method overloads in one class.
+    // Resolve to the first match (overloads are co-located; the file is correct).
+    if (crossFileEligible.length > 1) {
+      const targetFiles = new Set(crossFileEligible.map(c => c.file_id));
+      if (targetFiles.size === 1) {
+        updateResolved.run(crossFileEligible[0]!.id, 'name_single_file' satisfies ResolutionMethod, ref.id);
+        continue;
+      }
+    }
+
+    // Non-unique cross-file across multiple files: leave as unresolved
   }
 }
 

--- a/src/resolution/resolution-method.ts
+++ b/src/resolution/resolution-method.ts
@@ -17,6 +17,9 @@
  *   that was mapped to the narrowest enclosing indexed symbol.
  * - `name_same_file` — no LSP data was available; the callee/type name matched
  *   exactly one symbol *in the same file* as the reference.
+ * - `name_single_file` — no LSP data was available; the callee/type name matched
+ *   multiple symbols (e.g. overloads) but all reside in *the same target file*.
+ *   The first match is used (overloads are co-located, so the file is correct).
  * - `name_unique` — no LSP data was available; the callee/type name matched
  *   exactly one symbol *in the entire index*.
  * - `external_definition` — the LSP server returned a definition location whose
@@ -31,6 +34,7 @@ export const RESOLUTION_METHODS = [
   'scip_definition',
   'lsp_definition',
   'name_same_file',
+  'name_single_file',
   'name_unique',
   'external_definition',
   'ambiguous_definition',
@@ -49,6 +53,7 @@ export const RESOLVED_METHODS: ReadonlySet<ResolutionMethod> = new Set([
   'scip_definition',
   'lsp_definition',
   'name_same_file',
+  'name_single_file',
   'name_unique',
 ]);
 

--- a/tests/db/schema-audit.test.ts
+++ b/tests/db/schema-audit.test.ts
@@ -15,8 +15,8 @@ import {
 } from '../../src/resolution/resolution-method.js';
 
 describe('resolution-method taxonomy', () => {
-  it('should define exactly 8 resolution methods', () => {
-    expect(RESOLUTION_METHODS).toHaveLength(8);
+  it('should define exactly 9 resolution methods', () => {
+    expect(RESOLUTION_METHODS).toHaveLength(9);
   });
 
   it('should contain the canonical method names', () => {

--- a/tests/resolution/resolution-method.test.ts
+++ b/tests/resolution/resolution-method.test.ts
@@ -7,11 +7,12 @@ import {
 import type { ResolutionMethod } from '../../src/resolution/resolution-method.js';
 
 describe('resolution-method taxonomy', () => {
-  it('should define all eight resolution method values', () => {
+  it('should define all nine resolution method values', () => {
     expect(RESOLUTION_METHODS).toEqual([
       'scip_definition',
       'lsp_definition',
       'name_same_file',
+      'name_single_file',
       'name_unique',
       'external_definition',
       'ambiguous_definition',
@@ -24,6 +25,7 @@ describe('resolution-method taxonomy', () => {
     expect(RESOLVED_METHODS.has('scip_definition')).toBe(true);
     expect(RESOLVED_METHODS.has('lsp_definition')).toBe(true);
     expect(RESOLVED_METHODS.has('name_same_file')).toBe(true);
+    expect(RESOLVED_METHODS.has('name_single_file')).toBe(true);
     expect(RESOLVED_METHODS.has('name_unique')).toBe(true);
     expect(RESOLVED_METHODS.has('external_definition' as ResolutionMethod)).toBe(false);
     expect(RESOLVED_METHODS.has('unresolved' as ResolutionMethod)).toBe(false);


### PR DESCRIPTION
## Problem

In tree-sitter mode (no SCIP/LSP), Java method calls like `ctxt.reportInputMismatch(...)` get bare-name-extracted to `reportInputMismatch`. When the target method has multiple overloads (e.g. 4 overloads in `DeserializationContext`), the name is not globally unique, so the `name_unique` resolution tier skips it — leaving the edge permanently unresolved.

This caused `_checkFromStringCoercion` (the most frequently missed symbol at **7 occurrences**), `deserialize` (3×), and `_verifyNullForPrimitive` (3×) to be absent from `lore_dependents` results.

## Root Cause

The `resolveByNameFallback()` function in `call-graph.ts` has only two tiers:
1. `name_same_file` — exactly one match in the same file
2. `name_unique` — exactly one match in the entire index

Java method overloads produce multiple candidates with the same name, all in the same target class file. Neither tier matches.

## Fix

Add a new resolution tier **`name_single_file`** between `name_unique` and "give up": when all cross-file-eligible candidates with a given bare name reside in **the same target file** (typical for Java/C# overloads in one class), resolve to the first match. The file attribution is correct even though we can't distinguish overloads.

## Files Changed

| File | Change |
|------|--------|
| `src/resolution/resolution-method.ts` | Add `name_single_file` to method enum and `RESOLVED_METHODS` set |
| `src/resolution/call-graph.ts` | Add Tier 3 single-file resolution in `resolveByNameFallback()` |
| `tests/resolution/resolution-method.test.ts` | Update expected count from 8 → 9, add `name_single_file` assertions |
| `tests/db/schema-audit.test.ts` | Update expected count from 8 → 9 |

## Impact

Fixes **10** benchmark failure instances where Lore scored lower than control:
- `jackson-databind-1.1-reportInputMismatch` (iter 5)
- `jackson-databind-1.5-reportInputMismatch` (iters 2, 5)
- `jackson-databind-10.3-reportInputMismatch` (iters 1, 2, 4)
- `jackson-databind-11.2-reportInputMismatch` (iters 1, 5)
- `jackson-databind-11.3-reportInputMismatch` (iter 3)

## Testing

All 803 tests pass (indexer + resolution + db + server).