### PR TITLE
fix(parsing): TOML array parsing handles quoted commas (#435)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,9 +4569,6 @@
         "win32"
       ]
     },
-    "node_modules/sqlite-vec/node_modules/sqlite-vec-linux-arm64": {
-      "optional": true
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",

--- a/src/parsing/config-parser.ts
+++ b/src/parsing/config-parser.ts
@@ -249,6 +249,28 @@ function toKnownType(value: unknown): ConfigValueType | null {
   return null;
 }
 
+function splitOutsideQuotes(input: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  for (const ch of input) {
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      current += ch;
+      quote = ch;
+    } else if (ch === ',') {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
 function parseScalar(raw: string): unknown {
   const normalized = normalizeQuotedValue(raw);
   if (normalized === null) return null;
@@ -259,7 +281,7 @@ function parseScalar(raw: string): unknown {
   if (normalized.startsWith('[') && normalized.endsWith(']')) {
     const body = normalized.slice(1, -1).trim();
     if (!body) return [];
-    return body.split(',').map((part) => parseScalar(part.trim()));
+    return splitOutsideQuotes(body).map((part) => parseScalar(part.trim()));
   }
   return normalized;
 }

--- a/tests/parsing/config-parser.test.ts
+++ b/tests/parsing/config-parser.test.ts
@@ -198,4 +198,15 @@ describe('parseConfigFile', () => {
     expect(entries).toContainEqual(expect.objectContaining({ key: 'app.db.host', value: 'localhost' }));
     expect(entries).toContainEqual(expect.objectContaining({ key: 'app.debug', value: 'true' }));
   });
+
+  it('parses TOML arrays with commas inside quoted strings', () => {
+    const entries = parseConfigFile(
+      'test.toml',
+      'items = ["hello, world", "foo, bar"]\n',
+    );
+    const items = entries.find(e => e.key === 'items');
+    expect(items).toBeDefined();
+    expect(items!.inferredType).toBe('array');
+    // The value should contain both items, not be split on the inner commas
+  });
 });


### PR DESCRIPTION
Fixes #435

Added `splitOutsideQuotes` state-machine that tracks whether parser is inside quotes, splitting on commas only when outside quoted regions.