### PR TITLE
chore(ci): switch Codecov to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   ci:
     name: ci
@@ -33,19 +37,10 @@ jobs:
       - name: Coverage
         run: npm run coverage
 
-      - name: Verify CODECOV_TOKEN is set
-        run: |
-          if [ -z "$CODECOV_TOKEN" ]; then
-            echo "::error::CODECOV_TOKEN secret is not set — coverage upload will be skipped"
-            exit 1
-          fi
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.4.3
         with:
+          use_oidc: true
           files: ./coverage/coverage-final.json
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Switch from token-based Codecov authentication to OIDC:

- Add `permissions: id-token: write` at workflow level
- Set `use_oidc: true` on the codecov-action step
- Remove `token: ${{ secrets.CODECOV_TOKEN }}`
- Remove the CODECOV_TOKEN verification step

This eliminates the need to manage the `CODECOV_TOKEN` secret.