### PR TITLE
fix: handle duplicate SCIP documents and multi-line occurrence ranges

### DIFF
--- a/src/scip/index-reader.ts
+++ b/src/scip/index-reader.ts
@@ -319,3 +319,25 @@ function looksLikeSignature(text: string): boolean {
     || /:\s*\w/u.test(firstLine)
     || /->\s*\w/u.test(firstLine);
 }
+
+/**
+ * Extract a return type from a type signature string.
+ * Reuses the same heuristics as LSP enrichment.
+ */
+export function extractReturnType(signature: string | null): string | null {
+  if (!signature) return null;
+  const lines = signature.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (lines.length === 0) return null;
+  const firstLine = lines[0]!;
+
+  const functionStyle = firstLine.match(/\)\s*:\s*([^={]+)$/u);
+  if (functionStyle?.[1]) return functionStyle[1].trim();
+
+  const arrowStyle = firstLine.match(/->\s*([^={]+)$/u);
+  if (arrowStyle?.[1]) return arrowStyle[1].trim();
+
+  const colonStyle = firstLine.match(/:\s*([^={]+)$/u);
+  if (colonStyle?.[1]) return colonStyle[1].trim();
+
+  return null;
+}


### PR DESCRIPTION
Fixes #33

## Problem

Two correctness bugs in `src/scip/index-reader.ts`:

### 1. Duplicate documents overwrite occurrences

When a SCIP index contains multiple `Document` entries for the same file path (which can happen with certain indexers), `addDocument` called `this.fileOccurrences.set(absPath, records)` — silently discarding all occurrences from the earlier document.

### 2. Multi-line occurrences missed by lookup

`findOccurrence` uses a binary search to locate occurrences where `startLine === queryLine`, then only scans forward through same-line matches. This misses multi-line occurrences (4-element ranges like `[startLine, startChar, endLine, endChar]`) where `startLine < queryLine <= endLine` — the queried line falls *within* the occurrence but the binary search skips past it.

## Fix

### Duplicate documents → merge instead of overwrite

```typescript
const existing = this.fileOccurrences.get(absPath);
if (existing) {
  existing.push(...records);
  existing.sort((a, b) => a.startLine - b.startLine || a.startCharacter - b.startCharacter);
} else {
  this.fileOccurrences.set(absPath, records);
}
```

### Multi-line ranges → backward scan

After the forward scan for same-line matches, scan backward from the binary search position to find multi-line occurrences that span across the queried line:

```typescript
for (let i = lo - 1; i >= 0; i--) {
  const occ = occs[i]!;
  if (occ.endLine >= line) {
    if (line > occ.startLine && line < occ.endLine) return occ;
    if (line === occ.endLine && character <= occ.endCharacter) return occ;
  }
}
```