### PR TITLE
fix(indexer): validate file-set identity on checkpoint resume (#408)

### DIFF
--- a/src/indexer/stages/source-index.ts
+++ b/src/indexer/stages/source-index.ts
@@ -1098,6 +1098,7 @@ function loadBuildCheckpoint(
   try {
     const parsed = JSON.parse(raw) as Partial<BuildCheckpoint>;
     if (parsed.branch !== branch || parsed.rootDir !== rootDir) return { resumeAt: 0, failedFiles: [] };
+    if (parsed.totalFiles !== totalFiles) return { resumeAt: 0, failedFiles: [] };
     const nextFileIndex = parsed.nextFileIndex ?? 0;
     return {
       resumeAt: Math.max(0, Math.min(totalFiles, nextFileIndex)),


### PR DESCRIPTION
Fixes #408

Added `totalFiles` identity check in `loadBuildCheckpoint` so if file count changes between interrupted runs, the checkpoint is invalidated and build restarts from scratch.