### PR TITLE
fix(server): inline enclosing scope into caller_name for agent visibility

### DIFF
--- a/src/server/tools/dependents.ts
+++ b/src/server/tools/dependents.ts
@@ -371,10 +371,16 @@ function getSymbolIdsInFiles(
 
 // ─── Compact helpers ──────────────────────────────────────────────────────────
 
+function formatCallerName(row: RawCallerRow): string {
+  return row.enclosing_name
+    ? `${row.caller_name} (in ${row.enclosing_name})`
+    : row.caller_name;
+}
+
 function compactCaller(row: RawCallerRow): CompactCallerEntry {
   return {
     caller_id: row.caller_id,
-    caller_name: row.caller_name,
+    caller_name: formatCallerName(row),
     caller_kind: row.caller_kind,
     caller_file: row.caller_file,
     ...(row.enclosing_name ? { enclosing_name: row.enclosing_name } : {}),
@@ -384,7 +390,7 @@ function compactCaller(row: RawCallerRow): CompactCallerEntry {
 function fullCaller(row: RawCallerRow): CallerEntry {
   return {
     caller_id: row.caller_id,
-    caller_name: row.caller_name,
+    caller_name: formatCallerName(row),
     caller_kind: row.caller_kind,
     caller_file: row.caller_file,
     ...(row.enclosing_name ? { enclosing_name: row.enclosing_name } : {}),


### PR DESCRIPTION
## Problem

PR #229 added `parent_symbol_id` and surfaces `enclosing_name` as a separate field in `lore_dependents` results. Benchmark reruns showed that agents read `caller_name: "app"` and echo `app` — they ignore the sibling `enclosing_name` field entirely. FastAPI correctness remained -7pp worse than control because `get_request_handler` never appeared in the agent's answer.

## Fix

Inline the enclosing scope directly into `caller_name`:

```
Before: caller_name: "app",            enclosing_name: "get_request_handler"
After:  caller_name: "app (in get_request_handler)", enclosing_name: "get_request_handler"
```

The `enclosing_name` field is preserved for programmatic consumers. Top-level callers (no parent) are unchanged.

## Rationale

Lore's value is pre-computed correct answers. If the agent has to cross-reference fields to get the right answer, Lore failed. `caller_name` should be self-describing so any agent naturally includes the enclosing scope when echoing it.

## Files Changed

- `src/server/tools/dependents.ts` — add `formatCallerName()` helper, use it in `compactCaller()` and `fullCaller()`

## Testing

All 668 tests pass (server + indexer + db).