### PR TITLE
feat(benchmark): track and report repo indexing time

### DIFF
--- a/tests/benchmark/copilot-agent.test.ts
+++ b/tests/benchmark/copilot-agent.test.ts
@@ -109,6 +109,7 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
   const repoManager = new RepoManager(WORK_DIR);
   let repoPath: string;
   let dbPath: string;
+  let indexTimeMs: number | undefined;
 
   beforeAll(async () => {
     // Ensure Lore MCP server is built (used by lore-enabled arm)
@@ -129,6 +130,7 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
       lsp: ENABLE_LSP,
     });
     dbPath = indexed.dbPath!;
+    indexTimeMs = indexed.indexTimeMs;
 
     expect(indexed.indexed).toBe(true);
     console.log(`\n${TARGET_REPO} cloned at ${repoSpec.sha.slice(0, 8)}, indexed in ${indexed.indexTimeMs}ms`);
@@ -277,6 +279,9 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
     console.log(`Tasks: ${COPILOT_TASKS.length}`);
     console.log(`Iterations: ${ITERATIONS}`);
     console.log(`Arm filter: ${ARM_FILTER ?? 'both'}`);
+    if (indexTimeMs != null) {
+      console.log(`Index time: ${(indexTimeMs / 1000).toFixed(1)}s`);
+    }
 
     // Single-arm mode: report only the requested arm
     if (ARM_FILTER === 'control' && controlScores.length > 0) {
@@ -316,6 +321,7 @@ describe.skipIf(SKIP)(`Copilot agent benchmark: ${TARGET_REPO}`, () => {
           completedRuns: controlScores.length,
           totalExpectedRuns,
           timestamp: new Date().toISOString(),
+          ...(indexTimeMs != null ? { indexTimeMs } : {}),
         },
         structuredTasks,
         controlReport,

--- a/tests/benchmark/util/scorer.ts
+++ b/tests/benchmark/util/scorer.ts
@@ -561,6 +561,7 @@ export interface StructuredBenchmarkReport {
     completedRuns: number;
     totalExpectedRuns: number;
     timestamp: string;
+    indexTimeMs?: number;
   };
   tasks: StructuredTaskResult[];
   aggregate: {


### PR DESCRIPTION
## Summary

Track and report repo indexing time in benchmark results.

## Changes

- **`tests/benchmark/util/scorer.ts`**: Added `indexTimeMs?: number` to `StructuredBenchmarkReport.metadata` so it's persisted in the JSON output.
- **`tests/benchmark/copilot-agent.test.ts`**:
  - Capture `indexTimeMs` from the `indexRepo` result at describe scope.
  - Print `Index time: X.Xs` in the aggregate `BENCHMARK RESULTS` console block.
  - Include `indexTimeMs` in the metadata passed to `buildStructuredReport`.

## Why

The indexing time was already measured (`RepoInstance.indexTimeMs`) and logged during `beforeAll`, but it wasn't included in the structured JSON report or the aggregate results summary. This makes it visible in both places for tracking indexing performance across runs and repos.