### PR TITLE
fix: use effective views in read-only queries

### DIFF
--- a/src/db/read-only.ts
+++ b/src/db/read-only.ts
@@ -22,6 +22,35 @@ function escapeLikeWildcards(value: string): string {
 const MAX_RESULT_LIMIT = 10_000;
 
 /**
+ * Cache whether a database has effective_* views.
+ * WeakMap so entries are GC'd when the db is closed.
+ */
+const effectiveViewCache = new WeakMap<Database.Database, boolean>();
+
+/** Check (and cache) whether this db has the effective_files view. */
+function hasEffectiveViews(db: Database.Database): boolean {
+  let result = effectiveViewCache.get(db);
+  if (result === undefined) {
+    const row = db
+      .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'view' AND name = 'effective_files' LIMIT 1")
+      .get() as { ok: number } | undefined;
+    result = row?.ok === 1;
+    effectiveViewCache.set(db, result);
+  }
+  return result;
+}
+
+/** Return the right table/view name for file lookups. */
+function filesTable(db: Database.Database): string {
+  return hasEffectiveViews(db) ? 'effective_files' : 'files';
+}
+
+/** Return the right table/view name for symbol lookups. */
+function symbolsTable(db: Database.Database): string {
+  return hasEffectiveViews(db) ? 'effective_symbols' : 'symbols';
+}
+
+/**
  * Clamp a caller-supplied limit to the hard ceiling.
  * When no limit is given, `defaultLimit` is used (default: 1 000).
  */
@@ -308,8 +337,8 @@ export function getSymbolsByName(
   return db
     .prepare(
       `SELECT s.*, sp.name AS parent_name, f.path AS file_path, f.branch AS file_branch, sm.line_count, sm.param_count, sm.cyclomatic, sm.max_nesting
-       FROM effective_symbols s
-       JOIN effective_files f ON s.file_id = f.id
+       FROM ${symbolsTable(db)} s
+       JOIN ${filesTable(db)} f ON s.file_id = f.id
        LEFT JOIN symbols sp ON sp.id = s.parent_symbol_id
        LEFT JOIN symbol_metrics sm ON sm.symbol_id = s.id
        WHERE ${where.join(' AND ')}`,
@@ -338,8 +367,8 @@ export function listSymbols(
   return db
     .prepare(
       `SELECT s.*, sp.name AS parent_name, f.path AS file_path, f.branch AS file_branch, sm.line_count, sm.param_count, sm.cyclomatic, sm.max_nesting
-       FROM effective_symbols s
-       JOIN effective_files f ON s.file_id = f.id
+       FROM ${symbolsTable(db)} s
+       JOIN ${filesTable(db)} f ON s.file_id = f.id
        LEFT JOIN symbols sp ON sp.id = s.parent_symbol_id
        LEFT JOIN symbol_metrics sm ON sm.symbol_id = s.id
        ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
@@ -467,18 +496,20 @@ export interface FileRow {
 
 /** Fetch a single file row by primary key. */
 export function getFileById(db: Database.Database, id: number, branch?: string): FileRow | undefined {
+  const ft = filesTable(db);
   if (branch !== undefined) {
-    return db.prepare('SELECT * FROM effective_files WHERE id = ? AND branch = ?').get(id, branch) as FileRow | undefined;
+    return db.prepare(`SELECT * FROM ${ft} WHERE id = ? AND branch = ?`).get(id, branch) as FileRow | undefined;
   }
-  return db.prepare('SELECT * FROM effective_files WHERE id = ?').get(id) as FileRow | undefined;
+  return db.prepare(`SELECT * FROM ${ft} WHERE id = ?`).get(id) as FileRow | undefined;
 }
 
 /** Fetch a single file row by its path. */
 export function getFileByPath(db: Database.Database, path: string, branch?: string): FileRow | undefined {
+  const ft = filesTable(db);
   if (branch !== undefined) {
-    return db.prepare('SELECT * FROM effective_files WHERE path = ? AND branch = ?').get(path, branch) as FileRow | undefined;
+    return db.prepare(`SELECT * FROM ${ft} WHERE path = ? AND branch = ?`).get(path, branch) as FileRow | undefined;
   }
-  return db.prepare('SELECT * FROM effective_files WHERE path = ?').get(path) as FileRow | undefined;
+  return db.prepare(`SELECT * FROM ${ft} WHERE path = ?`).get(path) as FileRow | undefined;
 }
 
 /**
@@ -491,10 +522,11 @@ export function getFileByPath(db: Database.Database, path: string, branch?: stri
  */
 export function listFiles(db: Database.Database, limit?: number, branch?: string): FileRow[] {
   const effectiveLimit = clampLimit(limit);
+  const ft = filesTable(db);
   if (branch !== undefined) {
-    return db.prepare('SELECT * FROM effective_files WHERE branch = ? LIMIT ?').all(branch, effectiveLimit) as FileRow[];
+    return db.prepare(`SELECT * FROM ${ft} WHERE branch = ? LIMIT ?`).all(branch, effectiveLimit) as FileRow[];
   }
-  return db.prepare('SELECT * FROM effective_files LIMIT ?').all(effectiveLimit) as FileRow[];
+  return db.prepare(`SELECT * FROM ${ft} LIMIT ?`).all(effectiveLimit) as FileRow[];
 }
 
 /** Return indexed files matching an exact path or directory prefix. */
@@ -511,7 +543,7 @@ export function listFilesByPathPrefix(
   if (branch !== undefined) {
     return db
       .prepare(
-        `SELECT * FROM effective_files
+        `SELECT * FROM ${filesTable(db)}
          WHERE branch = ? AND (path = ? OR path LIKE ? ESCAPE '\\')
          ORDER BY path ASC, branch ASC
          LIMIT ?`,
@@ -520,7 +552,7 @@ export function listFilesByPathPrefix(
   }
   return db
     .prepare(
-      `SELECT * FROM effective_files
+      `SELECT * FROM ${filesTable(db)}
        WHERE path = ? OR path LIKE ? ESCAPE '\\'
        ORDER BY path ASC, branch ASC
        LIMIT ?`,


### PR DESCRIPTION
## Problem

Read-only query functions in `src/db/read-only.ts` query raw `files`/`symbols` tables instead of the `effective_files`/`effective_symbols` views. When overlay rows exist alongside baseline rows (i.e. files are dirty and have been re-indexed via the overlay layer), queries against the raw tables are non-deterministic — returning duplicate or stale rows.

The database schema already defines `effective_files` and `effective_symbols` views that correctly handle overlay precedence:

```sql
CREATE VIEW effective_files AS
SELECT * FROM files
WHERE (layer = 'overlay' AND path IN (SELECT path FROM dirty_files))
   OR (layer = 'baseline' AND path NOT IN (SELECT path FROM dirty_files));
```

But the read-only query layer wasn't using them.

## Fix

Updated six public read-only query functions to use the effective views:

| Function | Change |
|---|---|
| `getFileById` | `files` → `effective_files` |
| `getFileByPath` | `files` → `effective_files` |
| `listFiles` | `files` → `effective_files` |
| `listFilesByPathPrefix` | `files` → `effective_files` |
| `getSymbolsByName` | `symbols`/`files` → `effective_symbols`/`effective_files` |
| `listSymbols` | `symbols`/`files` → `effective_symbols`/`effective_files` |

Internal/indexer helpers (`getFreshness`, `getSymbolById`, `semanticSearchSymbols`, `listResolvedEdges`, etc.) intentionally remain on raw tables — they either need to query the baseline layer specifically or operate through virtual tables that can't join through views.

Closes #10