### PR TITLE
fix(db): make getFileByPath deterministic (#399)

### DIFF
--- a/src/db/read-only.ts
+++ b/src/db/read-only.ts
@@ -519,9 +519,9 @@ export function getFileById(db: Database.Database, id: number, branch?: string):
 export function getFileByPath(db: Database.Database, path: string, branch?: string): FileRow | undefined {
   const ft = filesTable(db);
   if (branch !== undefined) {
-    return db.prepare(`SELECT * FROM ${ft} WHERE path = ? AND branch = ?`).get(path, branch) as FileRow | undefined;
+    return db.prepare(`SELECT * FROM ${ft} WHERE path = ? AND branch = ? LIMIT 1`).get(path, branch) as FileRow | undefined;
   }
-  return db.prepare(`SELECT * FROM ${ft} WHERE path = ?`).get(path) as FileRow | undefined;
+  return db.prepare(`SELECT * FROM ${ft} WHERE path = ? ORDER BY indexed_at DESC, id DESC LIMIT 1`).get(path) as FileRow | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #399

Added `ORDER BY indexed_at DESC, id DESC LIMIT 1` to the branchless query path so it deterministically returns the most recently indexed row when multiple branches have the same path.