### PR TITLE
test: improve targeted coverage in high-gap modules

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -795,4 +795,434 @@ describe('cli', () => {
       await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
     });
   });
+
+  // ── index subcommand — error paths ─────────────────────────────────────────
+
+  describe('index subcommand — error paths', () => {
+    it('should error when --root is missing', async () => {
+      await loadCli(['index', '--db', freshDb()]);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--root'),
+      );
+    });
+
+    it('should error when --db is missing', async () => {
+      await loadCli(['index', '--root', tmpDir]);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--db'),
+      );
+    });
+
+    it('should error when --embeddings and --no-embeddings are both specified', async () => {
+      await loadCli(['index', '--db', freshDb(), '--root', tmpDir, '--embeddings', '--no-embeddings']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--embeddings and --no-embeddings cannot be used together'),
+      );
+    });
+
+    it('should error when --history-depth has an invalid value', async () => {
+      await loadCli(['index', '--db', freshDb(), '--root', tmpDir, '--history-depth', 'abc']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--history-depth must be a positive number'),
+      );
+    });
+
+    it('should error when --history-depth is zero', async () => {
+      await loadCli(['index', '--db', freshDb(), '--root', tmpDir, '--history-depth', '0']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--history-depth must be a positive number'),
+      );
+    });
+
+    it('should error when --history-depth is negative', async () => {
+      await loadCli(['index', '--db', freshDb(), '--root', tmpDir, '--history-depth', '-5']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--history-depth must be a positive number'),
+      );
+    });
+
+    it('should error when --language specifies an unknown language', async () => {
+      await loadCli(['index', '--db', freshDb(), '--root', tmpDir, '--language', 'brainfuck']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('unknown language "brainfuck"'),
+      );
+    });
+
+    it('should pass language extensions when --language is valid', async () => {
+      const dbPath = freshDb();
+      let capturedWalker: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--language', 'typescript'],
+        () => {
+          const factory = () => ({
+            IndexBuilder: class {
+              constructor(_dbPath: string, walkerConfig: unknown) {
+                capturedWalker = walkerConfig;
+              }
+              async build(): Promise<void> {}
+            },
+          });
+          for (const moduleId of INDEXER_MODULE_IDS) {
+            vi.doMock(moduleId, factory);
+          }
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedWalker).toBeDefined();
+      });
+      expect((capturedWalker as Record<string, unknown>).extensions).toEqual(['.ts', '.tsx']);
+    });
+
+    it('should pass history options when --history and --history-depth are provided', async () => {
+      const dbPath = freshDb();
+      let capturedOptions: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--history', '--history-depth', '10'],
+        () => {
+          mockIndexBuilderWithOptionsCapture((options) => {
+            capturedOptions = options;
+          });
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedOptions).toBeDefined();
+      });
+      expect(capturedOptions).toMatchObject({
+        history: { depth: 10 },
+      });
+    });
+
+    it('should pass history.all when --history-all is provided', async () => {
+      const dbPath = freshDb();
+      let capturedOptions: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--history-all'],
+        () => {
+          mockIndexBuilderWithOptionsCapture((options) => {
+            capturedOptions = options;
+          });
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedOptions).toBeDefined();
+      });
+      expect(capturedOptions).toMatchObject({
+        history: { all: true },
+      });
+    });
+
+    it('should pass include and exclude globs', async () => {
+      const dbPath = freshDb();
+      let capturedWalker: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--include', 'src/**', '--exclude', 'node_modules/**'],
+        () => {
+          const factory = () => ({
+            IndexBuilder: class {
+              constructor(_dbPath: string, walkerConfig: unknown) {
+                capturedWalker = walkerConfig;
+              }
+              async build(): Promise<void> {}
+            },
+          });
+          for (const moduleId of INDEXER_MODULE_IDS) {
+            vi.doMock(moduleId, factory);
+          }
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedWalker).toBeDefined();
+      });
+      expect((capturedWalker as Record<string, unknown>).includeGlobs).toEqual(['src/**']);
+      expect((capturedWalker as Record<string, unknown>).excludeGlobs).toEqual(['node_modules/**']);
+    });
+
+    it('should pass embeddingsEnabled when --embeddings is provided', async () => {
+      const dbPath = freshDb();
+      let capturedEmbedder: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--embeddings'],
+        () => {
+          const factory = () => ({
+            IndexBuilder: class {
+              constructor(_dbPath: string, _walkerConfig: unknown, embedder: unknown) {
+                capturedEmbedder = embedder;
+              }
+              async build(): Promise<void> {}
+            },
+          });
+          for (const moduleId of INDEXER_MODULE_IDS) {
+            vi.doMock(moduleId, factory);
+          }
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedEmbedder).toBeDefined();
+      });
+    });
+
+    it('should pass scip disabled when --no-scip is provided', async () => {
+      const dbPath = freshDb();
+      let capturedOptions: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--no-scip'],
+        () => {
+          mockIndexBuilderWithOptionsCapture((options) => {
+            capturedOptions = options;
+          });
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedOptions).toBeDefined();
+      });
+      expect((capturedOptions as Record<string, unknown>).scip).toMatchObject({
+        enabled: false,
+      });
+    });
+
+    it('should pass history options when only --history is provided', async () => {
+      const dbPath = freshDb();
+      let capturedOptions: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--history'],
+        () => {
+          mockIndexBuilderWithOptionsCapture((options) => {
+            capturedOptions = options;
+          });
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedOptions).toBeDefined();
+      });
+      expect(capturedOptions).toHaveProperty('history');
+    });
+
+    it('should report an explicit error for malformed .lore.config SCIP settings', async () => {
+      const dbPath = freshDb();
+      nodeFs.writeFileSync(
+        nodePath.join(tmpDir, '.lore.config'),
+        JSON.stringify({
+          scip: {
+            timeoutMs: 'fast',
+          },
+        }),
+        'utf8',
+      );
+
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error'),
+      );
+    });
+
+    it('should set embedding model from --embedding-model flag', async () => {
+      const dbPath = freshDb();
+      let capturedOptions: unknown;
+      await loadCli(
+        ['index', '--db', dbPath, '--root', tmpDir, '--embedding-model', 'test-model'],
+        () => {
+          mockIndexBuilderWithOptionsCapture((options) => {
+            capturedOptions = options;
+          });
+        },
+      );
+      await vi.waitFor(() => {
+        expect(capturedOptions).toBeDefined();
+      });
+      expect(capturedOptions).toMatchObject({
+        embeddingModel: 'test-model',
+      });
+    });
+  });
+
+  // ── analyze subcommand ─────────────────────────────────────────────────────
+
+  describe('analyze subcommand', () => {
+    it('should error when --db is missing', async () => {
+      await loadCli(['analyze']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--db'),
+      );
+    });
+
+    it('should error with invalid --mode', async () => {
+      const dbPath = freshDb();
+      await loadCli(['analyze', '--db', dbPath, '--mode', 'invalid']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--mode must be one of'),
+      );
+    });
+
+    it('should error with invalid --edge-kinds', async () => {
+      const dbPath = freshDb();
+      await loadCli(['analyze', '--db', dbPath, '--edge-kinds', 'invalid']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--edge-kinds must be one of'),
+      );
+    });
+
+    it('should error with invalid --max-lines', async () => {
+      const dbPath = freshDb();
+      await loadCli(['analyze', '--db', dbPath, '--max-lines', 'abc']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--max-lines must be a positive number'),
+      );
+    });
+
+    it('should error when --max-lines is zero', async () => {
+      const dbPath = freshDb();
+      await loadCli(['analyze', '--db', dbPath, '--max-lines', '0']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--max-lines must be a positive number'),
+      );
+    });
+
+    it('should run cycles mode on a pre-indexed DB', async () => {
+      // Create a minimal indexed DB
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+      await waitForFile(dbPath);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stderrSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      exitSpy.mockClear();
+
+      await loadCli(['analyze', '--db', dbPath, '--mode', 'cycles']);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(() => JSON.parse(output)).not.toThrow();
+      consoleSpy.mockRestore();
+    });
+
+    it('should run summary mode by default on a pre-indexed DB', async () => {
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+      await waitForFile(dbPath);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stderrSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      exitSpy.mockClear();
+
+      await loadCli(['analyze', '--db', dbPath]);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(() => JSON.parse(output)).not.toThrow();
+      consoleSpy.mockRestore();
+    });
+
+    it('should run components mode on a pre-indexed DB', async () => {
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+      await waitForFile(dbPath);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stderrSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      exitSpy.mockClear();
+
+      await loadCli(['analyze', '--db', dbPath, '--mode', 'components']);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+      consoleSpy.mockRestore();
+    });
+
+    it('should run clusters mode with --max-lines on a pre-indexed DB', async () => {
+      const dbPath = freshDb();
+      await loadCli(['index', '--db', dbPath, '--root', tmpDir]);
+      await waitForFile(dbPath);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      stderrSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      exitSpy.mockClear();
+
+      await loadCli(['analyze', '--db', dbPath, '--mode', 'clusters', '--max-lines', '100']);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── install-scip subcommand ────────────────────────────────────────────────
+
+  describe('install-scip subcommand', () => {
+    it('should list available indexers with --list flag', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await loadCli(['install-scip', '--list']);
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+      // Should have printed at least one indexer line
+      expect(consoleSpy.mock.calls.length).toBeGreaterThan(0);
+      consoleSpy.mockRestore();
+    });
+
+    it('should attempt installation and report results', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await loadCli(['install-scip', '--language', 'typescript']);
+      await vi.waitFor(() => {
+        const allOutput = consoleSpy.mock.calls.map(c => String(c[0])).join('\n');
+        expect(allOutput).toMatch(/\d+ installed, \d+ unavailable/u);
+      }, { timeout: 30_000 });
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── mcp subcommand — extended paths ────────────────────────────────────────
+
+  describe('mcp subcommand — extended paths', () => {
+    it('should error when --db points to a non-existent file without --root', async () => {
+      const nonExistent = nodePath.join(tmpDir, 'nonexistent-test.db');
+      await loadCli(['mcp', '--db', nonExistent]);
+      await vi.waitFor(() => {
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('database file not found'),
+      );
+    });
+  });
+
+  // ── refresh subcommand — history-depth error paths ─────────────────────────
+
+  describe('refresh subcommand — history-depth errors', () => {
+    it('should error when refresh --history-depth is invalid', async () => {
+      await loadCli(['refresh', '--db', freshDb(), '--root', tmpDir, '--history-depth', 'abc']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--history-depth must be a positive number'),
+      );
+    });
+
+    it('should error when refresh --history-depth is zero', async () => {
+      await loadCli(['refresh', '--db', freshDb(), '--root', tmpDir, '--history-depth', '0']);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
 });

--- a/tests/db/read-only.test.ts
+++ b/tests/db/read-only.test.ts
@@ -28,6 +28,16 @@ import {
   listCommitsByRef,
   hasCommitEmbeddings,
   listCommitsBySemanticQuery,
+  getFreshness,
+  listTypeRefs,
+  listSymbolRelationships,
+  listCommitCadence,
+  listCommitSizes,
+  listCommitChurnByFile,
+  listCommitAuthorStats,
+  listCommitMessagePrefixes,
+  listCommitSchedule,
+  listCommitBranchActivity,
   type FileRow,
   type SymbolRow,
 } from '../../src/db/read-only.js';
@@ -94,6 +104,46 @@ function createTestDb(): Database.Database {
       resolved_return_type TEXT,
       definition_uri       TEXT,
       definition_path      TEXT
+    );
+    CREATE TABLE file_imports (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_id     INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+      raw_import  TEXT    NOT NULL,
+      resolved_id INTEGER REFERENCES files(id) ON DELETE SET NULL
+    );
+    CREATE TABLE symbol_refs (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      caller_id         INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+      callee_id         INTEGER REFERENCES symbols(id) ON DELETE SET NULL,
+      callee_name       TEXT    NOT NULL DEFAULT '',
+      call_line         INTEGER NOT NULL DEFAULT 0,
+      call_character    INTEGER,
+      call_kind         TEXT    NOT NULL DEFAULT 'call',
+      file_id           INTEGER REFERENCES files(id) ON DELETE CASCADE,
+      resolution_method TEXT    NOT NULL DEFAULT 'unresolved'
+    );
+    CREATE TABLE type_refs (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_id           INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+      symbol_id         INTEGER REFERENCES symbols(id) ON DELETE SET NULL,
+      type_id           INTEGER REFERENCES symbols(id) ON DELETE SET NULL,
+      type_name         TEXT    NOT NULL,
+      type_name_bare    TEXT    NOT NULL,
+      ref_kind          TEXT    NOT NULL DEFAULT 'type_annotation',
+      ref_line          INTEGER NOT NULL DEFAULT 0,
+      ref_character     INTEGER,
+      resolution_method TEXT    NOT NULL DEFAULT 'unresolved'
+    );
+    CREATE TABLE symbol_relationships (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_id           INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+      source_symbol_id  INTEGER REFERENCES symbols(id) ON DELETE SET NULL,
+      target_symbol_id  INTEGER REFERENCES symbols(id) ON DELETE SET NULL,
+      target_symbol_name TEXT   NOT NULL,
+      relationship_type TEXT    NOT NULL,
+      line              INTEGER,
+      character         INTEGER,
+      resolution_method TEXT    NOT NULL DEFAULT 'unresolved'
     );
   `);
   return db;
@@ -996,5 +1046,488 @@ describe('commit helpers', () => {
     loadCommitEmbeddingsTable(db, 3);
     insertCommitEmbedding(db, 'bbb222', [1, 0, 0]);
     expect(listCommitsBySemanticQuery(db, [], 10)).toEqual([]);
+  });
+});
+
+// ─── getFreshness ─────────────────────────────────────────────────────────────
+
+describe('getFreshness', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('should return baseline source when no dirty_files table exists', () => {
+    const info = getFreshness(db);
+    expect(info.source).toBe('baseline');
+    expect(info.dirty_file_count).toBe(0);
+    expect(typeof info.baseline_age_s).toBe('number');
+  });
+
+  it('should return baseline source when dirty_files table exists but is empty', () => {
+    db.exec('CREATE TABLE IF NOT EXISTS dirty_files (path TEXT PRIMARY KEY)');
+    const info = getFreshness(db);
+    expect(info.source).toBe('baseline');
+    expect(info.dirty_file_count).toBe(0);
+  });
+
+  it('should return mixed source when dirty_files has entries', () => {
+    db.exec('CREATE TABLE IF NOT EXISTS dirty_files (path TEXT PRIMARY KEY)');
+    db.exec("INSERT INTO dirty_files VALUES ('/src/a.ts')");
+    const info = getFreshness(db);
+    expect(info.source).toBe('mixed');
+    expect(info.dirty_file_count).toBe(1);
+  });
+
+  it('should compute baseline_age_s from files table', () => {
+    // Insert a file indexed 60 seconds ago
+    const indexedAt = Math.floor(Date.now() / 1000) - 60;
+    db.prepare("INSERT INTO files (path, branch, language, indexed_at) VALUES ('/f.ts', '', 'typescript', ?)").run(indexedAt);
+    const info = getFreshness(db);
+    expect(info.baseline_age_s).toBeGreaterThanOrEqual(59);
+    expect(info.baseline_age_s).toBeLessThanOrEqual(62);
+  });
+});
+
+// ─── listTypeRefs ─────────────────────────────────────────────────────────────
+
+describe('listTypeRefs', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Insert a file and two symbols
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/types.ts', 'main', 'typescript')").run();
+    const fileId = 1;
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'Config', 'type', 1, 5)").run(fileId);
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'loadConfig', 'function', 10, 20)").run(fileId);
+    // Insert a type ref: loadConfig references Config
+    db.prepare("INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, ref_character, resolution_method) VALUES (?, 2, 1, 'Config', 'Config', 'type_annotation', 12, 10, 'name')").run(fileId);
+  });
+
+  it('should return type refs with default options', () => {
+    const refs = listTypeRefs(db);
+    expect(refs.length).toBe(1);
+    expect(refs[0]!.type_name).toBe('Config');
+    expect(refs[0]!.symbol_name).toBe('loadConfig');
+  });
+
+  it('should filter by resolvedOnly', () => {
+    const refs = listTypeRefs(db, { resolvedOnly: true });
+    expect(refs.length).toBe(1);
+  });
+
+  it('should filter by branch', () => {
+    const refs = listTypeRefs(db, { branch: 'main' });
+    expect(refs.length).toBe(1);
+    const noRefs = listTypeRefs(db, { branch: 'dev' });
+    expect(noRefs.length).toBe(0);
+  });
+
+  it('should filter by fileId', () => {
+    const refs = listTypeRefs(db, { fileId: 1 });
+    expect(refs.length).toBe(1);
+    const noRefs = listTypeRefs(db, { fileId: 999 });
+    expect(noRefs.length).toBe(0);
+  });
+
+  it('should filter by methods', () => {
+    const refs = listTypeRefs(db, { methods: ['name'] });
+    expect(refs.length).toBe(1);
+    const noRefs = listTypeRefs(db, { methods: ['scip'] });
+    expect(noRefs.length).toBe(0);
+  });
+
+  it('should respect limit', () => {
+    const refs = listTypeRefs(db, { limit: 0 });
+    expect(refs.length).toBe(0);
+  });
+});
+
+// ─── listSymbolRelationships ──────────────────────────────────────────────────
+
+describe('listSymbolRelationships', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/base.ts', 'main', 'typescript')").run();
+    const fileId = 1;
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'BaseClass', 'class', 1, 10)").run(fileId);
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (?, 'ChildClass', 'class', 15, 25)").run(fileId);
+    // ChildClass extends BaseClass
+    db.prepare("INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, character, resolution_method) VALUES (?, 2, 1, 'BaseClass', 'extends', 15, 0, 'resolved')").run(fileId);
+  });
+
+  it('should return symbol relationships with default options', () => {
+    const rels = listSymbolRelationships(db);
+    expect(rels.length).toBe(1);
+    expect(rels[0]!.target_symbol_name).toBe('BaseClass');
+    expect(rels[0]!.relationship_type).toBe('extends');
+  });
+
+  it('should filter by resolvedOnly', () => {
+    const rels = listSymbolRelationships(db, { resolvedOnly: true });
+    expect(rels.length).toBe(1);
+  });
+
+  it('should filter by branch', () => {
+    const rels = listSymbolRelationships(db, { branch: 'main' });
+    expect(rels.length).toBe(1);
+    const noRels = listSymbolRelationships(db, { branch: 'dev' });
+    expect(noRels.length).toBe(0);
+  });
+
+  it('should filter by relationshipType', () => {
+    const rels = listSymbolRelationships(db, { relationshipType: 'extends' });
+    expect(rels.length).toBe(1);
+    const noRels = listSymbolRelationships(db, { relationshipType: 'implements' });
+    expect(noRels.length).toBe(0);
+  });
+
+  it('should filter by methods', () => {
+    const rels = listSymbolRelationships(db, { methods: ['resolved'] });
+    expect(rels.length).toBe(1);
+    const noRels = listSymbolRelationships(db, { methods: ['scip'] });
+    expect(noRels.length).toBe(0);
+  });
+
+  it('should filter by fileId', () => {
+    const rels = listSymbolRelationships(db, { fileId: 1 });
+    expect(rels.length).toBe(1);
+    const noRels = listSymbolRelationships(db, { fileId: 999 });
+    expect(noRels.length).toBe(0);
+  });
+
+  it('should respect limit', () => {
+    const rels = listSymbolRelationships(db, { limit: 0 });
+    expect(rels.length).toBe(0);
+  });
+});
+
+// ─── listResolvedEdges ────────────────────────────────────────────────────────
+
+describe('listResolvedEdges', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Insert files and symbols
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/caller.ts', 'main', 'typescript')").run();
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/callee.ts', 'main', 'typescript')").run();
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (1, 'funcA', 'function', 1, 10)").run();
+    db.prepare("INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (2, 'funcB', 'function', 1, 5)").run();
+    // funcA calls funcB (resolved)
+    db.prepare("INSERT INTO symbol_refs (caller_id, callee_id, callee_name, call_line, call_character, call_kind, file_id, resolution_method) VALUES (1, 2, 'funcB', 5, 10, 'call', 1, 'resolved')").run();
+    // funcA has an unresolved call
+    db.prepare("INSERT INTO symbol_refs (caller_id, callee_id, callee_name, call_line, call_character, call_kind, file_id, resolution_method) VALUES (1, NULL, 'unknown', 7, 0, 'call', 1, 'unresolved')").run();
+  });
+
+  it('should return all edges with default options', () => {
+    const edges = listResolvedEdges(db);
+    expect(edges.length).toBe(2);
+  });
+
+  it('should filter by resolvedOnly', () => {
+    const edges = listResolvedEdges(db, { resolvedOnly: true });
+    expect(edges.length).toBe(1);
+    expect(edges[0]!.callee_name).toBe('funcB');
+  });
+
+  it('should filter by fileId', () => {
+    const edges = listResolvedEdges(db, { fileId: 1 });
+    expect(edges.length).toBe(2);
+    const noEdges = listResolvedEdges(db, { fileId: 999 });
+    expect(noEdges.length).toBe(0);
+  });
+
+  it('should filter by branch', () => {
+    const edges = listResolvedEdges(db, { branch: 'main' });
+    expect(edges.length).toBe(2);
+    const noEdges = listResolvedEdges(db, { branch: 'dev' });
+    expect(noEdges.length).toBe(0);
+  });
+
+  it('should filter by methods', () => {
+    const edges = listResolvedEdges(db, { methods: ['resolved'] });
+    expect(edges.length).toBe(1);
+    const unresolvedEdges = listResolvedEdges(db, { methods: ['unresolved'] });
+    expect(unresolvedEdges.length).toBe(1);
+  });
+
+  it('should respect limit', () => {
+    const edges = listResolvedEdges(db, { limit: 1 });
+    expect(edges.length).toBe(1);
+  });
+
+  it('should combine multiple filters', () => {
+    const edges = listResolvedEdges(db, { resolvedOnly: true, branch: 'main', methods: ['resolved'] });
+    expect(edges.length).toBe(1);
+    expect(edges[0]!.caller_name).toBe('funcA');
+    expect(edges[0]!.callee_name).toBe('funcB');
+  });
+});
+
+// ─── listFilesByPathPrefix ────────────────────────────────────────────────────
+
+describe('listFilesByPathPrefix', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/main.ts', 'main', 'typescript')").run();
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/src/utils/helpers.ts', 'main', 'typescript')").run();
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/lib/index.ts', 'main', 'typescript')").run();
+  });
+
+  it('should return files matching a path prefix', () => {
+    const files = listFilesByPathPrefix(db, '/src');
+    expect(files.length).toBe(2);
+  });
+
+  it('should handle trailing slash in prefix', () => {
+    const files = listFilesByPathPrefix(db, '/src/');
+    expect(files.length).toBe(2);
+  });
+
+  it('should return empty for non-matching prefix', () => {
+    const files = listFilesByPathPrefix(db, '/nonexistent');
+    expect(files.length).toBe(0);
+  });
+
+  it('should return empty for empty prefix', () => {
+    const files = listFilesByPathPrefix(db, '');
+    expect(files.length).toBe(0);
+  });
+
+  it('should filter by branch', () => {
+    const files = listFilesByPathPrefix(db, '/src', 'main');
+    expect(files.length).toBe(2);
+    const noFiles = listFilesByPathPrefix(db, '/src', 'dev');
+    expect(noFiles.length).toBe(0);
+  });
+
+  it('should return exact match for file path', () => {
+    const files = listFilesByPathPrefix(db, '/src/main.ts');
+    expect(files.length).toBe(1);
+    expect(files[0]!.path).toBe('/src/main.ts');
+  });
+
+  it('should handle root path prefix', () => {
+    const files = listFilesByPathPrefix(db, '/');
+    expect(files.length).toBe(3);
+  });
+
+  it('should respect limit', () => {
+    const files = listFilesByPathPrefix(db, '/src', undefined, 1);
+    expect(files.length).toBe(1);
+  });
+
+  it('should escape wildcards in path prefix', () => {
+    db.prepare("INSERT INTO files (path, branch, language) VALUES ('/data%dir/file.ts', 'main', 'typescript')").run();
+    // The % in the path should be escaped so it matches literally
+    const files = listFilesByPathPrefix(db, '/data%dir');
+    expect(files.length).toBe(1);
+    expect(files[0]!.path).toBe('/data%dir/file.ts');
+  });
+});
+
+// ─── getExternalSymbolsByName ─────────────────────────────────────────────────
+
+describe('getExternalSymbolsByName', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.prepare("INSERT INTO external_symbols (package_name, symbol_name, symbol_kind) VALUES ('lodash', 'debounce', 'function')").run();
+    db.prepare("INSERT INTO external_symbols (package_name, symbol_name, symbol_kind) VALUES ('lodash', 'throttle', 'function')").run();
+  });
+
+  it('should find external symbols by exact name', () => {
+    const syms = getExternalSymbolsByName(db, 'debounce');
+    expect(syms.length).toBe(1);
+    expect(syms[0]!.symbol_name).toBe('debounce');
+  });
+
+  it('should return empty for unknown symbol', () => {
+    const syms = getExternalSymbolsByName(db, 'nonexistent');
+    expect(syms.length).toBe(0);
+  });
+});
+
+// ─── searchExternalSymbolsByName ──────────────────────────────────────────────
+
+describe('searchExternalSymbolsByName', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    db.prepare("INSERT INTO external_symbols (package_name, symbol_name, symbol_kind) VALUES ('lodash', 'debounce', 'function')").run();
+    db.prepare("INSERT INTO external_symbols (package_name, symbol_name, symbol_kind) VALUES ('lodash', 'throttle', 'function')").run();
+    db.prepare("INSERT INTO external_symbols (package_name, symbol_name, symbol_kind) VALUES ('axios', 'create', 'function')").run();
+  });
+
+  it('should search by prefix', () => {
+    const syms = searchExternalSymbolsByName(db, 'deb');
+    expect(syms.length).toBe(1);
+    expect(syms[0]!.symbol_name).toBe('debounce');
+  });
+
+  it('should return multiple matches', () => {
+    const syms = searchExternalSymbolsByName(db, 'th');
+    expect(syms.length).toBe(1);
+    expect(syms[0]!.symbol_name).toBe('throttle');
+  });
+
+  it('should return empty for no matches', () => {
+    const syms = searchExternalSymbolsByName(db, 'zzz');
+    expect(syms.length).toBe(0);
+  });
+});
+
+// ─── Commit stats functions ───────────────────────────────────────────────────
+
+describe('commit stats functions', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createCommitDb(true);
+    // Insert commits with timestamps
+    const ts1 = Math.floor(new Date('2024-01-15T10:00:00Z').getTime() / 1000);
+    const ts2 = Math.floor(new Date('2024-01-16T14:00:00Z').getTime() / 1000);
+    const ts3 = Math.floor(new Date('2024-02-01T09:00:00Z').getTime() / 1000);
+    db.prepare("INSERT INTO commits (sha, author, author_email, timestamp, message) VALUES (?, ?, ?, ?, ?)").run('aaa111', 'Alice', 'alice@test.com', ts1, 'feat: add login');
+    db.prepare("INSERT INTO commits (sha, author, author_email, timestamp, message) VALUES (?, ?, ?, ?, ?)").run('bbb222', 'Bob', 'bob@test.com', ts2, 'fix: fix auth bug');
+    db.prepare("INSERT INTO commits (sha, author, author_email, timestamp, message) VALUES (?, ?, ?, ?, ?)").run('ccc333', 'Alice', 'alice@test.com', ts3, 'refactor: clean up');
+    // Insert commit files
+    db.prepare("INSERT INTO commit_files (commit_sha, file_path, change_type, insertions, deletions) VALUES (?, ?, ?, ?, ?)").run('aaa111', 'src/login.ts', 'A', 50, 0);
+    db.prepare("INSERT INTO commit_files (commit_sha, file_path, change_type, insertions, deletions) VALUES (?, ?, ?, ?, ?)").run('bbb222', 'src/auth.ts', 'M', 10, 5);
+    db.prepare("INSERT INTO commit_files (commit_sha, file_path, change_type, insertions, deletions) VALUES (?, ?, ?, ?, ?)").run('ccc333', 'src/auth.ts', 'M', 20, 15);
+    // Insert commit refs
+    db.prepare("INSERT INTO commit_refs (commit_sha, ref_name, ref_type) VALUES (?, ?, ?)").run('aaa111', 'main', 'branch');
+    db.prepare("INSERT INTO commit_refs (commit_sha, ref_name, ref_type) VALUES (?, ?, ?)").run('bbb222', 'main', 'branch');
+    db.prepare("INSERT INTO commit_refs (commit_sha, ref_name, ref_type) VALUES (?, ?, ?)").run('ccc333', 'develop', 'branch');
+  });
+
+  describe('listCommitCadence', () => {
+    it('should return daily commit counts', () => {
+      const rows = listCommitCadence(db, 'day');
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0]).toHaveProperty('bucket');
+      expect(rows[0]).toHaveProperty('commits');
+    });
+
+    it('should return weekly commit counts', () => {
+      const rows = listCommitCadence(db, 'week');
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('should return monthly commit counts', () => {
+      const rows = listCommitCadence(db, 'month');
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('should filter by author', () => {
+      const rows = listCommitCadence(db, 'day', { author: 'Alice' });
+      const totalCommits = rows.reduce((s, r) => s + r.commits, 0);
+      expect(totalCommits).toBe(2);
+    });
+
+    it('should filter by date range', () => {
+      const rows = listCommitCadence(db, 'day', { since: '2024-01-16', until: '2024-01-16' });
+      const totalCommits = rows.reduce((s, r) => s + r.commits, 0);
+      expect(totalCommits).toBe(1);
+    });
+  });
+
+  describe('listCommitSizes', () => {
+    it('should return commit sizes with insertions and deletions', () => {
+      const rows = listCommitSizes(db);
+      expect(rows.length).toBe(3);
+      expect(rows[0]).toHaveProperty('insertions');
+      expect(rows[0]).toHaveProperty('deletions');
+    });
+
+    it('should filter by author', () => {
+      const rows = listCommitSizes(db, { author: 'Bob' });
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.author).toBe('Bob');
+    });
+  });
+
+  describe('listCommitChurnByFile', () => {
+    it('should return file churn stats', () => {
+      const rows = listCommitChurnByFile(db);
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0]).toHaveProperty('file_path');
+      expect(rows[0]).toHaveProperty('total_churn');
+    });
+
+    it('should order by total churn descending', () => {
+      const rows = listCommitChurnByFile(db);
+      // src/auth.ts has more churn (2 commits) than src/login.ts (1 commit)
+      expect(rows[0]!.file_path).toBe('src/auth.ts');
+    });
+  });
+
+  describe('listCommitAuthorStats', () => {
+    it('should return author commit stats', () => {
+      const rows = listCommitAuthorStats(db);
+      expect(rows.length).toBe(2);
+      // Alice has more commits
+      expect(rows[0]!.author).toBe('Alice');
+      expect(rows[0]!.commit_count).toBe(2);
+    });
+  });
+
+  describe('listCommitMessagePrefixes', () => {
+    it('should return message prefix stats', () => {
+      const rows = listCommitMessagePrefixes(db);
+      expect(rows.length).toBeGreaterThan(0);
+      const prefixes = rows.map(r => r.prefix);
+      expect(prefixes).toContain('feat:');
+      expect(prefixes).toContain('fix:');
+    });
+  });
+
+  describe('listCommitSchedule', () => {
+    it('should return commit schedule by day/hour', () => {
+      const rows = listCommitSchedule(db);
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0]).toHaveProperty('day_of_week');
+      expect(rows[0]).toHaveProperty('hour_of_day');
+      expect(rows[0]).toHaveProperty('commits');
+    });
+  });
+
+  describe('listCommitBranchActivity', () => {
+    it('should return branch activity stats', () => {
+      const rows = listCommitBranchActivity(db);
+      expect(rows.length).toBe(2);
+      expect(rows[0]!.commits).toBeGreaterThanOrEqual(rows[1]!.commits);
+    });
+  });
+
+  describe('listCommitsByFile with renames', () => {
+    it('should find commits for renamed files', () => {
+      // Add a commit with a renamed file path
+      const ts = Math.floor(Date.now() / 1000) - 100;
+      db.prepare("INSERT INTO commits (sha, author, author_email, timestamp, message) VALUES (?, ?, ?, ?, ?)").run('ddd444', 'Charlie', 'charlie@test.com', ts, 'rename file');
+      db.prepare("INSERT INTO commit_files (commit_sha, file_path, change_type, insertions, deletions) VALUES (?, ?, ?, ?, ?)").run('ddd444', 'src/{old.ts => new.ts}', 'R', 0, 0);
+
+      const results = listCommitsByFile(db, 'src/new.ts');
+      expect(results.length).toBe(1);
+      expect(results[0]!.sha).toBe('ddd444');
+    });
+
+    it('should find commits for simple renamed files', () => {
+      const ts = Math.floor(Date.now() / 1000) - 50;
+      db.prepare("INSERT INTO commits (sha, author, author_email, timestamp, message) VALUES (?, ?, ?, ?, ?)").run('eee555', 'Dave', 'dave@test.com', ts, 'move file');
+      db.prepare("INSERT INTO commit_files (commit_sha, file_path, change_type, insertions, deletions) VALUES (?, ?, ?, ?, ?)").run('eee555', 'old-path.ts => new-path.ts', 'R', 0, 0);
+
+      const results = listCommitsByFile(db, 'new-path.ts');
+      expect(results.length).toBe(1);
+    });
   });
 });

--- a/tests/embeddings/embedder.test.ts
+++ b/tests/embeddings/embedder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   DEFAULT_EMBEDDING_MODEL,
   TransformersJsProvider,
@@ -6,6 +6,7 @@ import {
   buildStructuralEmbeddingText,
   hashEmbeddingText,
   tokenAwareBatch,
+  estimateTokens,
 } from '../../src/embeddings/embedder.js';
 
 describe('DEFAULT_EMBEDDING_MODEL', () => {
@@ -192,5 +193,144 @@ describe('LazyEmbeddingProvider', () => {
   it('should throw from dims getter before init (delegates to inner)', () => {
     const provider = new LazyEmbeddingProvider('some-model');
     expect(() => provider.dims).toThrow('EmbeddingProvider not initialised');
+  });
+});
+
+describe('estimateTokens', () => {
+  it('should estimate tokens as ceil(length / 4)', () => {
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('hello')).toBe(2);
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('a'.repeat(100))).toBe(25);
+  });
+});
+
+describe('TransformersJsProvider — init / embed / dispose with mock', () => {
+  const origEnv = process.env['LORE_EMBED_DEVICE'];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (origEnv === undefined) {
+      delete process.env['LORE_EMBED_DEVICE'];
+    } else {
+      process.env['LORE_EMBED_DEVICE'] = origEnv;
+    }
+  });
+
+  it('should detect LORE_EMBED_DEVICE env var', () => {
+    process.env['LORE_EMBED_DEVICE'] = 'cuda';
+    const provider = new TransformersJsProvider('mock-model');
+    // detectDevice is private, but we can test it indirectly via init()
+    // For now just verify it reads the env var by checking device before init
+    expect(provider.device).toBe('unknown');
+    // Clean up
+    delete process.env['LORE_EMBED_DEVICE'];
+  });
+
+  it('should use cpu as default device when no env var set', () => {
+    delete process.env['LORE_EMBED_DEVICE'];
+    const provider = new TransformersJsProvider('mock-model');
+    // Can only verify after init, but device remains 'unknown' before init
+    expect(provider.device).toBe('unknown');
+  });
+
+  it('should init, embed, and dispose with mocked pipeline', async () => {
+    const mockPipelineFn = vi.fn(async (_texts: unknown, _opts: unknown) => ({
+      tolist: () => [[0.1, 0.2, 0.3]],
+    }));
+    mockPipelineFn.dispose = vi.fn(async () => {});
+
+    vi.doMock('@huggingface/transformers', () => ({
+      pipeline: async () => mockPipelineFn,
+    }));
+
+    // Re-import to pick up mock
+    const { TransformersJsProvider: MockedProvider } = await import(
+      '../../src/embeddings/embedder.js'
+    );
+
+    const provider = new MockedProvider('mock-model') as TransformersJsProvider;
+    await provider.init();
+    expect(provider.dims).toBe(3);
+    expect(provider.device).toBe('cpu');
+
+    // init is idempotent
+    await provider.init();
+    expect(provider.dims).toBe(3);
+
+    // embed with texts
+    const result = await provider.embed(['hello']);
+    expect(result).toEqual([[0.1, 0.2, 0.3]]);
+
+    // dispose
+    await provider.dispose();
+
+    vi.doUnmock('@huggingface/transformers');
+  });
+
+  it('should fall back to cpu on unsupported device error', async () => {
+    process.env['LORE_EMBED_DEVICE'] = 'cuda';
+
+    let callCount = 0;
+    const mockPipelineFn = vi.fn(async (_texts: unknown, _opts: unknown) => ({
+      tolist: () => [[0.5, 0.6]],
+    }));
+
+    vi.doMock('@huggingface/transformers', () => ({
+      pipeline: async (_task: unknown, _model: unknown, opts: { device: string }) => {
+        callCount++;
+        if (callCount === 1 && opts.device !== 'cpu') {
+          throw new Error('Unsupported device: cuda');
+        }
+        return mockPipelineFn;
+      },
+    }));
+
+    const { TransformersJsProvider: MockedProvider } = await import(
+      '../../src/embeddings/embedder.js'
+    );
+
+    const provider = new MockedProvider('mock-model') as TransformersJsProvider;
+    await provider.init();
+    // Should have fallen back to CPU
+    expect(provider.device).toBe('cpu');
+    expect(provider.dims).toBe(2);
+
+    await provider.dispose();
+    delete process.env['LORE_EMBED_DEVICE'];
+    vi.doUnmock('@huggingface/transformers');
+  });
+});
+
+describe('LazyEmbeddingProvider — deferred init', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should init on first embed call and deduplicate init', async () => {
+    const mockPipelineFn = vi.fn(async (_texts: unknown, _opts: unknown) => ({
+      tolist: () => [[1, 2, 3, 4]],
+    }));
+    mockPipelineFn.dispose = vi.fn(async () => {});
+
+    vi.doMock('@huggingface/transformers', () => ({
+      pipeline: async () => mockPipelineFn,
+    }));
+
+    const { LazyEmbeddingProvider: MockedLazy } = await import(
+      '../../src/embeddings/embedder.js'
+    );
+
+    const provider = new MockedLazy('mock-model') as LazyEmbeddingProvider;
+
+    // First embed triggers init
+    const result = await provider.embed(['test text']);
+    expect(result).toEqual([[1, 2, 3, 4]]);
+    expect(provider.dims).toBe(4);
+
+    // dispose after init
+    await provider.dispose();
+
+    vi.doUnmock('@huggingface/transformers');
   });
 });

--- a/tests/fixtures/elm/calls.elm
+++ b/tests/fixtures/elm/calls.elm
@@ -1,0 +1,11 @@
+module Calls exposing (main, helper)
+
+import Html exposing (text)
+
+helper : String -> String
+helper name =
+    String.toUpper name
+
+main : String
+main =
+    helper "world"

--- a/tests/fixtures/javascript/import-combined.js
+++ b/tests/fixtures/javascript/import-combined.js
@@ -1,0 +1,10 @@
+import React, { useState, useEffect } from 'react';
+import * as lodash from 'lodash';
+
+function App() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    lodash.debounce(() => {}, 100);
+  }, []);
+  return count;
+}

--- a/tests/indexer/scip-indexer-imports.test.ts
+++ b/tests/indexer/scip-indexer-imports.test.ts
@@ -421,3 +421,76 @@ describe('ScipIndexerStage import resolution', () => {
     ctx.db.close();
   });
 });
+
+// ─── Kind inference from SCIP descriptor suffixes ─────────────────────────────
+
+describe('ScipIndexerStage — symbol kind inference', () => {
+  it('maps SCIP descriptor suffixes to Lore symbol kinds', async () => {
+    const rootDir = makeTmpDir('lore-scip-kinds-');
+    const indexDir = join(rootDir, '.scip-indexes');
+    mkdirSync(indexDir, { recursive: true });
+
+    // Write one source file so the walker finds it
+    writeFileSync(join(rootDir, 'kinds.ts'), 'export {};\n');
+
+    // Build SCIP index with symbols using every descriptor suffix
+    const bytes = buildScipIndexBytes([{
+      relativePath: 'kinds.ts',
+      language: 'TypeScript',
+      occurrences: [
+        // type (#) with enum hint → enum
+        { range: [0, 0, 0, 5], symbol: 'scip-ts npm pkg 1.0 Color#', symbolRoles: SymbolRole.Definition },
+        // term (.) with enum member hint → enum_member
+        { range: [1, 0, 1, 3], symbol: 'scip-ts npm pkg 1.0 Color#Red.', symbolRoles: SymbolRole.Definition },
+        // term (.) with const hint → constant
+        { range: [2, 0, 2, 8], symbol: 'scip-ts npm pkg 1.0 MAX_SIZE.', symbolRoles: SymbolRole.Definition },
+        // term (.) with property hint → property
+        { range: [3, 0, 3, 4], symbol: 'scip-ts npm pkg 1.0 MyClass#name.', symbolRoles: SymbolRole.Definition },
+        // meta (:) → property
+        { range: [4, 0, 4, 1], symbol: 'scip-ts npm pkg 1.0 x:', symbolRoles: SymbolRole.Definition },
+        // type (#) with interface hint → interface
+        { range: [5, 0, 5, 4], symbol: 'scip-ts npm pkg 1.0 IFoo#', symbolRoles: SymbolRole.Definition },
+        // type (#) with type hint → type_alias
+        { range: [6, 0, 6, 7], symbol: 'scip-ts npm pkg 1.0 MyAlias#', symbolRoles: SymbolRole.Definition },
+        // type (#) — plain class (default)
+        { range: [7, 0, 7, 7], symbol: 'scip-ts npm pkg 1.0 Widget#', symbolRoles: SymbolRole.Definition },
+        // method — function inside a type  
+        { range: [8, 0, 8, 6], symbol: 'scip-ts npm pkg 1.0 Widget#render().', symbolRoles: SymbolRole.Definition },
+      ],
+      symbols: [
+        { symbol: 'scip-ts npm pkg 1.0 Color#', displayName: 'Color', documentation: ['enum Color'] },
+        { symbol: 'scip-ts npm pkg 1.0 Color#Red.', displayName: 'Red', documentation: ['(enum member)'] },
+        { symbol: 'scip-ts npm pkg 1.0 MAX_SIZE.', displayName: 'MAX_SIZE', documentation: ['const MAX_SIZE = 100'] },
+        { symbol: 'scip-ts npm pkg 1.0 MyClass#name.', displayName: 'name', documentation: ['(property)'] },
+        { symbol: 'scip-ts npm pkg 1.0 x:', displayName: 'x', documentation: [] },
+        { symbol: 'scip-ts npm pkg 1.0 IFoo#', displayName: 'IFoo', documentation: ['interface IFoo'] },
+        { symbol: 'scip-ts npm pkg 1.0 MyAlias#', displayName: 'MyAlias', documentation: ['type MyAlias = string'] },
+        { symbol: 'scip-ts npm pkg 1.0 Widget#', displayName: 'Widget', documentation: ['class Widget'] },
+        { symbol: 'scip-ts npm pkg 1.0 Widget#render().', displayName: 'render', documentation: ['method render()'] },
+      ],
+    }]);
+    writeFileSync(join(indexDir, 'index.scip'), bytes);
+
+    const dbPath = join(rootDir, 'test.db');
+    const ctx = makeContext(rootDir, dbPath);
+    ctx.files = [{ path: join(rootDir, 'kinds.ts'), language: 'typescript' }];
+
+    const stage = new ScipIndexerStage();
+    await stage.execute(ctx, 'build');
+
+    const symbols = ctx.db.prepare('SELECT name, kind FROM symbols ORDER BY name').all() as Array<{ name: string; kind: string }>;
+    const kindMap = Object.fromEntries(symbols.map(s => [s.name, s.kind]));
+
+    expect(kindMap['Color']).toBe('enum');
+    expect(kindMap['Red']).toBe('enum_member');
+    expect(kindMap['MAX_SIZE']).toBe('constant');
+    expect(kindMap['name']).toBe('property');
+    expect(kindMap['x']).toBe('property');
+    expect(kindMap['IFoo']).toBe('interface');
+    expect(kindMap['MyAlias']).toBe('type_alias');
+    expect(kindMap['Widget']).toBe('class');
+    expect(kindMap['render']).toBe('method');
+
+    ctx.db.close();
+  });
+});

--- a/tests/indexer/stage-layer-guards.test.ts
+++ b/tests/indexer/stage-layer-guards.test.ts
@@ -2,10 +2,13 @@
  * Tests for pipeline stage layer guards and overlay mode entry points.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { openDb } from '../../src/db/schema.js';
 import { ScipIndexerStage } from '../../src/indexer/stages/scip-indexer.js';
-import { LspEnrichmentStage } from '../../src/indexer/stages/lsp-enrichment.js';
+import { LspEnrichmentStage, enrichProjectRefs } from '../../src/indexer/stages/lsp-enrichment.js';
 import type { PipelineContext } from '../../src/indexer/pipeline.js';
 import { initLogger, LogLevel } from '../../src/logger.js';
 import type Database from 'better-sqlite3';
@@ -110,5 +113,225 @@ describe('LspEnrichmentStage — baseline/overlay behavior', () => {
     // Should return early (no non-SCIP files)
     await stage.execute(ctx, 'build');
     await stage.dispose?.();
+  });
+
+  it('should log and return early when both non-SCIP and SCIP file lists are empty in overlay mode', async () => {
+    db = openDb(':memory:');
+    const stage = new LspEnrichmentStage();
+    const log = initLogger({ level: LogLevel.SILENT });
+    const ctx = makeContext(db, {
+      lsp: { enabled: true, languages: {} },
+      layer: 'overlay',
+      files: [{ path: '/a.ts', language: 'typescript' }],
+      scipSourcedLanguages: new Set(['typescript']),
+      scipCoveredLanguages: new Set(['typescript']),
+    });
+    // All files are SCIP-covered in overlay mode — but since they're scip-sourced
+    // they go to scipFiles. Test the case where enrichUnresolvedScipRefs is called.
+    await stage.execute(ctx, 'update');
+    await stage.dispose?.();
+  });
+
+  it('should dispose safely when coordinator was never created', async () => {
+    const stage = new LspEnrichmentStage();
+    // dispose should be safe even if execute was never called
+    await stage.dispose();
+    // No error means success
+  });
+
+  it('should handle overlay mode with non-SCIP files', async () => {
+    db = openDb(':memory:');
+    const stage = new LspEnrichmentStage();
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'lore-lsp-test-'));
+    writeFileSync(join(tmpRoot, 'file.py'), 'def hello(): pass\n', 'utf8');
+
+    const ctx = makeContext(db, {
+      lsp: {
+        enabled: true,
+        languages: {},
+        requestTimeoutMs: 500,
+        servers: {},
+      },
+      layer: 'overlay',
+      walkerConfig: { rootDir: tmpRoot },
+      files: [{ path: join(tmpRoot, 'file.py'), language: 'python' }],
+      scipSourcedLanguages: new Set(),
+      scipCoveredLanguages: new Set(),
+    });
+
+    // This will try to start the LspEnrichmentCoordinator with python
+    // It may fail to find a python LSP server, but should not throw
+    await stage.execute(ctx, 'update');
+    await stage.dispose?.();
+  });
+});
+
+describe('enrichProjectRefs', () => {
+  let db: Database.Database;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('should handle files that do not exist on disk', async () => {
+    db = openDb(':memory:');
+    const mockCoordinator = {
+      start: vi.fn(async () => new Set()),
+      enrich: vi.fn(() => []),
+      dispose: vi.fn(async () => {}),
+      coveredLanguages: new Set(),
+    };
+
+    // enrichProjectRefs with a non-existent file should just skip it
+    await enrichProjectRefs(
+      db,
+      'HEAD',
+      [{ path: '/nonexistent/file.ts', language: 'typescript' }],
+      mockCoordinator as any,
+      new Map(),
+    );
+
+    // Should not have called enrich since the file doesn't exist on disk
+    expect(mockCoordinator.enrich).not.toHaveBeenCalled();
+  });
+
+  it('should use sourceCache when available', async () => {
+    db = openDb(':memory:');
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'lore-enrich-cache-'));
+    const filePath = join(tmpRoot, 'cached.ts');
+    writeFileSync(filePath, 'export const x = 1;\n', 'utf8');
+
+    // Insert a file record and a symbol
+    db.exec(`INSERT INTO files (path, branch, language, last_hash) VALUES ('${filePath}', 'HEAD', 'typescript', 'abc')`);
+    const fileId = (db.prepare('SELECT id FROM files WHERE path = ?').get(filePath) as { id: number }).id;
+    db.exec(`INSERT INTO symbols (file_id, name, kind, signature, start_line, end_line) VALUES (${fileId}, 'x', 'variable', 'const x', 1, 1)`);
+
+    const mockCoordinator = {
+      start: vi.fn(async () => new Set()),
+      enrich: vi.fn(() => [null]),
+      dispose: vi.fn(async () => {}),
+      coveredLanguages: new Set(),
+    };
+
+    const sourceCache = new Map<string, string>();
+    sourceCache.set(filePath, 'export const x = 1;\n');
+
+    await enrichProjectRefs(
+      db,
+      'HEAD',
+      [{ path: filePath, language: 'typescript' }],
+      mockCoordinator as any,
+      sourceCache,
+    );
+
+    // Should have called enrich since the file has symbols
+    expect(mockCoordinator.enrich).toHaveBeenCalled();
+  });
+
+  it('should apply updates when coordinator returns metadata', async () => {
+    db = openDb(':memory:');
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'lore-enrich-update-'));
+    const filePath = join(tmpRoot, 'update.ts');
+    writeFileSync(filePath, 'export function greet(): string { return "hi"; }\n', 'utf8');
+
+    db.exec(`INSERT INTO files (path, branch, language, last_hash) VALUES ('${filePath}', 'HEAD', 'typescript', 'def')`);
+    const fileId = (db.prepare('SELECT id FROM files WHERE path = ?').get(filePath) as { id: number }).id;
+    db.exec(`INSERT INTO symbols (file_id, name, kind, signature, start_line, end_line) VALUES (${fileId}, 'greet', 'function', 'function greet(): string', 1, 1)`);
+
+
+    const mockCoordinator = {
+      start: vi.fn(async () => new Set()),
+      enrich: vi.fn(() => [{
+        resolvedTypeSignature: '() => string',
+        resolvedReturnType: 'string',
+        definitionUri: 'file:///test',
+        definitionPath: filePath,
+        definitionLine: 1,
+        definitionCharacter: 16,
+      }]),
+      dispose: vi.fn(async () => {}),
+      coveredLanguages: new Set(),
+    };
+
+    await enrichProjectRefs(
+      db,
+      'HEAD',
+      [{ path: filePath, language: 'typescript' }],
+      mockCoordinator as any,
+    );
+
+    // Verify the symbol was updated
+    const symbol = db.prepare('SELECT resolved_type_signature, resolved_return_type, definition_path FROM symbols WHERE name = ?').get('greet') as any;
+    expect(symbol.resolved_type_signature).toBe('() => string');
+    expect(symbol.resolved_return_type).toBe('string');
+    expect(symbol.definition_path).toBe(filePath);
+  });
+
+  it('should update callRef, typeRef, and relationship rows', async () => {
+    db = openDb(':memory:');
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'lore-enrich-refs-'));
+    const filePath = join(tmpRoot, 'refs.ts');
+    writeFileSync(filePath, 'export function caller() { callee(); }\n', 'utf8');
+
+    // Insert file and symbols
+    db.exec(`INSERT INTO files (path, branch, language, last_hash) VALUES ('${filePath}', 'HEAD', 'typescript', 'x')`);
+    const fileId = (db.prepare('SELECT id FROM files WHERE path = ?').get(filePath) as { id: number }).id;
+    db.exec(`INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (${fileId}, 'caller', 'function', 1, 1)`);
+    db.exec(`INSERT INTO symbols (file_id, name, kind, start_line, end_line) VALUES (${fileId}, 'callee', 'function', 2, 2)`);
+    const callerId = (db.prepare("SELECT id FROM symbols WHERE name = 'caller'").get() as { id: number }).id;
+    const calleeId = (db.prepare("SELECT id FROM symbols WHERE name = 'callee'").get() as { id: number }).id;
+
+    // Insert a symbol_ref (call ref)
+    db.exec(`INSERT INTO symbol_refs (caller_id, file_id, callee_id, callee_name, call_line, call_character, call_kind, resolution_method) VALUES (${callerId}, ${fileId}, ${calleeId}, 'callee', 1, 5, 'direct', 'unresolved')`);
+    const refId = (db.prepare('SELECT id FROM symbol_refs LIMIT 1').get() as { id: number }).id;
+
+    // Insert a type_ref
+    db.exec(`INSERT INTO type_refs (file_id, symbol_id, type_id, type_name, type_name_bare, ref_kind, ref_line, ref_character, resolution_method) VALUES (${fileId}, ${callerId}, ${calleeId}, 'MyType', 'MyType', 'type_annotation', 1, 10, 'unresolved')`);
+    const typeRefId = (db.prepare('SELECT id FROM type_refs LIMIT 1').get() as { id: number }).id;
+
+    // Insert a relationship
+    db.exec(`INSERT INTO symbol_relationships (file_id, source_symbol_id, target_symbol_id, target_symbol_name, relationship_type, line, character, resolution_method) VALUES (${fileId}, ${callerId}, ${calleeId}, 'callee', 'extends', 1, 0, 'unresolved')`);
+    const relId = (db.prepare('SELECT id FROM symbol_relationships LIMIT 1').get() as { id: number }).id;
+
+    const enrichResult = {
+      resolvedTypeSignature: '() => void',
+      resolvedReturnType: 'void',
+      definitionUri: 'file:///test/refs.ts',
+      definitionPath: filePath,
+      definitionLine: 2,
+      definitionCharacter: 0,
+    };
+
+    const mockCoordinator = {
+      start: vi.fn(async () => new Set()),
+      // Return results parallel to tagged: [symbol, symbol, callRef, typeRef, relationship]
+      enrich: vi.fn(() => [null, null, enrichResult, enrichResult, enrichResult]),
+      dispose: vi.fn(async () => {}),
+      coveredLanguages: new Set(),
+    };
+
+    await enrichProjectRefs(
+      db,
+      'HEAD',
+      [{ path: filePath, language: 'typescript' }],
+      mockCoordinator as any,
+    );
+
+    // Verify callRef was updated
+    const ref = db.prepare('SELECT resolved_type_signature, definition_path, definition_line FROM symbol_refs WHERE id = ?').get(refId) as any;
+    expect(ref.resolved_type_signature).toBe('() => void');
+    expect(ref.definition_path).toBe(filePath);
+    expect(ref.definition_line).toBe(2);
+
+    // Verify typeRef was updated
+    const tref = db.prepare('SELECT resolved_type_signature, definition_path, definition_line FROM type_refs WHERE id = ?').get(typeRefId) as any;
+    expect(tref.resolved_type_signature).toBe('() => void');
+    expect(tref.definition_path).toBe(filePath);
+
+    // Verify relationship was updated
+    const rel = db.prepare('SELECT definition_uri, definition_path, definition_line FROM symbol_relationships WHERE id = ?').get(relId) as any;
+    expect(rel.definition_uri).toBe('file:///test/refs.ts');
+    expect(rel.definition_path).toBe(filePath);
+    expect(rel.definition_line).toBe(2);
   });
 });

--- a/tests/parsing/config-parser.test.ts
+++ b/tests/parsing/config-parser.test.ts
@@ -157,4 +157,45 @@ describe('parseConfigFile', () => {
   it('throws for malformed TOML input', () => {
     expect(() => parseConfigFile('broken.toml', 'invalid line')).toThrow(/Invalid TOML config/u);
   });
+
+  it('parses TOML with nested tables and arrays', () => {
+    const entries = parseConfigFile(
+      'app.toml',
+      '[database]\nhost = "localhost"\nport = 5432\n\n[database.pool]\nmax = 10\nidle_timeout = 30\n',
+    );
+
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'database.host', value: 'localhost' }));
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'database.port', value: '5432' }));
+  });
+
+  it('parses TOML with quoted keys and inline arrays', () => {
+    const entries = parseConfigFile(
+      'spec.toml',
+      'tags = ["web", "api"]\nenabled = false\n',
+    );
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'tags', inferredType: 'array' }));
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'enabled', value: 'false', inferredType: 'boolean' }));
+  });
+
+  it('parses JSON with nested objects', () => {
+    const entries = parseConfigFile(
+      'settings.json',
+      JSON.stringify({ server: { port: 3000, host: '0.0.0.0' }, debug: true }),
+    );
+    expect(entries.length).toBe(3);
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'server.port', value: '3000' }));
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'debug', value: 'true' }));
+  });
+
+  it('parses YAML with deeply nested objects', () => {
+    const entries = parseConfigFile(
+      'config.yaml',
+      'app:\n  db:\n    host: localhost\n    port: 5432\n  debug: true\n',
+    );
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'app.db.host', value: 'localhost' }));
+    expect(entries).toContainEqual(expect.objectContaining({ key: 'app.debug', value: 'true' }));
+  });
 });

--- a/tests/parsing/language-extractors/elm.test.ts
+++ b/tests/parsing/language-extractors/elm.test.ts
@@ -42,3 +42,11 @@ describe('Elm import extraction', () => {
     expect(r.imports).toContainEqual(expect.objectContaining({ source: 'String' }));
   });
 });
+
+describe('Elm call reference extraction', () => {
+  const r = fixture('calls.elm');
+  test('extracts functions from call fixture', () => {
+    expect(r.symbols).toContainEqual(expect.objectContaining({ name: 'helper', kind: 'function' }));
+    expect(r.symbols).toContainEqual(expect.objectContaining({ name: 'main', kind: 'function' }));
+  });
+});

--- a/tests/parsing/language-extractors/javascript.test.ts
+++ b/tests/parsing/language-extractors/javascript.test.ts
@@ -68,3 +68,16 @@ describe('JS call-ref extraction', () => {
     expect(r.callRefs[0]).toMatchObject({ calleeRaw: 'path.normalize', callerSymbol: 'fmt' });
   });
 });
+
+describe('JS combined imports', () => {
+  const r = fixture('import-combined.js');
+  test('extracts multiple import types from one file', () => {
+    expect(r.imports.length).toBe(2);
+    expect(r.imports).toContainEqual(expect.objectContaining({ source: 'react' }));
+    expect(r.imports).toContainEqual(expect.objectContaining({ source: 'lodash' }));
+  });
+
+  test('extracts App function', () => {
+    expect(r.symbols).toContainEqual(expect.objectContaining({ name: 'App', kind: 'function' }));
+  });
+});

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for LoreRuntime lifecycle.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -74,5 +74,63 @@ describe('LoreRuntime', () => {
     const cfg = stubConfig();
     runtime = new LoreRuntime(cfg, initLogger({ level: LogLevel.SILENT }));
     expect(runtime.config).toBe(cfg);
+  });
+
+  it('should create embedder when embeddingModel is configured', async () => {
+    runtime = new LoreRuntime(
+      stubConfig({ embeddingModel: 'test-model' }),
+      initLogger({ level: LogLevel.SILENT }),
+    );
+    await runtime.start();
+    // The LazyEmbeddingProvider should be created (not initialized yet)
+    expect(runtime.embedder).toBeDefined();
+    expect(runtime.embedder!.modelName).toBe('test-model');
+  });
+
+  it('should start in watch mode and create a refresher', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const cfg = stubConfig({ refreshMode: 'watch' });
+    // Create a valid DB file for the watcher
+    const { openDb } = await import('../src/db/schema.js');
+    const db = openDb(cfg.dbPath);
+    db.close();
+
+    runtime = new LoreRuntime(cfg, initLogger({ level: LogLevel.SILENT }));
+    await runtime.start();
+    expect(runtime.refresher).toBeDefined();
+    stderrSpy.mockRestore();
+  });
+
+  it('should start in poll mode and create a refresher', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const cfg = stubConfig({ refreshMode: 'poll' });
+    // Create a valid DB file for the poller
+    const { openDb } = await import('../src/db/schema.js');
+    const db = openDb(cfg.dbPath);
+    db.close();
+
+    runtime = new LoreRuntime(cfg, initLogger({ level: LogLevel.SILENT }));
+    await runtime.start();
+    expect(runtime.refresher).toBeDefined();
+    stderrSpy.mockRestore();
+  });
+
+  it('should dispose embedder and refresher during shutdown', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const cfg = stubConfig({ refreshMode: 'poll', embeddingModel: 'test-model' });
+    const { openDb } = await import('../src/db/schema.js');
+    const db = openDb(cfg.dbPath);
+    db.close();
+
+    runtime = new LoreRuntime(cfg, initLogger({ level: LogLevel.SILENT }));
+    await runtime.start();
+    expect(runtime.refresher).toBeDefined();
+    expect(runtime.embedder).toBeDefined();
+
+    await runtime.shutdown();
+    expect(runtime.refresher).toBeUndefined();
+    expect(runtime.embedder).toBeUndefined();
+    expect(runtime.started).toBe(false);
+    stderrSpy.mockRestore();
   });
 });

--- a/tests/scip/compdb.test.ts
+++ b/tests/scip/compdb.test.ts
@@ -5,6 +5,7 @@ import {
   detectBuildSystem,
   ensureCompilationDatabase,
   generateCompdb,
+  createDefaultCompdbIO,
   type CompdbIO,
 } from '../../src/scip/compdb.js';
 

--- a/tests/scip/enrichment.test.ts
+++ b/tests/scip/enrichment.test.ts
@@ -342,4 +342,143 @@ describe('ScipEnrichmentCoordinator', () => {
 
     rmSync(rootDir, { recursive: true, force: true });
   });
+
+  it('returns empty set when no indexers are available for requested languages', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'lore-scip-noidx-'));
+
+    const settings: EffectiveScipSettings = {
+      enabled: true,
+      timeoutMs: 5000,
+      indexers: {},
+      indexDir: null,
+    };
+
+    const coordinator = new ScipEnrichmentCoordinator(settings, rootDir);
+    // Use 'dart' — scip-dart is a manual install, so the binary won't be available.
+    // This triggers autoInstallMissing since dart IS in SCIP_SUPPORTED_LANGUAGES
+    // but the indexer is not installed.
+    const covered = await coordinator.start(['dart']);
+    // Install should fail (no binary), but should not throw
+    expect(covered).toBeDefined();
+
+    await coordinator.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('returns empty set for unsupported languages', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'lore-scip-unsup-'));
+
+    const settings: EffectiveScipSettings = {
+      enabled: true,
+      timeoutMs: 5000,
+      indexers: {},
+      indexDir: null,
+    };
+
+    const coordinator = new ScipEnrichmentCoordinator(settings, rootDir);
+    // 'brainfuck' is not in SCIP_SUPPORTED_LANGUAGES
+    const covered = await coordinator.start(['brainfuck']);
+    expect(covered.size).toBe(0);
+
+    await coordinator.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('readPrecomputedIndex returns null when both candidates are missing', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'lore-scip-nofile-'));
+    // Create indexDir but don't write any .scip files
+    const indexDir = join(rootDir, '.scip-indexes');
+    mkdirSync(indexDir, { recursive: true });
+
+    const settings: EffectiveScipSettings = {
+      enabled: true,
+      timeoutMs: 5000,
+      indexers: {},
+      indexDir: '.scip-indexes',
+    };
+
+    const coordinator = new ScipEnrichmentCoordinator(settings, rootDir);
+    // Start with a language — it should try to read precomputed index and get null
+    const covered = await coordinator.start(['go']);
+    // Since there's no go.scip or index.scip, and no indexer, nothing to cover
+    expect(covered.has('go')).toBe(false);
+
+    await coordinator.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('handles indexer error gracefully and continues', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'lore-scip-err-'));
+
+    const settings: EffectiveScipSettings = {
+      enabled: true,
+      timeoutMs: 5000,
+      indexers: {
+        // Point to a non-existent binary
+        typescript: { command: '/nonexistent/scip-typescript', args: ['index'] },
+      },
+      indexDir: null,
+    };
+
+    const coordinator = new ScipEnrichmentCoordinator(settings, rootDir);
+    // Should not throw — errors are caught internally
+    const covered = await coordinator.start(['typescript']);
+    expect(covered).toBeDefined();
+
+    await coordinator.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('merges multiple indexes when multiple languages share data', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'lore-scip-merge-'));
+    const indexDir = join(rootDir, '.scip-indexes');
+    mkdirSync(indexDir, { recursive: true });
+
+    // Create two separate language indexes
+    const tsSymbol = 'npm . project 1.0 `src/`/tsFunc().';
+    const tsBytes = buildIndexBytes([{
+      relativePath: 'src/main.ts',
+      language: 'TypeScript',
+      occurrences: [
+        { range: [1, 0, 1, 6], symbol: tsSymbol, symbolRoles: SymbolRole.Definition },
+      ],
+      symbols: [{
+        symbol: tsSymbol,
+        documentation: ['function tsFunc(): void'],
+        displayName: 'tsFunc',
+      }],
+    }]);
+    writeFileSync(join(indexDir, 'typescript.scip'), tsBytes);
+
+    const pySymbol = 'pip . project 1.0 `lib/`/pyFunc().';
+    const pyBytes = buildIndexBytes([{
+      relativePath: 'lib/helper.py',
+      language: 'Python',
+      occurrences: [
+        { range: [2, 0, 2, 6], symbol: pySymbol, symbolRoles: SymbolRole.Definition },
+      ],
+      symbols: [{
+        symbol: pySymbol,
+        documentation: ['def pyFunc(): str'],
+        displayName: 'pyFunc',
+      }],
+    }]);
+    writeFileSync(join(indexDir, 'python.scip'), pyBytes);
+
+    const settings: EffectiveScipSettings = {
+      enabled: true,
+      timeoutMs: 5000,
+      indexers: {},
+      indexDir: '.scip-indexes',
+    };
+
+    const coordinator = new ScipEnrichmentCoordinator(settings, rootDir);
+    const covered = await coordinator.start(['typescript', 'python']);
+
+    expect(covered.has('typescript')).toBe(true);
+    expect(covered.has('python')).toBe(true);
+
+    await coordinator.dispose();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
 });

--- a/tests/server/tools/dependents.test.ts
+++ b/tests/server/tools/dependents.test.ts
@@ -78,6 +78,10 @@ function isSuccess(result: DependentsResult | DependentsErrorResult): result is 
   return !('error' in result);
 }
 
+function asObject(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
 function isError(result: DependentsResult | DependentsErrorResult): result is DependentsErrorResult {
   return 'error' in result;
 }
@@ -170,7 +174,7 @@ describe('dependents handler – kind=symbol', () => {
     expect(isSuccess(result)).toBe(true);
     if (!isSuccess(result)) return;
 
-    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    const caller = asObject(result.dependents.callers[0]);
     expect(caller).not.toHaveProperty('line');
     expect(caller).not.toHaveProperty('character');
     expect(caller).not.toHaveProperty('resolution_method');
@@ -184,7 +188,7 @@ describe('dependents handler – kind=symbol', () => {
     expect(isSuccess(result)).toBe(true);
     if (!isSuccess(result)) return;
 
-    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    const caller = asObject(result.dependents.callers[0]);
     expect(caller).toHaveProperty('line');
     expect(caller).toHaveProperty('resolution_method');
   });
@@ -225,7 +229,7 @@ describe('dependents handler – symbol subclasses and type refs', () => {
     if (!isSuccess(result)) return;
 
     expect(result.dependents.subclasses.length).toBe(1);
-    const sub = result.dependents.subclasses[0] as Record<string, unknown>;
+    const sub = asObject(result.dependents.subclasses[0]);
     expect(sub.symbol_name).toBe('ChildService');
     expect(sub.relationship_type).toBe('extends');
   });
@@ -236,7 +240,7 @@ describe('dependents handler – symbol subclasses and type refs', () => {
     if (!isSuccess(result)) return;
 
     expect(result.dependents.type_references.length).toBe(1);
-    const ref = result.dependents.type_references[0] as Record<string, unknown>;
+    const ref = asObject(result.dependents.type_references[0]);
     expect(ref.symbol_name).toBe('consume');
   });
 });
@@ -280,7 +284,7 @@ describe('dependents handler – kind=file', () => {
 
     // Only the cross-file caller (helper from util.ts), not intra-file calls
     expect(result.dependents.callers.length).toBe(1);
-    const caller = result.dependents.callers[0] as Record<string, unknown>;
+    const caller = asObject(result.dependents.callers[0]);
     expect(caller.caller_name).toBe('helper');
     expect(caller.caller_file).toBe('src/util.ts');
   });
@@ -310,10 +314,67 @@ describe('dependents handler – kind=file', () => {
     expect(isSuccess(result)).toBe(true);
     if (!isSuccess(result)) return;
 
-    const importer = result.dependents.importers[0] as Record<string, unknown>;
+    const importer = asObject(result.dependents.importers[0]);
     expect(importer).toHaveProperty('file_id');
     expect(importer).toHaveProperty('file_path');
     expect(importer).not.toHaveProperty('raw_import');
+  });
+});
+
+// ─── File dependents with subclasses and type_refs ─────────────────────────
+
+describe('dependents handler – kind=file with subclasses and type_refs', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    // Target file has a class
+    const targetFileId = insertFile(db, 'src/base.ts');
+    const childFileId = insertFile(db, 'src/child.ts');
+    const userFileId = insertFile(db, 'src/user.ts');
+
+    const baseClass = insertSymbol(db, targetFileId, 'Base', 'class');
+    const childClass = insertSymbol(db, childFileId, 'Child', 'class');
+    const userFn = insertSymbol(db, userFileId, 'useBase', 'function');
+
+    // Child extends Base (subclass of symbol in target file)
+    insertInheritanceEdge(db, childFileId, childClass, baseClass, 'Base');
+    // useBase references Base as a type
+    insertTypeRef(db, userFileId, userFn, baseClass, 'Base');
+  });
+
+  it('should return subclasses in file-kind query', () => {
+    const result = handler(db, { query: 'src/base.ts', kind: 'file' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.subclasses.length).toBe(1);
+    expect(asObject(result.dependents.subclasses[0]).symbol_name).toBe('Child');
+  });
+
+  it('should return type_references in file-kind query', () => {
+    const result = handler(db, { query: 'src/base.ts', kind: 'file' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.type_references.length).toBe(1);
+    expect(asObject(result.dependents.type_references[0]).symbol_name).toBe('useBase');
+  });
+
+  it('should compact subclasses and type_references in file-kind query', () => {
+    const result = handler(db, { query: 'src/base.ts', kind: 'file', compact: true });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.subclasses.length).toBe(1);
+    const sub = asObject(result.dependents.subclasses[0]);
+    expect(sub).toHaveProperty('symbol_name');
+    expect(sub).not.toHaveProperty('line');
+
+    expect(result.dependents.type_references.length).toBe(1);
+    const tref = asObject(result.dependents.type_references[0]);
+    expect(tref).toHaveProperty('symbol_name');
+    expect(tref).not.toHaveProperty('line');
   });
 });
 
@@ -340,7 +401,7 @@ describe('dependents handler – transitive closure', () => {
 
     expect(result.dependents.callers.length).toBe(2);
     const callerNames = result.dependents.callers.map(
-      (c) => (c as Record<string, unknown>).caller_name,
+      (c) => asObject(c).caller_name,
     );
     expect(callerNames).toContain('funcA');
     expect(callerNames).toContain('funcB');
@@ -368,7 +429,7 @@ describe('dependents handler – transitive import chain', () => {
     if (!isSuccess(result)) return;
 
     expect(result.dependents.importers.length).toBe(2);
-    const paths = result.dependents.importers.map((i) => (i as Record<string, unknown>).file_path);
+    const paths = result.dependents.importers.map((i) => asObject(i).file_path);
     expect(paths).toContain('src/mid.ts');
     expect(paths).toContain('src/app.ts');
   });
@@ -399,7 +460,7 @@ describe('dependents handler – branch filtering', () => {
     if (!isSuccess(result)) return;
 
     expect(result.dependents.callers.length).toBe(1);
-    expect((result.dependents.callers[0] as Record<string, unknown>).caller_name).toBe('mainCaller');
+    expect(asObject(result.dependents.callers[0]).caller_name).toBe('mainCaller');
   });
 });
 
@@ -461,5 +522,88 @@ describe('dependents handler – empty dependents', () => {
     expect(result.dependents.subclasses).toEqual([]);
     expect(result.dependents.type_references).toEqual([]);
     expect(result.total_count).toBe(0);
+  });
+});
+
+// ─── Subclass dependents ──────────────────────────────────────────────────────
+
+describe('dependents handler – subclass queries', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const baseFileId = insertFile(db, 'src/base.ts');
+    const childFileId = insertFile(db, 'src/child.ts');
+
+    const baseClass = insertSymbol(db, baseFileId, 'BaseService', 'class');
+    const childClass = insertSymbol(db, childFileId, 'ChildService', 'class');
+
+    // ChildService extends BaseService
+    insertInheritanceEdge(db, childFileId, childClass, baseClass, 'BaseService', 'extends');
+  });
+
+  it('should return subclass dependents for a symbol', () => {
+    const result = handler(db, { query: 'BaseService', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.subclasses.length).toBe(1);
+    const sub = asObject(result.dependents.subclasses[0]);
+    expect(sub.symbol_name).toBe('ChildService');
+    expect(sub.relationship_type).toBe('extends');
+  });
+
+  it('should omit provenance fields in compact subclass output', () => {
+    const result = handler(db, { query: 'BaseService', kind: 'symbol', compact: true });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.subclasses.length).toBe(1);
+    const sub = asObject(result.dependents.subclasses[0]);
+    expect(sub).toHaveProperty('symbol_name');
+    expect(sub).toHaveProperty('relationship_type');
+    // compact mode should not include resolution fields like line/character
+    expect(sub).not.toHaveProperty('line');
+  });
+});
+
+// ─── Type reference dependents ────────────────────────────────────────────────
+
+describe('dependents handler – type reference queries', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    const typeFileId = insertFile(db, 'src/types.ts');
+    const userFileId = insertFile(db, 'src/user.ts');
+
+    const configType = insertSymbol(db, typeFileId, 'Config', 'type');
+    const userSym = insertSymbol(db, userFileId, 'loadConfig', 'function');
+
+    // loadConfig uses Config as a type reference
+    insertTypeRef(db, userFileId, userSym, configType, 'Config');
+  });
+
+  it('should return type reference dependents for a symbol', () => {
+    const result = handler(db, { query: 'Config', kind: 'symbol' });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.type_references.length).toBe(1);
+    const ref = asObject(result.dependents.type_references[0]);
+    expect(ref.symbol_name).toBe('loadConfig');
+  });
+
+  it('should omit provenance fields in compact type reference output', () => {
+    const result = handler(db, { query: 'Config', kind: 'symbol', compact: true });
+    expect(isSuccess(result)).toBe(true);
+    if (!isSuccess(result)) return;
+
+    expect(result.dependents.type_references.length).toBe(1);
+    const ref = asObject(result.dependents.type_references[0]);
+    expect(ref).toHaveProperty('symbol_name');
+    expect(ref).toHaveProperty('ref_kind');
+    // compact mode should not include line/character
+    expect(ref).not.toHaveProperty('line');
   });
 });


### PR DESCRIPTION
## Summary
- add targeted tests for high-gap CLI, runtime, SCIP, embedding, DB, LSP, and dependents paths
- keep the stronger coverage gains while trimming a few low-signal assertions
- add small parser fixtures for the new extractor cases

## Validation
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx vitest run --coverage`
- overall line coverage: `89.93%`
- overall statement coverage: `87.46%`
- overall function coverage: `91.70%`
- overall branch coverage: `72.62%`