### PR TITLE
fix: restore inbound edges in incremental reverse_deps update

### DIFF
--- a/src/indexer/stages/reverse-deps.ts
+++ b/src/indexer/stages/reverse-deps.ts
@@ -64,7 +64,7 @@ export class ReverseDepsStage implements PipelineStage {
           deleteByDependent.run(fid);
         }
 
-        // Re-insert for changed files
+        // Re-insert outbound edges from changed files
         const insertFromImports = db.prepare(`
           INSERT OR IGNORE INTO reverse_deps (file_id, dependent_id, dep_kind)
           SELECT fi.resolved_id, fi.file_id, 'import'
@@ -80,9 +80,29 @@ export class ReverseDepsStage implements PipelineStage {
             AND sr.file_id = ?
             AND sr.file_id != s_callee.file_id
         `);
+
+        // Re-insert inbound edges to changed files (from unchanged files)
+        const insertInboundImports = db.prepare(`
+          INSERT OR IGNORE INTO reverse_deps (file_id, dependent_id, dep_kind)
+          SELECT fi.resolved_id, fi.file_id, 'import'
+          FROM file_imports fi
+          WHERE fi.resolved_id IS NOT NULL AND fi.resolved_id = ?
+        `);
+        const insertInboundRefs = db.prepare(`
+          INSERT OR IGNORE INTO reverse_deps (file_id, dependent_id, dep_kind)
+          SELECT s_callee.file_id, sr.file_id, 'ref'
+          FROM symbol_refs sr
+          JOIN symbols s_callee ON s_callee.id = sr.callee_id
+          WHERE sr.callee_id IS NOT NULL
+            AND s_callee.file_id = ?
+            AND sr.file_id != s_callee.file_id
+        `);
+
         for (const fid of changedFileIds) {
           insertFromImports.run(fid);
           insertFromRefs.run(fid);
+          insertInboundImports.run(fid);
+          insertInboundRefs.run(fid);
         }
       })();
     }


### PR DESCRIPTION
## Bug

In `src/indexer/stages/reverse-deps.ts`, the incremental update path (`mode === 'update'`) deletes all `reverse_deps` edges where a changed file is either the dependency (`file_id`) or the dependent (`dependent_id`). However, it only re-inserts **outbound** edges originating *from* the changed file:

- `file_imports` where `fi.file_id = ?` (changed file imports something)
- `symbol_refs` where `sr.file_id = ?` (changed file references a symbol)

**Inbound** edges — from unchanged files that import or reference symbols defined in the changed file — are permanently lost after each incremental update. Over successive updates, the `reverse_deps` table progressively loses edges, breaking impact-set computation.

## Fix

After re-inserting outbound edges, add two additional queries that restore inbound edges:

1. **Inbound imports**: Find all `file_imports` where `resolved_id` (the dependency) is the changed file, re-creating edges from their owners (dependents) to the changed file.
2. **Inbound refs**: Find all `symbol_refs` that reference symbols whose `file_id` is the changed file, re-creating ref edges from the referencing files.

Both use `INSERT OR IGNORE` so duplicates with already-inserted outbound edges are harmless.

Closes #4