### PR TITLE
docs: update benchmark claims with accurate numbers from 390 runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Lore is a code intelligence tool that enables AI agents and API consumers to und
 
 - **Correctness**: Pre-resolved symbols, call graphs, type relationships, and import edges give agents accurate structural facts rather than heuristic guesses.
 - **Scale**: Lore indexes entire repositories — across 23 languages — into a compact database that agents query surgically, avoiding full-file reads.
-- **Efficiency**: Agents using Lore achieve up to 97% fewer tokens and 8.8× faster responses on code intelligence tasks compared to grep + file-read baselines.
+- **Efficiency**: Across 6 benchmark repos (390 runs), Lore-enabled agents use 29% fewer tokens and 39% fewer tool calls compared to grep + file-read baselines, with an 11pp higher success rate.
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Lore holds your agent's institutional knowledge over the codebase — it knows what was built, why it changed, and how it all connects. Lore indexes your code and git history into a structured knowledge base that agents query through MCP. It maps symbols, imports, call relationships, type relationships, annotations, docs, and all git data — with optional embeddings for semantic search — so agents can reason about your codebase without re-reading it from scratch.
 
-Lore-enabled agents achieve up to **8.8× faster** responses, up to **97% fewer tokens**, and up to **+33pp correctness improvement** on code intelligence tasks compared to a baseline agent with grep and file reads alone. See the [full benchmark results](docs/benchmark-results.md) for details.
+Lore-enabled agents achieve **+11pp higher success rate**, **29% fewer tokens**, and **39% fewer tool calls** across 6 benchmark repos (390 runs) compared to a baseline agent with grep and file reads alone. See the [full benchmark results](docs/benchmark-results.md) for details.
 
 ## What Lore does
 


### PR DESCRIPTION
Replaces cherry-picked per-task maximums in README.md and CLAUDE.md with honest cross-repo averages from the latest benchmark suite (390 runs across 6 repos).

**Before:** "up to 8.8× faster responses, up to 97% fewer tokens, and up to +33pp correctness improvement"

**After:** "+11pp higher success rate, 29% fewer tokens, and 39% fewer tool calls across 6 benchmark repos (390 runs)"

The old numbers were maximum single-task peaks. The new numbers are weighted averages across all repos and iterations — defensible and reproducible.