### PR TITLE
fix(ci): add CODECOV_TOKEN guard, pin codecov action, enable verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,19 @@ jobs:
       - name: Coverage
         run: npm run coverage
 
+      - name: Verify CODECOV_TOKEN is set
+        run: |
+          if [ -z "$CODECOV_TOKEN" ]; then
+            echo "::error::CODECOV_TOKEN secret is not set — coverage upload will be skipped"
+            exit 1
+          fi
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.4.3
         with:
           files: ./coverage/coverage-final.json
           fail_ci_if_error: true
+          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

Codecov coverage reports stopped publishing after PR #222 (Mar 21). The Codecov dashboard shows "No coverage report uploaded for this branch head commit" and codecov/project + codecov/patch check runs disappeared from subsequent PRs.

## Changes

### `.github/workflows/ci.yml`
- **Add `CODECOV_TOKEN` verification step** — fails CI with a clear error if the secret is missing/empty, preventing silent upload failures
- **Pin `codecov/codecov-action` to `v5.4.3`** — avoids surprise behavioral changes from floating `@v5`
- **Enable `verbose: true`** — provides detailed upload logs for diagnosing future issues

## Diagnosis approach

This PR will reveal whether the root cause is:
1. **Missing/invalid token** — the new guard step will fail with a clear message
2. **Codecov action bug** — verbose output will show the upload attempt details
3. **Coverage file not generated** — the action will report the missing file